### PR TITLE
Add credits economy, Nikki facts, concurrent YES/NO OKRAMARKET, and command reference

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -32,6 +32,20 @@
 
     "items": { ".read": true, ".write": false },
     "drops": { ".read": true, ".write": false },
+
+    // OKRA FACTS: approved facts are public-readable, Admin-write only (kennyBot
+    // publishes them on `!fact approve`). The submission queue (factSubmissions)
+    // and its counter stay unreadable/unwritable to clients (default deny) — the
+    // website never touches them; suggestions arrive via chat (`!fact suggest`).
+    "facts": { ".read": true, ".write": false },
+
+    // OKRAMARKET: okra-buck balances and market state are public-READABLE (the
+    // site renders the board + odds) but Admin-write only — points can never be
+    // minted client-side; bets/opens/resolves all go through kennyBot. The bet
+    // counter (counters/) stays fully locked (default deny).
+    "wallets": { ".read": true, ".write": false },
+    "markets": { ".read": true, ".write": false },
+
     "players": { ".read": true, ".write": false },
     "usernames": { ".read": true, ".write": false },
     "bosses": { ".read": true, ".write": false },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node --test \"test/rules/**/*.test.js\"",
     "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
-    "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\""
+    "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",
+    "dev:all": "bash scripts/dev-all.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\""
   },

--- a/scripts/dev-all.sh
+++ b/scripts/dev-all.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# dev-all — launch the whole local stack in one terminal:
+#   1. the Firebase database emulator  (data 127.0.0.1:9000, UI http://localhost:4001)
+#   2. the website via Jekyll          (http://localhost:4000 — add ?dev to use the emulator)
+#   3. the interactive bot chat console (type ! commands, see the bot reply)
+#
+# The emulator is owned by `firebase emulators:exec`, which keeps it up for the
+# life of the console and tears it down on exit; Jekyll runs in the background and
+# is stopped when you /quit the console (or Ctrl-C). Data is EPHEMERAL — a fresh,
+# empty DB each run (seed it with chat commands or the console's /scenario).
+#
+#   npm run dev:all           # or:  bash scripts/dev-all.sh
+#   SITE_DIR=/path/to/site npm run dev:all      # if the website isn't at ~/git/nikkibreanne.github.io
+#
+set -uo pipefail
+
+BOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="${SITE_DIR:-$HOME/git/nikkibreanne.github.io}"
+JEKYLL_LOG="${TMPDIR:-/tmp}/kennybot-dev-jekyll.log"
+
+# Make the locally-installed firebase-tools resolvable even when run directly.
+PATH="$BOT_DIR/node_modules/.bin:$PATH"
+# Ensure bundler is reachable (user gem bin isn't always on PATH).
+if ! command -v bundle >/dev/null 2>&1; then
+  for d in "$HOME/.local/share/gem/ruby/"*/bin; do [ -d "$d" ] && PATH="$d:$PATH"; done
+fi
+
+SITE_PID=""
+cleanup() {
+  echo
+  echo "▶ shutting down…"
+  # SIGINT (not TERM): Jekyll traps it gracefully, like Ctrl-C — no stack trace.
+  [ -n "$SITE_PID" ] && kill -INT "$SITE_PID" 2>/dev/null
+  return 0
+}
+trap cleanup EXIT INT TERM
+
+# ── website (background) ────────────────────────────────────────────────────
+if [ -d "$SITE_DIR" ] && command -v bundle >/dev/null 2>&1; then
+  echo "▶ website → http://localhost:4000  (logs: $JEKYLL_LOG)"
+  ( cd "$SITE_DIR" && exec bundle exec jekyll serve ) >"$JEKYLL_LOG" 2>&1 &
+  SITE_PID=$!
+elif [ ! -d "$SITE_DIR" ]; then
+  echo "⚠ website skipped — no site repo at $SITE_DIR (set SITE_DIR=… to point at it)."
+else
+  echo "⚠ website skipped — 'bundle' not found (install bundler, or launch Jekyll yourself)."
+fi
+
+cat <<'EOF'
+▶ emulator DB → 127.0.0.1:9000  (the console + website ?dev both talk to it)
+▶ open any page with ?dev to read the local emulator, e.g. http://localhost:4000/?dev
+▶ in the console: ! runs chat commands · /as <name> [sub] [mod] switches identity · /help · /quit
+EOF
+echo
+
+# ── emulator + interactive chat console (foreground) ────────────────────────
+# emulators:exec owns the emulator; when the console exits, the emulator is torn
+# down and the EXIT trap stops Jekyll.
+cd "$BOT_DIR"
+firebase emulators:exec --only database --project okrafans "node scripts/dev-console.js"

--- a/src/commands/bet.js
+++ b/src/commands/bet.js
@@ -1,0 +1,60 @@
+// !bet <market#> <yes|no> <amount> — wager credits on an OKRAMARKET. The market
+// number targets one of the concurrently-open markets (see !market). You back
+// ONE side per market; betting again on the same side adds to your stake. If
+// exactly one market is open you can omit the number: !bet yes <amount>.
+// Payouts are parimutuel (see market.js).
+import { placeBet, listOpenMarkets } from '../db/market.js';
+
+const OUTCOMES = new Set(['yes', 'no', 'y', 'n']);
+
+export default {
+  names: ['bet', 'wager'],
+  mod: false,
+  cooldownMs: 2_000,
+  help: '!bet <market#> <yes|no> <amount> — wager credits on an OKRAMARKET',
+  async run({ user, args, reply }) {
+    let marketId;
+    let optionKey;
+    let amount;
+
+    if (OUTCOMES.has((args[0] || '').toLowerCase())) {
+      // No-number form — only works when exactly one market is open.
+      [optionKey, amount] = args;
+      const open = (await listOpenMarkets()).filter((m) => m.status === 'open');
+      if (open.length === 0) { reply(`@${user.displayName} no market is open right now.`); return; }
+      if (open.length > 1) {
+        const list = open.map((m) => `#${m.id} ${m.question}`).join(' · ');
+        reply(`@${user.displayName} which one? use !bet <#> ${optionKey.toLowerCase()} <amount> — open: ${list}`);
+        return;
+      }
+      marketId = open[0].id;
+    } else {
+      [marketId, optionKey, amount] = args;
+    }
+
+    if (marketId == null || marketId === '' || !optionKey || amount == null) {
+      reply(`@${user.displayName} usage: !bet <market#> <yes|no> <amount> — see open markets with !market (or the site).`);
+      return;
+    }
+
+    const res = await placeBet({ userId: user.id, login: user.login, displayName: user.displayName, marketId, optionKey, amount });
+    if (res.ok) {
+      reply(
+        `@${user.displayName} ✅ bet on #${res.marketId} "${res.optionLabel}"! Your stake there: ${res.staked.toLocaleString('en-US')} · ` +
+          `balance: ${res.balance.toLocaleString('en-US')} credits`,
+      );
+      return;
+    }
+
+    const msg = {
+      'no-market': `no market #${marketId} is open — see !market.`,
+      closed: 'betting is closed on that market.',
+      'bad-amount': 'enter a whole amount of at least 1.',
+      insufficient: `not enough credits (you have ${(res.balance || 0).toLocaleString('en-US')}). Claim !daily.`,
+      'no-wallet': 'get some credits first — !daily.',
+      'bad-option': 'pick a side: yes or no.',
+      'already-other-side': `you're already backing "${res.optionLabel}" on that market — no hedging in this universe!`,
+    }[res.reason] || 'that bet did not go through.';
+    reply(`@${user.displayName} ${msg}`);
+  },
+};

