### PR TITLE
Correct project version to 0.2.0 (align with release tags)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kennybot",
-  "version": "2.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kennybot",
-      "version": "2.0.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@twurple/api": "^8.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennybot",
-  "version": "2.0.0",
+  "version": "0.2.0",
   "description": "Twitch chat bot + raid-game backend for nikkibreanne (https://twitch.tv/nikkibreanne). Authoritative game state in Firebase RTDB; outbound-only.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Why

`package.json` was at **2.0.0**, but the release tags started at **v0.1.0**. The 2.0.0 came from the raid-game rewrite (PR #6) bumping `1.0.0 → 2.0.0` as if it were a major release — but the project is still pre-1.0, so that over-claimed maturity and clashed with the tag lineage.

## What

Set the project version to **0.2.0** so the next release tag (`v0.2.0` — mute + roster refresh) matches `package.json`. Tag and `package.json` stay in lockstep from here.

Touches only our root version (3 lines: `package.json` + the two root entries in `package-lock.json`) — no dependency versions changed.

Merge this, then I'll tag **v0.2.0** off main, which triggers the publish workflow (`:0.2.0` + `:latest` + `:sha` to GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)