### PR TITLE
Auto-refresh mustered roster cards during signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 `!muster`) needs an active sub — same as `!create` and `!grab`. A lapsed sub keeps
 the hero they built and keeps earning EXP, but must re-sub to muster.
 
+Mustering writes a snapshot of your hero onto the roster. While the muster window
+is open, the bot re-snapshots signees from their live record on a timer
+(`raid.rosterRefreshMs`), so leveling or gearing up after you muster keeps showing
+on the site without a re-`!muster`. At **roster lock** (15 min before raid night)
+every card is frozen from the live record — that's the loadout that fights.
+
 ## Local development
 
 Requires **Node ≥ 20** and **Java** (for the Firebase emulator).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -145,6 +145,7 @@ The muster → raid-night → battle cycle.
 | `maxRevealMs` | `480000` (8 min) | Upper bound on how long the battle "reveal" plays out before the bot flips the phase to *done*. | Mostly a safety bound on the replay length; rarely needs tuning. |
 | `defaultBossHp` | `6000` | HP for a boss made with `!boss set <name>` that has no explicit HP. Tuned so a modest roster downs it within the turn cap. | Raise for tougher custom bosses, lower for pushovers. (Scripted season bosses carry their own HP from `src/content/`.) |
 | `defaultBossAtk` | `90` | Default attack for such a boss. | Higher = the boss hits harder; raises wipe risk for thin rosters. |
+| `rosterRefreshMs` | `60000` (60 s) | While muster is **open**, how often the bot re-snapshots each signee from their live record so leveling/gearing up after mustering shows on the site without a re-`!muster`. No-op outside the signup phase; only rewrites cards that actually changed. | Lower = the roster page tracks heroes more promptly (more reads during a signup week); raise to ease load. It never needs to be real-time — the battle uses the **lock**-time snapshot regardless. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ import { TokenStore } from './src/db/tokenStore.js';
 import { buildAuth } from './src/twitch/auth.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
-import { advanceRaidPhases } from './src/db/raid.js';
+import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
 import { createMessageHandler } from './src/events/chat.js';
 import { attachTwitchEvents } from './src/events/twitchEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
@@ -222,6 +222,19 @@ async function main() {
   }, 30_000);
   phaseTimer.unref?.();
   shutdownHooks.push(() => clearInterval(phaseTimer));
+
+  // ── Muster roster refresh: during signup, keep each hero's card current with
+  //    their live level/gear (frozen again at lock). No-op outside signup. ──
+  const rosterTimer = setInterval(async () => {
+    try {
+      const n = await refreshMusteredRoster();
+      if (n) logger.info('muster roster refreshed', { updated: n });
+    } catch (err) {
+      logger.error('roster refresh failed', { err: String(err) });
+    }
+  }, config.raid.rosterRefreshMs);
+  rosterTimer.unref?.();
+  shutdownHooks.push(() => clearInterval(rosterTimer));
 
   // ── Loot lottery: close expired drops and draw a single winner (spec §5.2) ──
   const drawTimer = setInterval(async () => {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\""
   },

--- a/src/config.js
+++ b/src/config.js
@@ -97,6 +97,11 @@ export const config = {
     maxRevealMs: 8 * 60 * 1000,
     defaultBossHp: 6000, // tuned so a modest roster downs it within the turn cap
     defaultBossAtk: 90,
+    // While a raid is in the SIGNUP phase, re-snapshot each mustered hero from
+    // their live record on this cadence so leveling / gearing up between muster
+    // and lock shows on the site without a manual re-!muster. Coarse on purpose
+    // (it never needs to be real-time) and a no-op outside the signup phase.
+    rosterRefreshMs: 60_000,
   },
 
   // Fixed weekly raid-night slot, anchored to an explicit IANA time zone (DST-

--- a/src/db/raid.js
+++ b/src/db/raid.js
@@ -37,6 +37,28 @@ export function buildSnapshot(player) {
   };
 }
 