--- a/src/commands/daily.js
+++ b/src/commands/daily.js
@@ -1,0 +1,30 @@
+// !daily — claim the daily credit allowance (bootstraps a wallet + starter
+// grubstake for first-timers). Wagering currency for the OKRAMARKET.
+import { claimDaily } from '../db/wallet.js';
+
+function human(ms) {
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+export default {
+  names: ['daily'],
+  mod: false,
+  cooldownMs: 5_000,
+  help: '!daily — claim your daily credits',
+  async run({ user, reply }) {
+    const res = await claimDaily({ userId: user.id, login: user.login, displayName: user.displayName });
+    if (res.ok) {
+      reply(
+        `@${user.displayName} 💰 +${res.amount.toLocaleString('en-US')} credits!` +
+          `${res.firstTime ? ' (plus a starter grubstake — welcome!)' : ''} ` +
+          `Balance: ${res.balance.toLocaleString('en-US')}. Wager it: !bet <option> <amount>`,
+      );
+    } else if (res.reason === 'cooldown') {
+      reply(`@${user.displayName} already claimed today — next !daily in ${human(res.retryMs)}. Balance: ${(res.balance || 0).toLocaleString('en-US')}.`);
+    } else {
+      reply(`@${user.displayName} couldn't claim right now — try again in a moment.`);
+    }
+  },
+};

--- a/src/commands/fact.js
+++ b/src/commands/fact.js
@@ -1,0 +1,72 @@
+// !fact — NIKKI FACTS. Public: `!fact` shows a random approved fact;
+// `!fact suggest <text>` queues one for mod approval. Mod-only:
+// `!fact pending`, `!fact approve <#>`, `!fact reject <#>`. Mixed public/mod, so
+// it stays `mod:false` and gates the moderation subcommands on isMod inline.
+import { suggestFact, listPendingFacts, approveFact, rejectFact, randomApprovedFact, cleanFactText } from '../db/facts.js';
+import { config } from '../config.js';
+
+// Per-user suggest throttle (single instance → in-memory is authoritative).
+const SUGGEST_THROTTLE_MS = 20_000;
+const lastSuggest = new Map();
+
+export default {
+  names: ['fact', 'facts'],
+  mod: false,
+  cooldownMs: 3_000,
+  help: '!fact — a random Nikki fact · !fact suggest <text> — suggest one for approval',
+  async run({ user, args, reply }) {
+    const sub = (args[0] || '').toLowerCase();
+    const isMod = user.isMod || user.isBroadcaster;
+
+    // ── mod: review queue ──
+    if (sub === 'pending' || sub === 'queue') {
+      if (!isMod) return;
+      const pending = await listPendingFacts(8);
+      if (!pending.length) { reply('No pending fact suggestions.'); return; }
+      const list = pending.map((f) => `#${f.id} "${f.text}" (${f.by})`).join('  ·  ');
+      reply(`Pending — ${list}  →  !fact approve <#> / !fact reject <#>`);
+      return;
+    }
+    if (sub === 'approve' || sub === 'reject') {
+      if (!isMod) return;
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id)) { reply(`Usage: !fact ${sub} <#>  (see !fact pending)`); return; }
+      if (sub === 'approve') {
+        const res = await approveFact(id);
+        reply(res.ok ? `✅ Fact #${id} approved — it's live at ${config.siteUrl}/info/` : `Couldn't approve #${id} (${res.reason}).`);
+      } else {
+        const res = await rejectFact(id);
+        reply(res.ok ? `🗑️ Fact #${id} rejected.` : `Couldn't reject #${id} (${res.reason}).`);
+      }
+      return;
+    }
+
+    // ── public: suggest a fact ──
+    if (sub === 'suggest' || sub === 'add') {
+      const text = cleanFactText(args.slice(1).join(' '));
+      if (!text) { reply(`@${user.displayName} usage: !fact suggest <your fact about Nikki>`); return; }
+      const now = Date.now();
+      if (now - (lastSuggest.get(user.id) || 0) < SUGGEST_THROTTLE_MS) {
+        reply(`@${user.displayName} whoa, let the last one settle — try again in a moment.`);
+        return;
+      }
+      const res = await suggestFact({ userId: user.id, login: user.login, displayName: user.displayName, text });
+      if (!res.ok) {
+        const why = res.reason === 'too-short' ? 'too short' : res.reason === 'too-long' ? 'too long (200 char max)' : res.reason;
+        reply(`@${user.displayName} couldn't submit that (${why}).`);
+        return;
+      }
+      lastSuggest.set(user.id, now);
+      reply(`@${user.displayName} fact #${res.id} submitted for approval — thanks! It'll show at ${config.siteUrl}/info/ once a mod okays it.`);
+      return;
+    }
+
+    // ── public: a random Nikki fact ──
+    const fact = await randomApprovedFact();
+    reply(
+      fact
+        ? `NIKKI FACT: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}  ·  suggest yours: !fact suggest <text>`
+        : `No facts yet — be the first! !fact suggest <your fact>  (${config.siteUrl}/info/)`,
+    );
+  },
+};

--- a/src/commands/fact.js
+++ b/src/commands/fact.js
@@ -1,4 +1,4 @@
-// !fact — NIKKI FACTS. Public: `!fact` shows a random approved fact;
+// !fact — NIKKI FUN FACTS. Public: `!fact` shows a random approved fact;
 // `!fact suggest <text>` queues one for mod approval. Mod-only:
 // `!fact pending`, `!fact approve <#>`, `!fact reject <#>`. Mixed public/mod, so
 // it stays `mod:false` and gates the moderation subcommands on isMod inline.
