### PR TITLE
Add !mute: mod switch to silence chat output without going offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!grab` / `!loot` | **subs** | roll for the active drop (independent rolls within the window) |
 | `!muster` | everyone* | sign up for this week's raid (during muster) / see status |
 | `!exp on\|off\|auto\|status` | mod | control the EXP gate (`on` bypasses live for testing) |
+| `!mute on\|off\|status` | mod | silence the bot's chat output when it gets noisy; it keeps listening, tracking EXP, and holding the lease — bare `!mute` toggles |
 | `!drop [item]` | mod | force a single loot drop |
 | `!drops on\|off\|every <min>` | mod | auto chat-drop scheduler (rarity-weighted, while live) |
 | `!boss set <name>` / `!boss next` | mod | custom boss / advance to the next scripted season boss |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,6 +37,7 @@ so a mod can change them **while the bot is running**. These are the
 | What | How (chat command) | Where it's stored (RTDB) |
 |---|---|---|
 | **EXP gate** — on / off / auto | `!exp on` · `!exp off` · `!exp auto` · `!exp status` | `config/expMode` |
+| **Chat output mute** — silence sends, keep listening | `!mute on` · `!mute off` · `!mute status` (bare `!mute` toggles) | `config/chatMuted` |
 | **Auto drop scheduler** — on/off + interval | `!drops on` · `!drops off` · `!drops every <min>` · `!drops status` | `config/dropScheduler` |
 | **Live status** (set automatically by Twitch) | _(no command — EventSub / Helix poll set it)_ | `config/live` |
 | **Active season** | `!season start <id>` · `!season rollover <id>` | `config/season/current` |

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import { ChatClient } from '@twurple/chat';
 import { logger } from './src/logger.js';
 import { config } from './src/config.js';
 import { initFirebase, closeFirebase } from './src/db/firebase.js';
-import { startConfigMirror, setLive } from './src/db/configStore.js';
+import { startConfigMirror, setLive, isChatMuted } from './src/db/configStore.js';
 import { acquireLock, startHeartbeat, releaseLock, defaultInstanceId } from './src/db/lock.js';
 import { TokenStore } from './src/db/tokenStore.js';
 import { buildAuth } from './src/twitch/auth.js';
@@ -157,6 +157,15 @@ async function main() {
 
   // ── Chat ──
   const chat = new ChatClient({ authProvider, channels: [channel] });
+  // Mute-aware sender for spontaneous (non-command) announcements. When a mod
+  // mutes the bot (`!mute`) every outbound send is suppressed while the bot
+  // keeps listening, granting EXP, processing drops, and holding the lease.
+  // Command replies are gated inside the message handler (which also lets the
+  // !mute control itself bypass, so mods still get confirmation).
+  const out = {
+    say: (ch, text) => (isChatMuted() ? Promise.resolve() : chat.say(ch, text)),
+    action: (ch, text) => (isChatMuted() ? Promise.resolve() : chat.action(ch, text)),
+  };
   chat.onMessage(createMessageHandler({ chat, channel, botUserId, logger, onActivity: touchHeartbeat }));
   chat.onConnect(() => {
     health.chatConnected = true;
@@ -173,7 +182,7 @@ async function main() {
   shutdownHooks.push(() => chat.quit());
 
   // Auto chat-drop scheduler (mod-toggled via !drops; fires only while live).
-  shutdownHooks.push(startDropScheduler({ chat, channel, logger }));
+  shutdownHooks.push(startDropScheduler({ chat: out, channel, logger }));
 
   // ── Live gate: Helix poll (always) + EventSub (when broadcaster auth fits) ──
   const setLiveBound = (live, source) => {
@@ -220,7 +229,7 @@ async function main() {
       const { drawResult, activated } = await processDrops();
       if (drawResult) {
         if (drawResult.winner) {
-          chat
+          out
             .say(
               channel,
               `🎉 @${drawResult.winner.name || 'a lucky grabber'} won the ${drawResult.item?.rarity ?? ''} ${drawResult.item?.name ?? 'drop'}! (${drawResult.count} entered) — it's in their !bag.`,