+/**
+ * Are two roster snapshots equivalent? Compares the rendered fields, normalizing
+ * `equipped` (RTDB drops an empty object on write, so a stored gearless card has
+ * no `equipped` key while a fresh snapshot carries `{}`). Used to skip redundant
+ * writes during the signup-phase refresh.
+ */
+function sameSnapshot(a, b) {
+  if (!a || !b) return false;
+  return (
+    a.displayName === b.displayName &&
+    a.class === b.class &&
+    a.role === b.role &&
+    a.level === b.level &&
+    a.roleRating === b.roleRating &&
+    a.maxHp === b.maxHp &&
+    a.power === b.power &&
+    a.defense === b.defense &&
+    a.healing === b.healing &&
+    JSON.stringify(a.equipped || {}) === JSON.stringify(b.equipped || {})
+  );
+}
+
 /** Aggregate team stats from the signup roster (written at lock; UI also recomputes). */
 export function computeTeam(signups) {
   const team = {
@@ -94,6 +116,43 @@ export async function setupRaidWeek({ seasonId, weekId, boss, locksAt, startsAt 
 /** Enlist a hero into the muster (a live preview snapshot, frozen again at lock). */
 export async function enlist({ seasonId, weekId, userId, player }) {
   await database().ref(PATHS.signup(seasonId, weekId, userId)).set(buildSnapshot(player));
+}
+
+/**
+ * Keep mustered heroes' roster cards current during the SIGNUP phase: re-snapshot
+ * each signee from their live player record so leveling / gearing up between
+ * muster and lock shows on the site without a manual re-!muster. Driven by a
+ * coarse timer (it needn't be real-time). Strictly a no-op outside the signup
+ * phase — once the roster LOCKS the snapshot is frozen for determinism and must
+ * not be rewritten. Only rewrites entries that actually changed (cheap, and it
+ * deliberately leaves the `team` aggregate alone so the site keeps recomputing
+ * it from the fresh signups until lock writes the real one).
+ * @returns {Promise<number>} how many roster cards were refreshed
+ */
+export async function refreshMusteredRoster() {
+  const p = getRaidPointer();
+  if (!p?.seasonId || !p?.weekId || p.phase !== 'signup') return 0;
+  const db = database();
+  const signupsSnap = await db.ref(PATHS.signups(p.seasonId, p.weekId)).get();
+  const signups = signupsSnap.val();
+  if (!signups) return 0;
+
+  const updates = {};
+  await Promise.all(
+    Object.keys(signups).map(async (uid) => {
+      const playerSnap = await db.ref(PATHS.player(uid)).get();
+      const player = playerSnap.val();
+      if (!player) return; // hero record gone — leave the existing card as-is
+      const fresh = buildSnapshot(player);
+      if (!sameSnapshot(fresh, signups[uid])) {
+        updates[PATHS.signup(p.seasonId, p.weekId, uid)] = fresh;
+      }
+    }),
+  );
+
+  const n = Object.keys(updates).length;
+  if (n) await db.ref().update(updates);
+  return n;
 }
 
 /** Resolve the active raid (pointer + boss + team), or null. */

--- a/test/roster-refresh.test.js
+++ b/test/roster-refresh.test.js
@@ -1,0 +1,80 @@
+// Behavioral test for the signup-phase roster refresh (refreshMusteredRoster).
+// Proves: while a raid is in the SIGNUP phase, a hero who levels up after
+// mustering gets re-snapshotted onto the roster (so the site updates without a
+// manual re-!muster); redundant passes write nothing; and once the roster LOCKS
+// the snapshot is frozen. Run via `npm run test:emulator` (skipped without the
+// emulator host, same as firebase-rules.test.js).
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase, PATHS } from '../src/db/firebase.js';
+import { startConfigMirror, getRaidPointer, setRaidPointer } from '../src/db/configStore.js';
+import { setupRaidWeek, enlist, getSignup, refreshMusteredRoster } from '../src/db/raid.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+const SEASON = 's_rtest';
+const WEEK = 'w1';
+const UID = 'u_rtest';
+
+const makePlayer = (level) => ({
+  displayName: 'RTester', class: 'Ranger', role: 'dps', level, equipped: {}, subTier: 0, renown: 0, exp: 0,
+});
+
+// The config mirror is fed by an async RTDB listener — poll until it converges.
+async function waitForPointer(pred, ms = 3000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (pred(getRaidPointer())) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error('config/raid mirror did not converge in time');
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(noopLogger);
+});
+
+after(async () => {
+  if (!host) return;
+  await database().ref(PATHS.raid(SEASON, WEEK)).remove().catch(() => {});
+  await database().ref(PATHS.bossesForSeason(SEASON)).remove().catch(() => {});
+  await database().ref(PATHS.player(UID)).remove().catch(() => {});
+  await database().ref(PATHS.configRaid()).remove().catch(() => {});
+  await closeFirebase();
+});
+
+runOrSkip('signup phase: a mustered hero who levels up is re-snapshotted', async () => {
+  const db = database();
+  await db.ref(PATHS.player(UID)).set(makePlayer(1));
+  await setupRaidWeek({
+    seasonId: SEASON, weekId: WEEK,
+    boss: { name: 'Test Boss', thresholds: { tank: 0, healer: 0, dps: 0 } },
+    locksAt: Date.now() + 3_600_000, startsAt: Date.now() + 7_200_000,
+  });
+  await waitForPointer((p) => p?.seasonId === SEASON && p?.phase === 'signup');
+
+  await enlist({ seasonId: SEASON, weekId: WEEK, userId: UID, player: makePlayer(1) });
+  assert.equal((await getSignup(SEASON, WEEK, UID)).level, 1, 'mustered at level 1');
+
+  // Hero levels up after mustering → a refresh updates the card.
+  await db.ref(PATHS.player(UID)).update({ level: 5 });
+  assert.equal(await refreshMusteredRoster(), 1, 'one card refreshed');
+  assert.equal((await getSignup(SEASON, WEEK, UID)).level, 5, 'card now reflects level 5');
+
+  // Nothing changed since → no redundant write.
+  assert.equal(await refreshMusteredRoster(), 0, 'unchanged roster writes nothing');
+});
+
+runOrSkip('locked phase: the roster is frozen — no refresh', async () => {
+  const db = database();
+  await setRaidPointer({ phase: 'locked' });
+  await waitForPointer((p) => p?.phase === 'locked');
+
+  await db.ref(PATHS.player(UID)).update({ level: 9 });
+  assert.equal(await refreshMusteredRoster(), 0, 'a locked roster must not be rewritten');
+  assert.equal((await getSignup(SEASON, WEEK, UID)).level, 5, 'snapshot stays frozen at lock-time level');
+});


### PR DESCRIPTION
## What

Fixes the thing you hit: you level up *after* mustering, but the okrafans Raid page keeps showing your old level until you re-`!muster`.

`!muster` writes a **point-in-time snapshot** of your hero onto the roster (`raids/<s>/<w>/signups/<you>`), and the site renders the roster from those snapshots. So the card was only as fresh as your last muster.

This adds a **coarse signup-phase refresh**: a timer (`config.raid.rosterRefreshMs`, default 60 s) re-snapshots each signee from their *live* player record while the muster window is open — so leveling or gearing up after you muster shows on the site on its own, no re-`!muster` needed.

Per your call, it doesn't need to be instant — 60 s is plenty and cheap.

## Properties

- **No-op outside signup.** Guarded on the in-memory raid pointer — when there's no raid, or it's locked/live/done, the timer does a single memory check and returns. Zero DB cost the vast majority of the time.
- **Frozen at lock, unchanged.** Once the roster locks, the snapshot is the deterministic combat loadout and is never rewritten. The battle still uses the lock-time snapshot — **this is purely a pre-lock display fix, combat outcomes are untouched.**
- **No wasted writes.** Only rewrites cards that actually changed (`sameSnapshot` diff, normalizing RTDB's dropped empty `equipped`).
- **Leaves `team` alone** so the site keeps recomputing team stats from the fresh signups until lock writes the real aggregate.

## Tests

New emulator behavioral test (`test/roster-refresh.test.js`):
- signup-phase level-up → card re-snapshotted (level 1 → 5);
- unchanged pass → 0 writes;
- locked phase → 0 writes, snapshot stays frozen at lock-time level.

`npm test` 44/44 · `npm run test:emulator` 12/12.

## Docs

README muster note + `docs/CONFIG.md` raid table (`rosterRefreshMs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)