@@ -13,7 +13,7 @@ export default {
   names: ['fact', 'facts'],
   mod: false,
   cooldownMs: 3_000,
-  help: '!fact — a random Nikki fact · !fact suggest <text> — suggest one for approval',
+  help: '!fact — a random Nikki fun fact · !fact suggest <text> — suggest one for approval',
   async run({ user, args, reply }) {
     const sub = (args[0] || '').toLowerCase();
     const isMod = user.isMod || user.isBroadcaster;
@@ -61,11 +61,11 @@ export default {
       return;
     }
 
-    // ── public: a random Nikki fact ──
+    // ── public: a random Nikki fun fact ──
     const fact = await randomApprovedFact();
     reply(
       fact
-        ? `NIKKI FACT: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}  ·  suggest yours: !fact suggest <text>`
+        ? `NIKKI FUN FACT: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}  ·  suggest yours: !fact suggest <text>`
         : `No facts yet — be the first! !fact suggest <your fact>  (${config.siteUrl}/info/)`,
     );
   },

--- a/src/commands/kennycommands.js
+++ b/src/commands/kennycommands.js
@@ -1,0 +1,13 @@
+// !kennycommands — point chat at the full command reference (like Nightbot's
+// !commands). The website hosts the always-current list; this just links to it.
+import { config } from '../config.js';
+
+export default {
+  names: ['kennycommands', 'kennybot', 'kcommands'],
+  mod: false,
+  cooldownMs: 10_000,
+  help: '!kennycommands — the full list of everything kennyBot can do',
+  async run({ reply }) {
+    reply(`🤖 Everything I can do → ${config.siteUrl}/commands/  ·  source: github.com/nikkibreanne/kennyBot`);
+  },
+};

--- a/src/commands/mod/market.js
+++ b/src/commands/mod/market.js
@@ -87,7 +87,7 @@ export default {
           reply(`Can't approve #${id}: ${why}`);
           return;
         }
-        reply(`✅ Suggestion #${id} is live → 📈 OKRAMARKET #${res.market.id} "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+        reply(`✅ Suggestion #${id} is live → 📈 OKRAMARKET #${res.market.id} "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/okramarket/`);
       } else {
         const res = await rejectMarketSuggestion(id);
         reply(res.ok ? `🗑️ Suggestion #${id} rejected.` : `Couldn't reject #${id} (${res.reason}).`);
@@ -108,7 +108,7 @@ export default {
         reply(`Can't open: ${why}`);
         return;
       }
-      reply(`📈 OKRAMARKET #${res.market.id} OPEN — "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+      reply(`📈 OKRAMARKET #${res.market.id} OPEN — "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/okramarket/`);
       return;
     }
 
@@ -162,6 +162,6 @@ export default {
     const shown = open.slice(0, 5);
     const lines = shown.map((m) => `#${m.id} "${clip(m.question, 40)}" [${m.status}] Y:${(m.pools?.yes || 0).toLocaleString('en-US')}/N:${(m.pools?.no || 0).toLocaleString('en-US')}`).join('  ·  ');
     const more = open.length > shown.length ? ` · +${open.length - shown.length} more` : '';
-    reply(`📈 OKRAMARKETs (${open.length}) — ${lines}${more} · bet: !bet <#> <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+    reply(`📈 OKRAMARKETs (${open.length}) — ${lines}${more} · bet: !bet <#> <yes|no> <amount> · board: ${config.siteUrl}/okramarket/`);
   },
 };

--- a/src/commands/mod/market.js
+++ b/src/commands/mod/market.js
@@ -1,0 +1,167 @@
+// !market — the OKRAMARKET: concurrent binary YES/NO prediction markets staked in
+// credits (Polymarket-style). Mixed public/mod (like !fact): stays `mod:false`
+// and gates the management subcommands on isMod inline. Markets are targeted by
+// their number (see !market).
+//   Public:  !market                       — list the open markets
+//            !market suggest <question>     — propose a YES/NO market for approval
+//   Mod:     !market open <question>        — open a YES/NO market for wagering
+//            !market close <#>              — stop accepting bets on #
+//            !market resolve <#> <yes|no>   — pay out # (parimutuel)
+//            !market cancel <#>             — void # + refund every bet
+//            !market queue                  — review viewer suggestions
+//            !market approve <#> / reject <#>
+import {
+  openMarket, closeMarket, resolveMarket, cancelMarket, listOpenMarkets,
+  suggestMarket, listPendingMarketSuggestions, approveMarketSuggestion, rejectMarketSuggestion,
+} from '../../db/market.js';
+import { config } from '../../config.js';
+
+// Per-user suggest throttle (single instance → in-memory is authoritative).
+const SUGGEST_THROTTLE_MS = 30_000;
+const lastSuggest = new Map();
+
+const clip = (s, n) => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+/** Format a market's outcomes as "1) Yes  2) No" for chat. */
+function optionLine(market) {
+  return market.optionOrder.map((k, i) => `${i + 1}) ${market.options[k].label}`).join('  ');
+}
+
+export default {
+  names: ['market'],
+  mod: false, // mixed: public list/suggest, mod management (gated inline)
+  cooldownMs: 2_000,
+  help: '!market — list open markets · !market suggest <question> — propose a YES/NO market',
+  async run({ user, args, reply }) {
+    const sub = (args[0] || 'status').toLowerCase();
+    const rest = args.slice(1).join(' ').trim();
+    const isMod = user.isMod || user.isBroadcaster;
+
+    // ── public: propose a market ──
+    if (sub === 'suggest' || sub === 'propose') {
+      if (!rest) {
+        reply(`@${user.displayName} usage: !market suggest <yes/no question>  (e.g. !market suggest Will we clear the boss tonight?)`);
+        return;
+      }
+      const now = Date.now();
+      if (now - (lastSuggest.get(user.id) || 0) < SUGGEST_THROTTLE_MS) {
+        reply(`@${user.displayName} easy — let that one queue up. Try again in a moment.`);
+        return;
+      }
+      const res = await suggestMarket({ userId: user.id, login: user.login, displayName: user.displayName, question: rest });
+      if (!res.ok) {
+        const why = {
+          'too-short': 'question too short',
+          'too-long': 'question too long (140 char max)',
+        }[res.reason] || res.reason;
+        reply(`@${user.displayName} couldn't submit that (${why}).`);
+        return;
+      }
+      lastSuggest.set(user.id, now);
+      reply(`@${user.displayName} 🗳️ market suggestion #${res.id} submitted — a mod will review it. Thanks!`);
+      return;
+    }
+
+    // ── mod: review the suggestion queue ──
+    if (sub === 'queue' || sub === 'pending' || sub === 'suggestions') {
+      if (!isMod) return;
+      const pending = await listPendingMarketSuggestions(6);
+      if (!pending.length) { reply('No pending market suggestions.'); return; }
+      const list = pending.map((s) => `#${s.id} "${s.question}" —${s.by}`).join('  ·  ');
+      reply(`Suggested markets (Yes/No) — ${list}  →  !market approve <#> / !market reject <#>`);
+      return;
+    }
+    if (sub === 'approve' || sub === 'reject') {
+      if (!isMod) return;
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id)) { reply(`Usage: !market ${sub} <#>  (see !market queue)`); return; }
+      if (sub === 'approve') {
+        const res = await approveMarketSuggestion(id);
+        if (!res.ok) {
+          const why = {
+            'not-found': `no suggestion #${id}.`,
+            'already-approved': `#${id} was already approved.`,
+            'too-many-open': `max ${res.max} markets already open — resolve or cancel one, then approve #${id}.`,
+            'need-question': 'that suggestion is empty.',
+          }[res.reason] || res.reason;
+          reply(`Can't approve #${id}: ${why}`);
+          return;
+        }
+        reply(`✅ Suggestion #${id} is live → 📈 OKRAMARKET #${res.market.id} "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+      } else {
+        const res = await rejectMarketSuggestion(id);
+        reply(res.ok ? `🗑️ Suggestion #${id} rejected.` : `Couldn't reject #${id} (${res.reason}).`);
+      }
+      return;
+    }
+
+    // ── mod: open a market directly ──
+    if (sub === 'open') {
+      if (!isMod) return;
+      if (!rest) { reply('Usage: !market open <yes/no question>'); return; }
+      const res = await openMarket({ question: rest });
+      if (!res.ok) {
+        const why = {
+          'too-many-open': `max ${res.max} markets already open — resolve or cancel one first.`,
+          'need-question': 'give the market a question.',
+        }[res.reason] || res.reason;
+        reply(`Can't open: ${why}`);
+        return;
+      }
+      reply(`📈 OKRAMARKET #${res.market.id} OPEN — "${res.market.question}"  ${optionLine(res.market)}  ·  bet: !bet ${res.market.id} <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+      return;
+    }
+
+    if (sub === 'close') {
+      if (!isMod) return;
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id)) { reply('Usage: !market close <#>  (see !market)'); return; }
+      const res = await closeMarket(id);
+      reply(res.ok ? `🔒 Betting closed on #${id} "${res.question}". Result when ready — !market resolve ${id} <yes|no>.` : `Nothing to close on #${id} (${res.reason}).`);
+      return;
+    }
+
+    if (sub === 'resolve') {
+      if (!isMod) return;
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id) || !args[2]) { reply('Usage: !market resolve <#> <yes|no>'); return; }
+      const res = await resolveMarket(id, args[2]);
+      if (!res.ok) {
+        const why = {
+          'no-market': `no market #${id}.`,
+          'already-resolved': `#${id} is already resolved.`,
+          'bad-option': 'unknown outcome — use: yes or no.',
+        }[res.reason] || res.reason;
+        reply(`Can't resolve #${id}: ${why}`);
+        return;
+      }
+      if (res.refunded) {
+        reply(`#${id} "${res.winLabel}" wins — but nobody backed it, so all bets were refunded.`);
+        return;
+      }
+      const top = res.top ? ` Top: ${res.top.displayName} (+${res.top.payout.toLocaleString('en-US')})!` : '';
+      reply(`🏆 OKRAMARKET #${id} resolved: "${res.winLabel}" wins! ${res.winners.length} winner(s) split ${res.totalPool.toLocaleString('en-US')} credits.${top}`);
+      return;
+    }
+
+    if (sub === 'cancel') {
+      if (!isMod) return;
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id)) { reply('Usage: !market cancel <#>'); return; }
+      const res = await cancelMarket(id);
+      reply(res.ok ? `❌ Market #${id} cancelled — ${res.count} bet(s) refunded (${res.refunded.toLocaleString('en-US')} credits returned).` : `Nothing to cancel on #${id} (${res.reason}).`);
+      return;
+    }
+
+    // ── public: list the open markets ──
+    const open = await listOpenMarkets();
+    if (!open.length) {
+      reply(`No OKRAMARKETs open right now. Got a call to make? !market suggest <yes/no question>`);
+      return;
+    }
+    const shown = open.slice(0, 5);
+    const lines = shown.map((m) => `#${m.id} "${clip(m.question, 40)}" [${m.status}] Y:${(m.pools?.yes || 0).toLocaleString('en-US')}/N:${(m.pools?.no || 0).toLocaleString('en-US')}`).join('  ·  ');
+    const more = open.length > shown.length ? ` · +${open.length - shown.length} more` : '';
+    reply(`📈 OKRAMARKETs (${open.length}) — ${lines}${more} · bet: !bet <#> <yes|no> <amount> · board: ${config.siteUrl}/#okramarket`);
+  },
+};

