### PR TITLE
Log the running version on startup + in the heartbeat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ VOLUME /data
 USER node
 
 # File-based healthcheck (§E): no HTTP listener exists, so a port probe is
-# meaningless. The bot writes a JSON snapshot {ts, chatConnected, live} to
-# HEARTBEAT_FILE. Unhealthy = stale ts (process hung) OR chatConnected:false
+# meaningless. The bot writes a JSON snapshot {ts, version, chatConnected, live}
+# to HEARTBEAT_FILE. Unhealthy = stale ts (process hung) OR chatConnected:false
 # (chat socket wedged/disconnected and not recovered) — so the orchestrator
 # restarts a "process alive but chat dead" zombie instead of trusting it.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 // Outbound-only: listens on nothing (IMPLEMENTATION §B).
 import 'dotenv/config';
 import { writeFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { ApiClient } from '@twurple/api';
 import { ChatClient } from '@twurple/chat';
 
@@ -22,13 +23,24 @@ import { attachTwitchEvents } from './src/events/twitchEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
 import { processDrops } from './src/db/drops.js';
 
+// Running version, read from the bundled package.json (in the image at /app).
+// Surfaced in the startup log + heartbeat so "which release is this box on?"
+// is answerable from `docker logs` / the health snapshot — no label inspection.
+const APP_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')).version;
+  } catch {
+    return 'unknown';
+  }
+})();
+
 const HEARTBEAT_FILE = process.env.HEARTBEAT_FILE || '/tmp/kennybot.heartbeat';
 
 // Health snapshot written to HEARTBEAT_FILE for the container HEALTHCHECK. More
 // than a liveness ping: it records whether the Twitch chat socket is actually
 // connected, so a "process alive but chat wedged" zombie reads unhealthy and the
 // orchestrator restarts it, rather than the check passing on a dead connection.
-const health = { chatConnected: false, live: false };
+const health = { version: APP_VERSION, chatConnected: false, live: false };
 
 // Shutdown is wired up inside main(); module scope holds the reference so signal
 // handlers and the lease-lost callback can trigger it cleanly.
@@ -89,6 +101,7 @@ async function main() {
   };
 
   logger.info('kennyBot starting', {
+    version: APP_VERSION,
     channel,
     instanceId,
     emulator: Boolean(process.env.FIREBASE_DATABASE_EMULATOR_HOST),
@@ -272,7 +285,7 @@ async function main() {
   hbTimer.unref?.();
   shutdownHooks.push(() => clearInterval(hbTimer));
 
-  logger.info('kennyBot ready', { channel, botUserId, channelUserId, eventsub: eventSubActive });
+  logger.info('kennyBot ready', { version: APP_VERSION, channel, botUserId, channelUserId, eventsub: eventSubActive });
 }
 
 // First signal → graceful shutdown (itself watchdog-bounded above). A second


### PR DESCRIPTION
## Why

There was no way to see which release a running container is on without inspecting OCI labels (`docker inspect … org.opencontainers.image.version`), because the on-disk tag is just `:latest`. This surfaces the version directly.

## What

- Read the version from the bundled `package.json` (via `fs` — version-agnostic, no import-attribute concerns; Node 20 base image).
- Include it in the **`kennyBot starting`** and **`kennyBot ready`** logs, so `docker logs kennybot` answers "which release?" at a glance.
- Add it to the **heartbeat JSON** snapshot (`{ts, version, chatConnected, live}`), so the health file carries it too.

Falls back to `"unknown"` if `package.json` can't be read. The healthcheck is unchanged — it only reads `ts` + `chatConnected`, so the extra field is ignored.

After this ships and faraday updates, you'll see e.g.:
```
{"t":"…","level":"info","msg":"kennyBot ready","version":"0.2.0","channel":"nikkibreanne",…}
```

Git SHA was deliberately left out (it'd need a CI build-arg); the package.json version covers "which release am I on", and the exact sha is still on the image as the `org.opencontainers.image.revision` label.

## Tests

`node --check index.js` ✓ · version read returns `0.2.0` ✓ · `npm test` 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)