@@ -233,7 +242,7 @@ async function main() {
       }
       if (activated) {
         const secs = Math.round(config.loot.windowMs / 1000);
-        chat
+        out
           .say(channel, `⏭️ Next up — a ${activated.rarity} ${activated.name} is open! !grab within ${secs}s to enter the draw.`)
           .catch(() => {});
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\""
   },

--- a/src/commands/mod/mute.js
+++ b/src/commands/mod/mute.js
@@ -1,0 +1,41 @@
+// !mute on|off|status (mod) — silence the bot's OUTBOUND chat when things get
+// noisy, without taking it offline. While muted the bot stays fully connected:
+// it keeps listening, granting EXP, processing loot drops, advancing raid
+// phases, and holding the single-instance lease — it just stops talking.
+// Bare `!mute` toggles; the ack always states the resulting state.
+//
+// `bypassMute` lets THIS command's replies reach chat even while muted, so mods
+// always get confirmation (otherwise unmuting would feel like shouting into the
+// void). Every other command and announcement is gated by the mute flag.
+import { setChatMuted, getConfig } from '../../db/configStore.js';
+
+export default {
+  names: ['mute', 'silence'],
+  mod: true,
+  bypassMute: true,
+  cooldownMs: 0,
+  help: '!mute on|off|status — mod-only: silence kennyBot’s chat output (it keeps listening + tracking)',
+  async run({ args, reply }) {
+    const sub = (args[0] || 'toggle').toLowerCase();
+    const muted = Boolean(getConfig().chatMuted);
+
+    if (sub === 'status') {
+      reply(muted ? '🤫 Muted — still listening + tracking EXP, just not talking. !mute off to bring me back.' : '🔊 Live — chat output is on.');
+      return;
+    }
+
+    let next;
+    if (['on', 'mute'].includes(sub)) next = true;
+    else if (['off', 'unmute'].includes(sub)) next = false;
+    else if (sub === 'toggle') next = !muted;
+    else {
+      reply('Usage: !mute on | off | status');
+      return;
+    }
+
+    await setChatMuted(next);
+    reply(next
+      ? '🤫 Muted — I’ll keep listening and tracking EXP, but I’ll stop talking. !mute off to bring me back.'
+      : '🔊 Unmuted — back to chatting. 🌱');
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -10,13 +10,14 @@ import grab from './grab.js';
 import raid from './raid.js';
 import top from './top.js';
 import exp from './mod/exp.js';
+import mute from './mod/mute.js';
 import drop from './mod/drop.js';
 import drops from './mod/drops.js';
 import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, exp, drop, drops, boss, raidnight, season];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, exp, mute, drop, drops, boss, raidnight, season];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -6,10 +6,14 @@
 import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
 import { config as gameConfig } from '../config.js';
 