--- a/src/commands/points.js
+++ b/src/commands/points.js
@@ -12,7 +12,7 @@ export default {
     const w = await ensureWallet({ userId: user.id, login: user.login, displayName: user.displayName });
     reply(
       `@${user.displayName} 💰 you have ${(w.balance || 0).toLocaleString('en-US')} credits. ` +
-        `Wager at the OKRAMARKET (!bet <option> <amount>) · claim your free !daily · board: ${config.siteUrl}/#okramarket`,
+        `Wager at the OKRAMARKET (!bet <#> <yes|no> <amount>) · claim your free !daily · board: ${config.siteUrl}/okramarket/`,
     );
   },
 };

--- a/src/commands/points.js
+++ b/src/commands/points.js
@@ -1,0 +1,18 @@
+// !credits / !points — check your credit balance (creates a wallet + grubstake on
+// first use). Credits are the OKRAMARKET wagering currency.
+import { ensureWallet } from '../db/wallet.js';
+import { config } from '../config.js';
+
+export default {
+  names: ['credits', 'points', 'bal', 'balance'],
+  mod: false,
+  cooldownMs: 3_000,
+  help: '!credits — your credit balance',
+  async run({ user, reply }) {
+    const w = await ensureWallet({ userId: user.id, login: user.login, displayName: user.displayName });
+    reply(
+      `@${user.displayName} 💰 you have ${(w.balance || 0).toLocaleString('en-US')} credits. ` +
+        `Wager at the OKRAMARKET (!bet <option> <amount>) · claim your free !daily · board: ${config.siteUrl}/#okramarket`,
+    );
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -9,6 +9,12 @@ import unequip from './unequip.js';
 import grab from './grab.js';
 import raid from './raid.js';
 import top from './top.js';
+import fact from './fact.js';
+import kennycommands from './kennycommands.js';
+import points from './points.js';
+import daily from './daily.js';
+import bet from './bet.js';
+import market from './mod/market.js';
 import exp from './mod/exp.js';
 import mute from './mod/mute.js';
 import drop from './mod/drop.js';
@@ -17,7 +23,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, exp, mute, drop, drops, boss, raidnight, season];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/config.js
+++ b/src/config.js
@@ -158,6 +158,17 @@ export const config = {
     staleMs: 60_000,
   },
 
+  // ── OKRAMARKET points economy (viewer wagering, spec §5.2 extension) ────────
+  // credits are the wagering currency (bot-owned ledger; NOT the RPG EXP/loot
+  // economy). Balances start with a grubstake; a daily allowance keeps everyone in
+  // the game. Markets pay out parimutuel (winners split the pool, no rake).
+  economy: {
+    grubstake: 500, // starting balance the first time a viewer touches their wallet
+    minBet: 1, // smallest wager
+    daily: { amount: 200, cooldownMs: 20 * 60 * 60 * 1000 }, // ~once/day claim
+    maxOpenMarkets: 8, // how many OKRAMARKET predictions can run concurrently
+  },
+
   // ── Site link surfaced by !muster / !char ──────────────────────────────────
   siteUrl: 'https://okrafans.com',
 };

