### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kennybot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kennybot",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@twurple/api": "^8.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennybot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Twitch chat bot + raid-game backend for nikkibreanne (https://twitch.tv/nikkibreanne). Authoritative game state in Firebase RTDB; outbound-only.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Release bump for the version-in-logs change (#14).

Now that the bot reads its version from `package.json` at startup, the bump must land **before** the tag so the `v0.2.1` image actually logs `version: 0.2.1`. Touches only our root version (3 lines; no dependency changes).

Merge this and I'll tag **v0.2.1** off main → publishes `:0.2.1` + `:latest` + `:sha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)