### PR TITLE
CI: JDK 21 for the emulator test (fixes the publish)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # The Firebase RTDB emulator (firebase-tools@15) requires JDK 21+.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
       - run: npm ci
       # Pure engine unit tests (offline).
       - run: npm test


### PR DESCRIPTION
The `v0.1.0` publish failed at `npm run test:emulator` with:

```
Error: firebase-tools no longer supports Java version before 21.
```

`firebase-tools@15` (which we bumped to, and which fixed the `npm test` glob) needs **JDK 21+**, but the runner's default Java is older. This adds `actions/setup-java@v4` (Temurin 21) before the emulator step. `npm test` already passes; this unblocks `test:emulator` → the `docker` build/push.

After this merges, re-tagging will publish cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)