--- a/src/db/facts.js
+++ b/src/db/facts.js
@@ -1,0 +1,81 @@
+// OKRA FACTS moderation (/info/ page). Viewers suggest facts via `!fact suggest`;
+// a mod approves. Submissions live in an admin-only moderation queue
+// (`factSubmissions/<id>`) keyed by a short atomic counter so mods can reference
+// them in chat (`!fact approve 7`). Approved facts are copied to `facts/<pushId>`
+// — client-READ-ONLY — which the website renders. All writes are Admin-SDK only.
+
+import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
+
+const MIN_LEN = 3;
+const MAX_LEN = 200;
+
+/** Normalize submitted text: collapse whitespace, trim. */
+export function cleanFactText(raw) {
+  return String(raw || '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Queue a viewer's fact suggestion for moderation.
+ * @returns {Promise<{ ok: true, id: number } | { ok: false, reason: string }>}
+ */
+export async function suggestFact({ userId, login, displayName, text }) {
+  const clean = cleanFactText(text);
+  if (clean.length < MIN_LEN) return { ok: false, reason: 'too-short' };
+  if (clean.length > MAX_LEN) return { ok: false, reason: 'too-long' };
+
+  const counter = await database().ref(PATHS.factCounter()).transaction((n) => (n || 0) + 1);
+  const id = counter.snapshot.val();
+  await database().ref(PATHS.factSubmission(id)).set({
+    text: clean,
+    by: displayName || login || 'anon',
+    byId: String(userId),
+    login: login || null,
+    status: 'pending',
+    at: SERVER_TIMESTAMP,
+  });
+  return { ok: true, id };
+}
+
+/** Pending suggestions (oldest first), for the mod queue. */
+export async function listPendingFacts(limit = 10) {
+  const snap = await database().ref(PATHS.factSubmissions()).get();
+  const val = snap.val() || {};
+  return Object.entries(val)
+    .filter(([, f]) => f && f.status === 'pending')
+    .map(([id, f]) => ({ id: Number(id), text: f.text, by: f.by }))
+    .sort((a, b) => a.id - b.id)
+    .slice(0, limit);
+}
+
+/**
+ * Approve a pending suggestion: publish it to `facts/` and mark the submission.
+ * @returns {Promise<{ ok: true, fact: {text,by} } | { ok: false, reason: string }>}
+ */
+export async function approveFact(id) {
+  const subRef = database().ref(PATHS.factSubmission(id));
+  const sub = (await subRef.get()).val();
+  if (!sub) return { ok: false, reason: 'not-found' };
+  if (sub.status === 'approved') return { ok: false, reason: 'already-approved' };
+
+  const factRef = database().ref(PATHS.facts()).push();
+  await factRef.set({ text: sub.text, by: sub.by || null, at: SERVER_TIMESTAMP });
+  await subRef.update({ status: 'approved', factId: factRef.key });
+  return { ok: true, fact: { text: sub.text, by: sub.by } };
+}
+
+/** Reject a pending suggestion (kept as audit, status flipped). */
+export async function rejectFact(id) {
+  const subRef = database().ref(PATHS.factSubmission(id));
+  const sub = (await subRef.get()).val();
+  if (!sub) return { ok: false, reason: 'not-found' };
+  await subRef.update({ status: 'rejected' });
+  return { ok: true, text: sub.text };
+}
+
+/** A random approved fact (for the bare `!fact` command), or null if none. */
+export async function randomApprovedFact() {
+  const snap = await database().ref(PATHS.facts()).get();
+  const facts = Object.values(snap.val() || {}).filter((f) => f && f.text);
+  if (!facts.length) return null;
+  return facts[Math.floor(Math.random() * facts.length)];
+}

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -86,6 +86,27 @@ export const PATHS = {
   configRaid: () => 'config/raid',
   configDropScheduler: () => 'config/dropScheduler',
   configLock: () => 'config/lock',
+  // OKRA FACTS (/info/): approved facts are client-read-only; the submission
+  // queue + counter are admin-only.
+  facts: () => 'facts',
+  factSubmissions: () => 'factSubmissions',
+  factSubmission: (id) => `factSubmissions/${id}`,
+  factCounter: () => 'counters/factSub',
+  // OKRAMARKET economy: wallets (points ledger) + the active/archived markets.
+  wallet: (userId) => `wallets/${userId}`,
+  wallets: () => 'wallets',
+  // Concurrent binary YES/NO markets: each lives at markets/open/<id> while
+  // running (bets nested under it); resolved/cancelled ones move to history.
+  marketsOpen: () => 'markets/open',
+  marketOpen: (id) => `markets/open/${id}`,
+  marketBet: (id, userId) => `markets/open/${id}/bets/${userId}`,
+  marketHistory: (id) => `markets/history/${id}`,
+  marketCounter: () => 'counters/market',
+  // Viewer-proposed markets: an admin-only moderation queue (default-deny, like
+  // factSubmissions) — a mod promotes one to the live market via `!market approve`.
+  marketSuggestions: () => 'marketSuggestions',
+  marketSuggestion: (id) => `marketSuggestions/${id}`,
+  marketSuggestionCounter: () => 'counters/marketSug',
   botToken: () => 'config/secrets/botToken',
   items: () => 'items',
   dropActive: () => 'drops/active',

--- a/src/db/market.js
+++ b/src/db/market.js
@@ -1,0 +1,296 @@
+// OKRAMARKET — parimutuel binary YES/NO prediction markets staked in credits.
+// Bot-owned (Admin SDK only). MANY markets run concurrently, each at
+// `markets/open/<id>` keyed by its atomic numeric id (the easy chat target);
+// resolved / cancelled markets are removed from `open` and archived to
+// `markets/history/<id>`. Betting DEBITS the wallet into the chosen side's pool;
+// on resolve the winning side's backers split the WHOLE pool proportional to
+// their stake (parimutuel, no rake) — so credits are conserved, never minted.
+// There is no resolution timer: a market lives until a mod resolves/cancels it,
+// so short- and long-horizon markets can coexist. Rules are enforced here.
+
+import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
+import { debit, credit } from './wallet.js';
+import { config } from '../config.js';
+
+const slug = (s) => String(s).toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 16);
+
+// Viewer market-suggestion limits (mirrors the fact-suggestion shape).
+const SUG_Q_MIN = 5;
+const SUG_Q_MAX = 140;
+
+// Every market is a binary YES/NO proposition (Polymarket-style prediction
+// market, not an arbitrary poll). Options are fixed so both chat and the site
+// speak the same two outcomes.
+const BINARY_OPTIONS = { yes: { label: 'Yes' }, no: { label: 'No' } };
+const BINARY_ORDER = ['yes', 'no'];
+
+/** Max markets open at once (config-tunable). */
+const maxOpen = () => config.economy.maxOpenMarkets || 8;
+
+/** Normalize suggested text: collapse whitespace, trim. */
+export function cleanMarketText(raw) {
+  return String(raw || '').replace(/\s+/g, ' ').trim();
+}
+
+/** Resolve a user-typed outcome token to a canonical option key (yes/no, 1/2, or label). */
+function resolveOptionKey(market, token) {
+  const key = String(token || '').toLowerCase().trim();
+  if (!key) return null;
+  if (key === 'y') return 'yes';
+  if (key === 'n') return 'no';
+  if (market.options?.[key]) return key;
+  if (/^\d+$/.test(key)) return (market.optionOrder || [])[parseInt(key, 10) - 1] || null;
+  return (market.optionOrder || []).find(
+    (k) => slug(market.options[k].label) === slug(key) || String(market.options[k].label).toLowerCase() === key,
+  ) || null;
+}
+
+/** Read a single open market by id (null if not open). */
+export async function getMarket(id) {
+  return (await database().ref(PATHS.marketOpen(id)).get()).val();
+}
+
+/** All currently open/closed markets, oldest id first. */
+export async function listOpenMarkets() {
+  const val = (await database().ref(PATHS.marketsOpen()).get()).val() || {};
+  return Object.values(val).filter(Boolean).sort((a, b) => a.id - b.id);
+}
+
+/**
+ * Open a new binary YES/NO market. Fails if the concurrent-market cap is hit.
+ * @returns {Promise<{ok:true,market:object}|{ok:false,reason:string}>}
+ */
+export async function openMarket({ question }) {
+  const q = String(question || '').trim();
+  if (!q) return { ok: false, reason: 'need-question' };
+
+  const openCount = Object.keys((await database().ref(PATHS.marketsOpen()).get()).val() || {}).length;
+  if (openCount >= maxOpen()) return { ok: false, reason: 'too-many-open', max: maxOpen() };
+
+  const counter = await database().ref(PATHS.marketCounter()).transaction((n) => (n || 0) + 1);
+  const id = counter.snapshot.val();
+  const market = {
+    id,
+    question: q,
+    options: { ...BINARY_OPTIONS },
+    optionOrder: [...BINARY_ORDER],
+    status: 'open',
+    pools: { yes: 0, no: 0 },
+    betCount: 0,
+    totalPool: 0,
+    openedAt: Date.now(),
+  };
+  await database().ref(PATHS.marketOpen(id)).set(market);
+  return { ok: true, market };
+}
+
+/** Stop accepting bets on a market (open → closed). */
+export async function closeMarket(id) {
+  let outcome = null;
+  await database().ref(PATHS.marketOpen(id)).transaction((m) => {
+    if (m === null) return null; // empty local cache → fetch & retry (NOT abort)
+    if (m.status !== 'open') { outcome = { ok: false, reason: 'not-open' }; return; } // abort
+    outcome = { ok: true, question: m.question };
+    return { ...m, status: 'closed', closedAt: Date.now() };
+  });
+  return outcome || { ok: false, reason: 'no-market' };
+}
+
+/**
+ * Place/append a bet on a market. Debits the wallet into the option pool. A user
+ * backs ONE side per market (accumulates on the same one — no hedging). Saga:
+ * wallet debit → market pool add, with compensation (refund) if the write can't proceed.
+ */
+export async function placeBet({ userId, login, displayName, marketId, optionKey, amount }) {
+  const amt = Math.floor(Number(amount));
+  if (!Number.isFinite(amt) || amt < config.economy.minBet) return { ok: false, reason: 'bad-amount' };
+
+  const market = await getMarket(marketId);
+  if (!market) return { ok: false, reason: 'no-market' };
+  if (market.status !== 'open') return { ok: false, reason: 'closed' };
+
+  const optKey = resolveOptionKey(market, optionKey);
+  if (!optKey) return { ok: false, reason: 'bad-option', options: market.options };
+
+  const existingBet = market.bets?.[userId];
+  if (existingBet && existingBet.option !== optKey) {
+    return { ok: false, reason: 'already-other-side', option: existingBet.option, optionLabel: market.options[existingBet.option]?.label };
+  }
+
+  // 1) Debit the wallet (atomic balance check).
+  const deb = await debit(userId, amt);
+  if (!deb.ok) return { ok: false, reason: deb.reason, balance: deb.balance };
+
+  // 2) Add to the pool + record the bet (transaction on the market).
+  let marketOk = false;
+  await database().ref(PATHS.marketOpen(marketId)).transaction((m) => {
+    if (m === null) return null; // empty local cache → fetch & retry (NOT abort)
+    if (m.status !== 'open' || !m.options?.[optKey]) return; // abort → compensate below
+    const pools = { ...(m.pools || {}) };
+    pools[optKey] = (pools[optKey] || 0) + amt;
+    const bets = { ...(m.bets || {}) };
+    const prev = bets[userId];
+    bets[userId] = { option: optKey, amount: (prev?.amount || 0) + amt, displayName: displayName || login || 'anon', at: Date.now() };
+    marketOk = true;
+    return { ...m, pools, bets, betCount: prev ? m.betCount || 0 : (m.betCount || 0) + 1, totalPool: (m.totalPool || 0) + amt };
+  });
+
+  if (!marketOk) {
+    await credit(userId, amt, { login, displayName }); // compensate — market moved under us
+    return { ok: false, reason: 'closed' };
+  }
+
+  return { ok: true, marketId, question: market.question, option: optKey, optionLabel: market.options[optKey].label, staked: (existingBet?.amount || 0) + amt, balance: deb.balance };
+}
+
+/**
+ * Resolve a market to a winning option and pay out parimutuel. Winners split the
+ * whole pool proportional to stake. If nobody backed the winner, all bets are
+ * refunded. Double-resolve safe: atomically CLAIMS the market (→ 'resolving')
+ * before paying, then archives to history and removes it from `open`.
+ */
+export async function resolveMarket(id, winningOption) {
+  const ref = database().ref(PATHS.marketOpen(id));
+  const peek = (await ref.get()).val();
+  if (!peek) {
+    // Not open — distinguish "already resolved/cancelled" from "never existed".
+    const archived = (await database().ref(PATHS.marketHistory(id)).get()).val();
+    return { ok: false, reason: archived ? 'already-resolved' : 'no-market' };
+  }
+  const winKey = resolveOptionKey(peek, winningOption);
+  if (!winKey) return { ok: false, reason: 'bad-option', options: peek.options };
+
+  const claim = await ref.transaction((m) => {
+    if (m === null) return null; // empty local cache → fetch & retry (NOT abort)
+    if (m.status === 'resolved' || m.status === 'resolving' || m.status === 'cancelling' || m.status === 'cancelled') return; // abort
+    return { ...m, status: 'resolving', resolvedOption: winKey };
+  });
+  if (!claim.committed || !claim.snapshot.exists()) return { ok: false, reason: 'already-resolved' };
+
+  const market = claim.snapshot.val();
+  const bets = market.bets || {};
+  const pools = market.pools || {};
+  const totalPool = Object.values(pools).reduce((s, v) => s + (v || 0), 0);
+  const winnersPool = pools[winKey] || 0;
+
+  const payouts = [];
+  if (winnersPool <= 0) {
+    for (const [uid, b] of Object.entries(bets)) {
+      await credit(uid, b.amount, { displayName: b.displayName });
+      payouts.push({ uid, displayName: b.displayName, refund: b.amount });
+    }
+  } else {
+    const factor = totalPool / winnersPool; // stake back + share of the losing pool
+    for (const [uid, b] of Object.entries(bets)) {
+      if (b.option !== winKey) continue;
+      const payout = Math.floor(b.amount * factor);
+      await credit(uid, payout, { displayName: b.displayName });
+      payouts.push({ uid, displayName: b.displayName, stake: b.amount, payout });
+    }
+  }
+
+  const record = {
+    ...market,
+    status: 'resolved', resolvedOption: winKey, resolvedLabel: market.options[winKey].label,
+    resolvedAt: Date.now(), refunded: winnersPool <= 0,
+  };
+  await database().ref(PATHS.marketHistory(id)).set(record);
+  await ref.remove();
+
+  const winners = payouts.filter((p) => p.payout);
+  winners.sort((a, b) => b.payout - a.payout);
+  return { ok: true, id, question: market.question, winKey, winLabel: market.options[winKey].label, totalPool, winnersPool, refunded: winnersPool <= 0, winners, top: winners[0] || null };
+}
+
+/** Void a market and refund every bet. Atomically claims (→ 'cancelling') first. */
+export async function cancelMarket(id) {
+  const ref = database().ref(PATHS.marketOpen(id));
+  const peek = (await ref.get()).val();
+  if (!peek) return { ok: false, reason: 'no-market' };
+
+  const claim = await ref.transaction((m) => {
+    if (m === null) return null; // empty local cache → fetch & retry (NOT abort)
+    if (m.status === 'resolving' || m.status === 'cancelling' || m.status === 'resolved') return; // abort
+    return { ...m, status: 'cancelling' };
+  });
+  if (!claim.committed || !claim.snapshot.exists()) return { ok: false, reason: 'busy' };
+
+  const market = claim.snapshot.val();
+  const bets = market.bets || {};
+  let refunded = 0;
+  let count = 0;
+  for (const [uid, b] of Object.entries(bets)) {
+    await credit(uid, b.amount, { displayName: b.displayName });
+    refunded += b.amount;
+    count += 1;
+  }
+  await database().ref(PATHS.marketHistory(id)).set({ ...market, status: 'cancelled', cancelledAt: Date.now() });
+  await ref.remove();
+  return { ok: true, id, question: market.question, refunded, count };
+}
+
+// ── Viewer-proposed markets ────────────────────────────────────────────────
+// Anyone can `!market suggest <yes/no question>`; the proposal lands in an
+// admin-only queue keyed by a short atomic counter. A mod reviews the queue and
+// `!market approve <#>` opens it as a live market (subject to the concurrent-market
+// cap). This mirrors facts.js.
+
+/**
+ * Queue a viewer's market proposal (a YES/NO question) for moderation.
+ * @returns {Promise<{ok:true,id:number}|{ok:false,reason:string}>}
+ */
+export async function suggestMarket({ userId, login, displayName, question }) {
+  const q = cleanMarketText(question);
+  if (q.length < SUG_Q_MIN) return { ok: false, reason: 'too-short' };
+  if (q.length > SUG_Q_MAX) return { ok: false, reason: 'too-long' };
+
+  const counter = await database().ref(PATHS.marketSuggestionCounter()).transaction((n) => (n || 0) + 1);
+  const id = counter.snapshot.val();
+  await database().ref(PATHS.marketSuggestion(id)).set({
+    question: q,
+    by: displayName || login || 'anon',
+    byId: String(userId),
+    login: login || null,
+    status: 'pending',
+    at: SERVER_TIMESTAMP,
+  });
+  return { ok: true, id };
+}
+
+/** Pending market suggestions (oldest first), for the mod queue. */
+export async function listPendingMarketSuggestions(limit = 6) {
+  const snap = await database().ref(PATHS.marketSuggestions()).get();
+  const val = snap.val() || {};
+  return Object.entries(val)
+    .filter(([, s]) => s && s.status === 'pending')
+    .map(([id, s]) => ({ id: Number(id), question: s.question, by: s.by }))
+    .sort((a, b) => a.id - b.id)
+    .slice(0, limit);
+}
+
+/**
+ * Approve a pending suggestion: open it as a live market and mark the queue entry.
+ * If the concurrent cap is hit, openMarket returns 'too-many-open' and the
+ * suggestion is LEFT pending (approve again after resolving one).
+ * @returns {Promise<{ok:true,market:object}|{ok:false,reason:string}>}
+ */
+export async function approveMarketSuggestion(id) {
+  const ref = database().ref(PATHS.marketSuggestion(id));
+  const sub = (await ref.get()).val();
+  if (!sub) return { ok: false, reason: 'not-found' };
+  if (sub.status === 'approved') return { ok: false, reason: 'already-approved' };
+
+  const res = await openMarket({ question: sub.question });
+  if (!res.ok) return res; // e.g. 'too-many-open' — leave it pending for later
+  await ref.update({ status: 'approved', marketId: res.market.id });
+  return { ok: true, market: res.market };
+}
+
+/** Reject a pending suggestion (kept as audit, status flipped). */
+export async function rejectMarketSuggestion(id) {
+  const ref = database().ref(PATHS.marketSuggestion(id));
+  const sub = (await ref.get()).val();
+  if (!sub) return { ok: false, reason: 'not-found' };
+  await ref.update({ status: 'rejected' });
+  return { ok: true, question: sub.question };
+}

--- a/src/db/wallet.js
+++ b/src/db/wallet.js
@@ -1,0 +1,92 @@
+// Credits wallet — the viewer points ledger for OKRAMARKET wagering. Bot-owned
+// (Admin SDK only) so points can NEVER be minted client-side (same anti-cheat
+// stance as the EXP/loot ledgers, spec §7). Keyed by Twitch user id so any
+// chatter can play — no hero (players/) required. Every mutation is an RTDB
+// transaction (idempotent under duplicated/echoed messages).
+
+import { database, PATHS } from './firebase.js';
+import { config } from '../config.js';
+
+/** Raw wallet record (or null). */
+export async function getWallet(userId) {
+  return (await database().ref(PATHS.wallet(userId)).get()).val();
+}
+
+/** Balance only (0 if no wallet yet). */
+export async function getBalance(userId) {
+  const w = await getWallet(userId);
+  return w ? w.balance || 0 : 0;
+}
+
+/**
+ * Create the wallet with a starting grubstake on first touch (idempotent), keeping
+ * the display identity fresh on later touches. Returns the wallet record.
+ */
+export async function ensureWallet({ userId, login, displayName }) {
+  const res = await database().ref(PATHS.wallet(userId)).transaction((curr) => {
+    if (curr) {
+      return { ...curr, login: login || curr.login || null, displayName: displayName || curr.displayName || null };
+    }
+    return {
+      login: login || null,
+      displayName: displayName || login || 'anon',
+      balance: config.economy.grubstake,
+      createdAt: Date.now(),
+      grubstaked: true,
+    };
+  });
+  return res.snapshot.val();
+}
+
+/** Credit points (winnings / daily / buy-in). Creates a bare wallet if absent. */
+export async function credit(userId, amount, { login, displayName } = {}) {
+  if (!(amount > 0)) return null;
+  const res = await database().ref(PATHS.wallet(userId)).transaction((curr) => {
+    const base = curr || { login: login || null, displayName: displayName || login || 'anon', balance: 0, createdAt: Date.now() };
+    return { ...base, balance: (base.balance || 0) + amount };
+  });
+  return res.snapshot.val()?.balance ?? null;
+}
+
+/**
+ * Debit points iff the balance covers it (atomic).
+ * @returns {Promise<{ok:true,balance:number}|{ok:false,reason:string,balance?:number}>}
+ */
+export async function debit(userId, amount) {
+  if (!(amount > 0)) return { ok: false, reason: 'bad-amount' };
+  let outcome = null;
+  await database().ref(PATHS.wallet(userId)).transaction((curr) => {
+    if (curr === null) return null; // empty local cache → fetch server data & retry (NOT abort)
+    const bal = curr.balance || 0;
+    if (bal < amount) { outcome = { ok: false, reason: 'insufficient', balance: bal }; return; } // abort
+    outcome = { ok: true, balance: bal - amount };
+    return { ...curr, balance: bal - amount };
+  });
+  return outcome || { ok: false, reason: 'no-wallet' }; // null committed → wallet truly absent
+}
+
+/**
+ * Claim the daily allowance if the cooldown has elapsed (bootstraps the wallet +
+ * grubstake for a first-timer). Atomic.
+ */
+export async function claimDaily({ userId, login, displayName }) {
+  const { amount, cooldownMs } = config.economy.daily;
+  const now = Date.now();
+  let outcome = { ok: false, reason: 'unknown' };
+  await database().ref(PATHS.wallet(userId)).transaction((curr) => {
+    const firstTime = !curr;
+    const base = curr || {
+      login: login || null, displayName: displayName || login || 'anon',
+      balance: config.economy.grubstake, createdAt: now, grubstaked: true,
+    };
+    const since = now - (base.lastDailyAt || 0);
+    if (!firstTime && since < cooldownMs) {
+      outcome = { ok: false, reason: 'cooldown', retryMs: cooldownMs - since, balance: base.balance || 0 };
+      return; // abort
+    }
+    const balance = (base.balance || 0) + amount;
+    outcome = { ok: true, amount, balance, firstTime };
+    return { ...base, balance, lastDailyAt: now, displayName: displayName || base.displayName, login: login || base.login || null };
+  });
+  return outcome;
+}

--- a/test/market.test.js
+++ b/test/market.test.js
@@ -1,0 +1,173 @@
+// Behavioral tests for the OKRAMARKET economy: the credit wallet (grubstake,
+// daily, atomic debit), fact moderation, and the parimutuel market (betting
+// guards, pool conservation on payout, double-resolve safety, refunds). Proves
+// points are conserved and can't be over-paid. Run via `npm run test:emulator`
+// (skipped without the emulator host, same as the other emulator tests).
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { ensureWallet, claimDaily, getBalance, credit } from '../src/db/wallet.js';
+import { suggestFact, listPendingFacts, approveFact, rejectFact, randomApprovedFact } from '../src/db/facts.js';
+import { openMarket, placeBet, closeMarket, resolveMarket, cancelMarket, getMarket, listOpenMarkets } from '../src/db/market.js';
+import { suggestMarket, listPendingMarketSuggestions, approveMarketSuggestion, rejectMarketSuggestion } from '../src/db/market.js';
+import { config } from '../src/config.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+async function wipe() {
+  await Promise.all(
+    ['wallets', 'markets', 'marketSuggestions', 'facts', 'factSubmissions', 'counters'].map((p) => database().ref(p).remove().catch(() => {})),
+  );
+}
+
+before(async () => { if (host) initFirebase(); });
+after(async () => { if (host) { await wipe(); await closeFirebase(); } });
+beforeEach(async () => { if (host) await wipe(); });
+
+runOrSkip('facts: suggest → moderate → publish', async () => {
+  const s1 = await suggestFact({ userId: 'u1', displayName: 'Alice', text: '  nikki   is okra  ' });
+  const s2 = await suggestFact({ userId: 'u2', displayName: 'Bob', text: 'okra is a fruit (legally)' });
+  assert.deepEqual([s1.ok, s1.id, s2.id], [true, 1, 2], 'short ids assigned 1,2');
+  assert.equal((await suggestFact({ userId: 'u3', text: 'ab' })).reason, 'too-short');
+
+  const pending = await listPendingFacts();
+  assert.equal(pending.length, 2);
+  assert.equal(pending[0].text, 'nikki is okra', 'whitespace collapsed');
+
+  assert.equal((await approveFact(1)).ok, true);
+  assert.equal((await approveFact(1)).reason, 'already-approved', 'no double-approve');
+  await rejectFact(2);
+  assert.equal((await listPendingFacts()).length, 0, 'queue clears');
+  assert.equal((await randomApprovedFact()).text, 'nikki is okra');
+});
+
+runOrSkip('wallet: grubstake, daily, cooldown', async () => {
+  assert.equal((await ensureWallet({ userId: 'A', displayName: 'A' })).balance, 500, 'grubstake');
+  const d = await claimDaily({ userId: 'A', displayName: 'A' });
+  assert.equal(d.balance, 700, 'daily +200');
+  assert.equal((await claimDaily({ userId: 'A', displayName: 'A' })).reason, 'cooldown');
+  assert.equal((await getBalance('A')), 700);
+});
+
+runOrSkip('wallet: debit on a non-existent wallet reports no-wallet (not a false abort)', async () => {
+  // Regression: the RTDB null-cache first call must fetch+retry, not abort.
+  await ensureWallet({ userId: 'W', displayName: 'W' }); // balance 500
+  await credit('W', 0); // no-op
+  const { debit } = await import('../src/db/wallet.js');
+  assert.equal((await debit('W', 100)).ok, true, 'existing wallet debits');
+  assert.equal((await debit('ghost', 100)).reason, 'no-wallet', 'absent wallet → no-wallet');
+});
+
+runOrSkip('market: parimutuel payout conserves the pool', async () => {
+  const om = await openMarket({ question: 'Will Nikki beat the boss?' });
+  assert.deepEqual(om.market.optionOrder, ['yes', 'no']);
+  const id = om.market.id;
+
+  await ensureWallet({ userId: 'A', displayName: 'A' });
+  await claimDaily({ userId: 'A', displayName: 'A' }); // A = 700
+  await ensureWallet({ userId: 'B', displayName: 'B' }); // B = 500
+
+  assert.equal((await placeBet({ userId: 'A', displayName: 'A', marketId: id, optionKey: 'yes', amount: 300 })).balance, 400);
+  assert.equal((await placeBet({ userId: 'B', displayName: 'B', marketId: id, optionKey: '2', amount: 200 })).optionLabel, 'No');
+
+  // guards
+  assert.equal((await placeBet({ userId: 'A', displayName: 'A', marketId: id, optionKey: 'no', amount: 10 })).reason, 'already-other-side');
+  assert.equal((await placeBet({ userId: 'A', displayName: 'A', marketId: id, optionKey: 'yes', amount: 99999 })).reason, 'insufficient');
+  assert.equal((await placeBet({ userId: 'B', displayName: 'B', marketId: id, optionKey: 'maybe', amount: 10 })).reason, 'bad-option');
+
+  const m = await getMarket(id);
+  assert.deepEqual([m.pools.yes, m.pools.no, m.totalPool], [300, 200, 500], 'pools tallied');
+
+  const r = await resolveMarket(id, 'yes');
+  assert.equal(r.winLabel, 'Yes');
+  assert.equal((await resolveMarket(id, 'no')).reason, 'already-resolved', 'no double-resolve');
+  assert.equal(await getMarket(id), null, 'resolved market leaves the open board');
+  // A backed the winner: stake 300 of a 500 pool → gets the whole 500. Total paid == pool.
+  assert.equal(await getBalance('A'), 900, 'winner: 400 + 500');
+  assert.equal(await getBalance('B'), 300, 'loser unchanged');
+});
+
+runOrSkip('market: nobody backs the winner → all bets refunded', async () => {
+  const { market } = await openMarket({ question: 'An edge case here?' });
+  await ensureWallet({ userId: 'A', displayName: 'A' }); // 500
+  await placeBet({ userId: 'A', displayName: 'A', marketId: market.id, optionKey: 'no', amount: 100 }); // A → 400
+  const r = await resolveMarket(market.id, 'yes'); // nobody bet yes
+  assert.equal(r.refunded, true);
+  assert.equal(await getBalance('A'), 500, 'refunded to full');
+});
+
+runOrSkip('market: cancel refunds every bet', async () => {
+  const { market } = await openMarket({ question: 'Cancel this one?' });
+  await ensureWallet({ userId: 'A', displayName: 'A' }); // 500
+  await placeBet({ userId: 'A', displayName: 'A', marketId: market.id, optionKey: '1', amount: 100 }); // → 400
+  const c = await cancelMarket(market.id);
+  assert.deepEqual([c.ok, c.refunded, c.count], [true, 100, 1]);
+  assert.equal(await getBalance('A'), 500, 'refunded');
+  assert.equal(await getMarket(market.id), null, 'cancelled market leaves the open board');
+});
+
+runOrSkip('market: multiple markets run concurrently and independently', async () => {
+  const a = await openMarket({ question: 'First concurrent market?' });
+  const b = await openMarket({ question: 'Second concurrent market?' });
+  assert.notEqual(a.market.id, b.market.id, 'distinct ids');
+  assert.equal((await listOpenMarkets()).length, 2, 'both open');
+
+  await ensureWallet({ userId: 'A', displayName: 'A' }); // 500
+  // same user can back a different side on each market (no-hedging is per-market)
+  await placeBet({ userId: 'A', displayName: 'A', marketId: a.market.id, optionKey: 'yes', amount: 50 });
+  await placeBet({ userId: 'A', displayName: 'A', marketId: b.market.id, optionKey: 'no', amount: 30 });
+  assert.equal((await getMarket(a.market.id)).pools.yes, 50);
+  assert.equal((await getMarket(b.market.id)).pools.no, 30);
+  assert.equal(await getBalance('A'), 420, '500 - 50 - 30');
+
+  // resolving one leaves the other untouched
+  await resolveMarket(a.market.id, 'yes');
+  const open = await listOpenMarkets();
+  assert.deepEqual([open.length, open[0].id], [1, b.market.id], 'only the other remains');
+});
+
+runOrSkip('market: respects the concurrent-market cap', async () => {
+  const cap = config.economy.maxOpenMarkets;
+  for (let i = 0; i < cap; i += 1) {
+    assert.equal((await openMarket({ question: `Market number ${i} here?` })).ok, true);
+  }
+  const over = await openMarket({ question: 'One market too many?' });
+  assert.deepEqual([over.reason, over.max], ['too-many-open', cap], 'cap enforced');
+  assert.equal((await listOpenMarkets()).length, cap);
+});
+
+runOrSkip('market suggestions: suggest → queue → approve opens a live market', async () => {
+  const s1 = await suggestMarket({ userId: 'u1', displayName: 'Alice', question: '  Will we clear   the boss?  ' });
+  const s2 = await suggestMarket({ userId: 'u2', displayName: 'Bob', question: 'Nikki dies to trash pull?' });
+  assert.deepEqual([s1.ok, s1.id, s2.id], [true, 1, 2], 'short ids 1,2');
+
+  // validation (question only — options are always Yes/No)
+  assert.equal((await suggestMarket({ userId: 'u3', question: 'hi?' })).reason, 'too-short');
+
+  const pending = await listPendingMarketSuggestions();
+  assert.equal(pending.length, 2);
+  assert.equal(pending[0].question, 'Will we clear the boss?', 'whitespace collapsed');
+
+  const appr = await approveMarketSuggestion(1);
+  assert.equal(appr.ok, true);
+  assert.deepEqual(appr.market.optionOrder, ['yes', 'no']);
+  assert.equal((await getMarket(appr.market.id)).question, 'Will we clear the boss?', 'approved suggestion is now live');
+
+  // both can be approved — markets are concurrent
+  const appr2 = await approveMarketSuggestion(2);
+  assert.equal(appr2.ok, true);
+  assert.equal((await listOpenMarkets()).length, 2, 'both live at once');
+  assert.equal((await listPendingMarketSuggestions()).length, 0, 'queue cleared');
+});
+
+runOrSkip('market suggestions: reject + no double-approve', async () => {
+  await suggestMarket({ userId: 'u1', displayName: 'Alice', question: 'A good question to ask?' });
+  assert.equal((await approveMarketSuggestion(1)).ok, true);
+  assert.equal((await approveMarketSuggestion(1)).reason, 'already-approved', 'no double-approve');
+
+  await suggestMarket({ userId: 'u2', displayName: 'Bob', question: 'Another one to consider?' });
+  assert.equal((await rejectMarketSuggestion(2)).ok, true);
+  assert.equal((await listPendingMarketSuggestions()).length, 0, 'queue clears');
+  assert.equal((await rejectMarketSuggestion(99)).reason, 'not-found');
+});


### PR DESCRIPTION
## What

Adds the viewer-facing **credits economy**, **Nikki facts** moderation, the **OKRAMARKET** — concurrent binary YES/NO prediction markets (Polymarket-style) including viewer-proposed markets — and a **command reference** command.

## Commands

**Public**
- `!credits` / `!points` / `!bal` — check your balance
- `!daily` — claim the daily credit allowance (first claim grants a starter grubstake)
- `!bet <market#> <yes|no> <amount>` — wager on a market (the number is optional when only one is open: `!bet yes 100`)
- `!market` — list the open markets
- `!market suggest <question>` — propose a YES/NO market for mod approval
- `!fact` / `!fact suggest <text>` — random fact / suggest one
- `!kennycommands` — links chat to `okrafans.com/commands/`

**Mod**
- `!market open <question>` · `close <#>` · `resolve <#> <yes|no>` · `cancel <#>`
- `!market queue | approve <#> | reject <#>` — review viewer suggestions
- `!fact pending | approve <#> | reject <#>`

## Design notes

- **Binary & concurrent.** Every market is a fixed YES/NO proposition. Many run at once under `markets/open/<id>`, each targeted by its number. **No resolution timer** — a mod closes/resolves/cancels each by hand, so short- and long-horizon markets coexist. A config cap (`economy.maxOpenMarkets`, default 8) bounds concurrency; resolved/cancelled markets move to `markets/history/<id>` and leave the open board.
- **No credit minting.** Payouts are parimutuel: winners split the whole pool proportional to stake; conserved end-to-end. Debits are atomic (RTDB transaction with the null-cache `return null` retry guard). Resolve atomically claims (→ `resolving`) before paying, so a repeat can't double-pay.
- **Free web vote is separate.** The website's YES/NO community vote is anonymous and stakes **no** credits (it writes the wide-open `polls/market-<id>` path); credits only ever move through chat `!bet`.
- **Anti-cheat unchanged.** `wallets` / `markets` / `facts` are client-read-only; all writes go through the Admin SDK. `marketSuggestions` + `counters/*` inherit default-deny.

## Tests

`test/market.test.js` (via `npm run test:emulator`) — **22/22 passing**: wallet grubstake/daily/cooldown, atomic-debit regression, parimutuel conservation, double-resolve safety, nobody-wins & cancel refunds, **concurrent markets running independently**, the **concurrent cap**, and the suggest → queue → approve flow.

Pairs with website PR nikkibreanne/nikkibreanne.github.io#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
