### PR TITLE
CI: set up buildx for SBOM/provenance attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # docker-container driver — required to attach the SBOM/provenance attestations below.
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
The `v0.1.0` build got past `test` (JDK 21 ✓) but failed in the `docker` job:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
```

`sbom: true` / `provenance: true` need a **docker-container** buildx builder, not the default `docker` driver. This adds `docker/setup-buildx-action@v3` before the build. (The build was otherwise correct — it was already tagging `0.1.0`, `sha-…`, and `latest`.)

This should be the final blocker; merge and I'll re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)