-/** @type {{ live: boolean, expMode: string, season: any, raid: any, dropScheduler: any }} */
+/** @type {{ live: boolean, expMode: string, chatMuted: boolean, season: any, raid: any, dropScheduler: any }} */
 const mirror = {
   live: false,
   expMode: gameConfig.liveGate.defaultExpMode,
+  // Mod kill-switch for OUTBOUND chat (`!mute`). When true the bot stays fully
+  // connected — listening, granting EXP, processing drops, holding the lease —
+  // but sends nothing to chat. Persisted so a restart keeps the mods' choice.
+  chatMuted: false,
   season: null,
   raid: null, // config/raid: { seasonId, weekId, phase, locksAt, startsAt }
   dropScheduler: { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec },
@@ -29,9 +33,11 @@ export async function startConfigMirror(logger = console) {
   // Seed defaults transactionally if absent (never clobber existing values).
   await db.ref(PATHS.configExpMode()).transaction((v) => (v == null ? gameConfig.liveGate.defaultExpMode : v));
   await db.ref(PATHS.configLive()).transaction((v) => (v == null ? false : v));
+  await db.ref(PATHS.configChatMuted()).transaction((v) => (v == null ? false : v));
 
   const liveRef = db.ref(PATHS.configLive());
   const expRef = db.ref(PATHS.configExpMode());
+  const mutedRef = db.ref(PATHS.configChatMuted());
   const seasonRef = db.ref(PATHS.seasonCurrent());
   const raidRef = db.ref(PATHS.configRaid());
   const dropRef = db.ref(PATHS.configDropScheduler());
@@ -41,25 +47,32 @@ export async function startConfigMirror(logger = console) {
 
   liveRef.on('value', (s) => { mirror.live = Boolean(s.val()); });
   expRef.on('value', (s) => { mirror.expMode = s.val() || gameConfig.liveGate.defaultExpMode; });
+  mutedRef.on('value', (s) => { mirror.chatMuted = Boolean(s.val()); });
   seasonRef.on('value', (s) => { mirror.season = s.val(); });
   raidRef.on('value', (s) => { mirror.raid = s.val(); });
   dropRef.on('value', (s) => { if (s.val()) mirror.dropScheduler = s.val(); });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, seasonSnap, raidSnap, dropSnap] = await Promise.all([
-    liveRef.get(), expRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
+  const [liveSnap, expSnap, mutedSnap, seasonSnap, raidSnap, dropSnap] = await Promise.all([
+    liveRef.get(), expRef.get(), mutedRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
+  mirror.chatMuted = Boolean(mutedSnap.val());
   mirror.season = seasonSnap.val();
   mirror.raid = raidSnap.val();
   if (dropSnap.val()) mirror.dropScheduler = dropSnap.val();
-  logger.info?.('config mirror warm', { live: mirror.live, expMode: mirror.expMode });
+  logger.info?.('config mirror warm', { live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted });
 }
 
 /** Current in-memory config view (hot path). */
 export function getConfig() {
-  return { live: mirror.live, expMode: mirror.expMode, season: mirror.season };
+  return { live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, season: mirror.season };
+}
+
+/** True when a mod has muted the bot's outbound chat (`!mute`). Hot-path read. */
+export function isChatMuted() {
+  return mirror.chatMuted;
 }
 
 /** Active season pointer { id, name, weekId, ... } or null. */
@@ -110,6 +123,18 @@ export async function setExpMode(mode) {
   if (!['on', 'off', 'auto'].includes(mode)) throw new Error(`invalid expMode: ${mode}`);
   await database().ref(PATHS.configExpMode()).set(mode);
   return mode;
+}
+
+/**
+ * Mute / unmute the bot's outbound chat (`!mute`). Updates the mirror
+ * synchronously so the very next send respects it without waiting for the RTDB
+ * round-trip, then persists so the choice survives a restart.
+ */
+export async function setChatMuted(value) {
+  const next = Boolean(value);
+  mirror.chatMuted = next;
+  await database().ref(PATHS.configChatMuted()).set(next);
+  return next;
 }
 
 /**

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -81,6 +81,7 @@ export async function closeFirebase() {
 export const PATHS = {
   configLive: () => 'config/live',
   configExpMode: () => 'config/expMode',
+  configChatMuted: () => 'config/chatMuted',
   seasonCurrent: () => 'config/season/current',
   configRaid: () => 'config/raid',
   configDropScheduler: () => 'config/dropScheduler',

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -11,7 +11,7 @@
 // A lapsed sub keeps earning EXP on an existing character; only !create and loot
 // claims require an active sub (handled by the per-command `subOnly` gate).
 import { getCommand } from '../commands/registry.js';
-import { getConfig } from '../db/configStore.js';
+import { getConfig, isChatMuted } from '../db/configStore.js';
 import { config, shouldGrantExp } from '../config.js';
 import { applyChatTick } from '../db/players.js';
 
@@ -29,19 +29,35 @@ export function createMessageHandler({ chat, channel, botUserId, logger, onActiv
   const expCooldown = new Map(); // userId -> last grant ms
   const cmdCooldown = new Map(); // `${userId}:${cmd}` -> last run ms
 
-  async function dispatchCommand(ctx, name) {
+  const rawSay = (t) => chat.say(channel, t).catch((e) => logger.warn('say failed', { err: String(e) }));
+  const rawAction = (t) => chat.action(channel, t).catch(() => {});
+
+  async function dispatchCommand(user, args, name) {
     const def = getCommand(name);
     if (!def) return;
-    if (def.mod && !ctx.user.isMod && !ctx.user.isBroadcaster) return; // silently ignore non-mods
+    if (def.mod && !user.isMod && !user.isBroadcaster) return; // silently ignore non-mods
 
-    const key = `${ctx.user.id}:${name}`;
+    const key = `${user.id}:${name}`;
     const now = Date.now();
     if (def.cooldownMs && now - (cmdCooldown.get(key) || 0) < def.cooldownMs) return;
     cmdCooldown.set(key, now);
 
+    // Outbound mute (`!mute`): swallow every reply while muted EXCEPT for
+    // commands flagged `bypassMute` — that's the !mute control itself, so mods
+    // still get confirmation even while the bot is otherwise silent.
+    const silent = isChatMuted() && !def.bypassMute;
+    const ctx = {
+      user,
+      args,
+      channel,
+      reply: (t) => (silent ? undefined : rawSay(t)),
+      action: (t) => (silent ? undefined : rawAction(t)),
+      logger,
+    };
+
     // Sub-only participation (broadcaster can't sub to herself → always allowed).
-    if (def.subOnly && !ctx.user.isSubscriber && !ctx.user.isBroadcaster) {
-      ctx.reply(`@${ctx.user.displayName} the raid game is subscriber-only — sub to ${channel} to play! 🌱`);
+    if (def.subOnly && !user.isSubscriber && !user.isBroadcaster) {
+      ctx.reply(`@${user.displayName} the raid game is subscriber-only — sub to ${channel} to play! 🌱`);
       return;
     }
 
@@ -70,7 +86,7 @@ export function createMessageHandler({ chat, channel, botUserId, logger, onActiv
       return;
     }
     if (!tick) return; // not a player → nothing accrues (non-subs never created one)
-    if (tick.leveledUp) {
+    if (tick.leveledUp && !isChatMuted()) {
       chat.say(channel, `@${user.displayName} reached level ${tick.toLevel}! ⚔️`).catch(() => {});
     }
   }
@@ -95,15 +111,7 @@ export function createMessageHandler({ chat, channel, botUserId, logger, onActiv
       if (trimmed.startsWith('!')) {
         const parts = trimmed.slice(1).split(/\s+/);
         const name = parts[0].toLowerCase();
-        const ctx = {
-          user,
-          args: parts.slice(1),
-          channel,
-          reply: (t) => chat.say(channel, t).catch((e) => logger.warn('say failed', { err: String(e) })),
-          action: (t) => chat.action(channel, t).catch(() => {}),
-          logger,
-        };
-        await dispatchCommand(ctx, name);
+        await dispatchCommand(user, parts.slice(1), name);
       }
 
       await passiveTick(user);

--- a/src/events/twitchEvents.js
+++ b/src/events/twitchEvents.js
@@ -7,7 +7,7 @@ import { setSubStatus } from '../db/players.js';
 import { setDrop } from '../db/drops.js';
 import { pickDrop } from '../rules/loot.js';
 import { getItem, DEFAULT_LOOT_TABLE } from '../content/items.js';
-import { getSeason } from '../db/configStore.js';
+import { getSeason, isChatMuted } from '../db/configStore.js';
 import { config } from '../config.js';
 
 /** Twitch sub plan → engagement tier (Prime counts as tier 1). */
@@ -33,6 +33,9 @@ function lootTable() {
  */
 export function attachTwitchEvents({ chat, channel, logger }) {
   const listeners = [];
+  // Outbound mute (`!mute`): these communal-drop announcements are suppressed
+  // while muted, but the drop itself is still created so !grab keeps working.
+  const say = (text) => { if (!isChatMuted()) chat.say(channel, text).catch(() => {}); };
 
   const onSubLike = (label) => async (_ch, _user, info, msg) => {
     const userId = msg?.userInfo?.userId;
@@ -68,7 +71,7 @@ export function attachTwitchEvents({ chat, channel, logger }) {
         drop.status === 'open'
           ? `${lead} A ${drop.rarity} ${drop.name} dropped — !grab to enter the draw!`
           : `${lead} A ${drop.rarity} ${drop.name} is queued up — !grab when it opens!`;
-      chat.say(channel, line).catch(() => {});
+      say(line);
     } catch (err) {
       logger.error('raid handler failed', { err: String(err) });
     }
@@ -90,7 +93,7 @@ export function attachTwitchEvents({ chat, channel, logger }) {
         drop.status === 'open'
           ? `${bits} bits! A ${drop.rarity} ${drop.name} dropped — !grab to enter the draw!`
           : `${bits} bits! A ${drop.rarity} ${drop.name} is queued — !grab when it opens!`;
-      chat.say(channel, line).catch(() => {});
+      say(line);
     } catch (err) {
       logger.error('cheer handler failed', { err: String(err) });
     }

--- a/test/firebase-rules.test.js
+++ b/test/firebase-rules.test.js
@@ -51,7 +51,7 @@ runOrSkip('client WRITE to players is rejected and leaves no data', async () => 
 });
 
 runOrSkip('client WRITE to leaderboard/bosses/raids/config is rejected', async () => {
-  for (const path of ['leaderboard/t1/u1', 'bosses/t1/w1', 'raids/t1/w1/x', 'config/live', 'config/expMode']) {
+  for (const path of ['leaderboard/t1/u1', 'bosses/t1/w1', 'raids/t1/w1/x', 'config/live', 'config/expMode', 'config/chatMuted']) {
     const res = await fetch(restUrl(path), { method: 'PUT', body: JSON.stringify({ x: 1 }) });
     assert.equal(res.status, 401, `client write to ${path} must be denied`);
   }

--- a/test/mute.test.js
+++ b/test/mute.test.js
@@ -1,0 +1,98 @@
+// Behavioral test for the mod mute switch (!mute). Verifies the actual chat
+// handler wiring against the emulator: while muted, ordinary command replies are
+// SUPPRESSED, but the !mute control itself (bypassMute) still answers so mods
+// keep getting confirmation. Run via:
+//
+//   npm run test:emulator
+//
+// (skipped when the emulator host isn't set, same as firebase-rules.test.js).
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { startConfigMirror, setChatMuted, isChatMuted } from '../src/db/configStore.js';
+import { createMessageHandler } from '../src/events/chat.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+// Records outbound chat so we can assert on what the bot said (or didn't).
+const sent = [];
+const fakeChat = {
+  say: (_ch, text) => { sent.push(text); return Promise.resolve(); },
+  action: (_ch, text) => { sent.push(text); return Promise.resolve(); },
+};
+
+let handler;
+
+// Distinct ids per call avoid the per-user/per-command cooldown masking a send.
+let seq = 0;
+function fire(text, { mod = false, broadcaster = false } = {}) {
+  seq += 1;
+  const userId = `u_mute_${seq}`;
+  const msg = {
+    userInfo: {
+      userId,
+      userName: `tester${seq}`,
+      displayName: `Tester${seq}`,
+      isMod: mod,
+      isBroadcaster: broadcaster,
+      isSubscriber: false,
+    },
+  };
+  return handler('#test', `tester${seq}`, text, msg);
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(noopLogger);
+  handler = createMessageHandler({ chat: fakeChat, channel: '#test', botUserId: 'bot', logger: noopLogger, onActivity() {} });
+});
+
+after(async () => {
+  if (!host) return;
+  await setChatMuted(false).catch(() => {});
+  await closeFirebase();
+});
+
+beforeEach(async () => {
+  if (!host) return;
+  sent.length = 0;
+  await setChatMuted(false);
+});
+
+runOrSkip('unmuted: an ordinary command replies in chat', async () => {
+  await fire('!muster'); // no active raid → "No raid is scheduled yet"
+  assert.equal(sent.length, 1, 'an unmuted command should reply');
+});
+
+runOrSkip('muted: an ordinary command is silenced', async () => {
+  await setChatMuted(true);
+  assert.equal(isChatMuted(), true, 'setter updates the mirror synchronously');
+  await fire('!muster');
+  assert.equal(sent.length, 0, 'muted commands must not reach chat');
+});
+
+runOrSkip('muted: !mute (bypassMute) still answers so mods get confirmation', async () => {
+  await setChatMuted(true);
+  await fire('!mute status', { mod: true });
+  assert.equal(sent.length, 1, '!mute must bypass the mute gate');
+});
+
+runOrSkip('!mute off re-enables output and confirms', async () => {
+  await setChatMuted(true);
+  await fire('!mute off', { mod: true });
+  assert.equal(isChatMuted(), false, '!mute off clears the flag');
+  assert.equal(sent.length, 1, 'the unmute confirmation reaches chat');
+  // …and ordinary commands talk again afterward.
+  await fire('!muster');
+  assert.equal(sent.length, 2, 'output resumes after unmute');
+});
+
+runOrSkip('a non-mod cannot toggle mute', async () => {
+  await fire('!mute on'); // ordinary viewer
+  assert.equal(isChatMuted(), false, 'non-mods must not flip the switch');
+  assert.equal(sent.length, 0, 'and get no response');
+});


### PR DESCRIPTION
## What

A mod-only switch to **silence kennyBot's chat output** when things get noisy — without taking the bot offline.

While muted the bot stays fully connected and keeps doing everything *except talking*: it still listens, grants EXP, processes loot drops, advances raid phases, and holds the single-instance lease. It just stops sending.

## Usage (mods / broadcaster)

| Command | Effect |
|---|---|
| `!mute` | toggle |
| `!mute on` | go quiet |
| `!mute off` | resume talking |
| `!mute status` | report current state |

The acknowledgement always states the resulting state.

## How it works

- **Persisted, runtime, no restart.** State lives in RTDB at `config/chatMuted` (mirrored in-memory like `expMode`/`dropScheduler`). The setter updates the mirror synchronously, so the very next send respects the change without waiting for the round-trip. A restart keeps the mods' choice.
- **Single chokepoint.** Command replies are gated in the message handler; spontaneous announcements (level-ups, auto/raid/cheer drops, draw results) flow through mute-aware senders. No call site can accidentally leak.
- **`bypassMute`.** The `!mute` control itself is flagged so its own replies always reach chat — otherwise unmuting would feel like shouting into the void.
- **Anti-cheat preserved.** `config/chatMuted` is admin-write-only; clients can't flip it.

## Tests

- Extended the rules-rejection test to cover `config/chatMuted` (client writes denied).
- New behavioral test (`test/mute.test.js`) proves the gate end-to-end against the emulator: unmuted commands reply, muted commands are silenced, `!mute` bypasses the gate, `!mute off` re-enables + confirms, and non-mods can't toggle.
- `npm test` 44/44 · `npm run test:emulator` 10/10.

## Docs

- README chat-command table + `docs/CONFIG.md` runtime-toggle table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)