### PR TITLE
Add mod-only !todo command with a date-organized public board

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -39,6 +39,11 @@
     // website never touches them; suggestions arrive via chat (`!fact suggest`).
     "facts": { ".read": true, ".write": false },
 
+    // TODO BOARD (/todo/): Nikki's to-do list is public-READABLE (the page renders
+    // it) but Admin-write only — mods add/remove items from chat (`!todo`), never
+    // the client. Its counter (counters/) stays fully locked (default deny).
+    "todos": { ".read": true, ".write": false },
+
     // OKRAMARKET: okra-buck balances and market state are public-READABLE (the
     // site renders the board + odds) but Admin-write only — points can never be
     // minted client-side; bets/opens/resolves all go through kennyBot. The bet

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",
     "dev:all": "bash scripts/dev-all.sh"

--- a/src/commands/mod/todo.js
+++ b/src/commands/mod/todo.js
@@ -1,0 +1,59 @@
+// !todo (mod) — manage Nikki's public, date-organized to-do list shown on the
+// /todo/ page. Mods/broadcaster only: the whole command is `mod:true`, so the
+// dispatcher hides it from everyone else. Control is chat-only; the page is
+// read-only (viewers just watch the list get worked through).
+//   !todo                         — list the current items
+//   !todo add [YYYY-MM-DD] <text> — add an item (date optional; defaults to today)
+//   !todo remove <#>              — remove/cross off an item by its number
+import { addTodo, removeTodo, listTodos, resolveDateToken, cleanTodoText } from '../../db/todo.js';
+import { config } from '../../config.js';
+
+const PAGE = () => `${config.siteUrl}/todo/`;
+
+/** "Mon Jul 14" from a YYYY-MM-DD, parsed as a plain calendar date (no TZ shift). */
+function dayLabel(date) {
+  const [y, m, d] = String(date).split('-').map(Number);
+  if (!y || !m || !d) return date;
+  return new Date(y, m - 1, d).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+export default {
+  names: ['todo', 'todos'],
+  mod: true,
+  cooldownMs: 2_000,
+  help: '!todo add [date] <text> | !todo remove <#> | !todo — mod-only date-organized to-do list (okrafans.com/todo/)',
+  async run({ user, args, reply }) {
+    const sub = (args[0] || 'list').toLowerCase();
+
+    // ── add ──
+    if (sub === 'add' || sub === 'new') {
+      let rest = args.slice(1);
+      const date = resolveDateToken(rest[0]); // null unless the first token is a date
+      if (date) rest = rest.slice(1);
+      const text = cleanTodoText(rest.join(' '));
+      if (!text) { reply(`@${user.displayName} usage: !todo add [YYYY-MM-DD] <thing to do>`); return; }
+      const res = await addTodo({ text, date: date || undefined, by: user.displayName });
+      if (!res.ok) {
+        reply(`@${user.displayName} couldn't add that (${res.reason === 'too-long' ? '200 char max' : res.reason}).`);
+        return;
+      }
+      reply(`📝 To-do #${res.id} added for ${dayLabel(res.todo.date)}: “${res.todo.text}” → ${PAGE()}`);
+      return;
+    }
+
+    // ── remove / cross off ──
+    if (['remove', 'rm', 'del', 'delete', 'done'].includes(sub)) {
+      const id = parseInt(args[1], 10);
+      if (!Number.isFinite(id)) { reply(`@${user.displayName} usage: !todo remove <#>  (see !todo)`); return; }
+      const res = await removeTodo(id);
+      reply(res.ok ? `✅ To-do #${id} crossed off: “${res.text}”` : `Couldn't remove #${id} (${res.reason}).`);
+      return;
+    }
+
+    // ── list (default) ──
+    const todos = await listTodos(8);
+    if (!todos.length) { reply(`Nothing on the to-do board. Add one: !todo add <thing> · ${PAGE()}`); return; }
+    const line = todos.map((t) => `#${t.id} [${dayLabel(t.date)}] ${t.text}`).join('  ·  ');
+    reply(`📝 To-do: ${line}  →  full list: ${PAGE()}`);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -15,6 +15,7 @@ import points from './points.js';
 import daily from './daily.js';
 import bet from './bet.js';
 import market from './mod/market.js';
+import todo from './mod/todo.js';
 import exp from './mod/exp.js';
 import mute from './mod/mute.js';
 import drop from './mod/drop.js';
@@ -23,7 +24,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market, todo];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -92,6 +92,12 @@ export const PATHS = {
   factSubmissions: () => 'factSubmissions',
   factSubmission: (id) => `factSubmissions/${id}`,
   factCounter: () => 'counters/factSub',
+  // TODO BOARD (/todo/): Nikki's public, date-organized to-do list. Items are
+  // client-READ-ONLY; mods add/remove them from chat (`!todo`). Keyed by a short
+  // atomic counter so a mod can target one to remove (`!todo remove 3`).
+  todos: () => 'todos',
+  todo: (id) => `todos/${id}`,
+  todoCounter: () => 'counters/todo',
   // OKRAMARKET economy: wallets (points ledger) + the active/archived markets.
   wallet: (userId) => `wallets/${userId}`,
   wallets: () => 'wallets',

--- a/src/db/todo.js
+++ b/src/db/todo.js
@@ -1,0 +1,76 @@
+// TODO BOARD (/todo/) — Nikki's public, date-organized to-do list, controlled
+// entirely from chat by mods/broadcaster (`!todo add|remove|list`). Items live at
+// `todos/<id>` keyed by a short atomic counter (the easy chat target) and are
+// client-READ-ONLY; the website groups them by day. All writes are Admin-SDK only.
+
+import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
+import { config } from '../config.js';
+
+const MIN_LEN = 1;
+const MAX_LEN = 200;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Bucket todos by the CHANNEL's local day (not UTC / the server's TZ) so "today"
+// matches Nikki's wall clock. Reuses the raid-night time zone as the channel TZ.
+const CHANNEL_TZ = config.raidNight?.timeZone || 'America/Los_Angeles';
+
+/** YYYY-MM-DD for the given instant in the channel's time zone (now by default). */
+export function channelDate(when = new Date()) {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: CHANNEL_TZ, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(when);
+}
+
+/** Normalize submitted text: collapse whitespace, trim. */
+export function cleanTodoText(raw) {
+  return String(raw || '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Resolve an optional leading date token to a YYYY-MM-DD string, or null if the
+ * token isn't a date (so the caller keeps it as part of the todo text). Accepts an
+ * explicit `YYYY-MM-DD`, or the words `today` / `tomorrow` (in channel time).
+ */
+export function resolveDateToken(token) {
+  const t = String(token || '').toLowerCase().trim();
+  if (ISO_DATE.test(t)) return t;
+  if (t === 'today') return channelDate();
+  if (t === 'tomorrow') return channelDate(new Date(Date.now() + 86_400_000));
+  return null;
+}
+
+/**
+ * Add a to-do item. Date defaults to the channel's today when not given/invalid.
+ * @returns {Promise<{ok:true,id:number,todo:object}|{ok:false,reason:string}>}
+ */
+export async function addTodo({ text, date, by }) {
+  const clean = cleanTodoText(text);
+  if (clean.length < MIN_LEN) return { ok: false, reason: 'empty' };
+  if (clean.length > MAX_LEN) return { ok: false, reason: 'too-long' };
+  const day = ISO_DATE.test(String(date || '')) ? date : channelDate();
+
+  const counter = await database().ref(PATHS.todoCounter()).transaction((n) => (n || 0) + 1);
+  const id = counter.snapshot.val();
+  const todo = { id, text: clean, date: day, by: by || null, at: SERVER_TIMESTAMP };
+  await database().ref(PATHS.todo(id)).set(todo);
+  return { ok: true, id, todo: { ...todo, at: Date.now() } };
+}
+
+/** Remove a to-do by id. */
+export async function removeTodo(id) {
+  const ref = database().ref(PATHS.todo(id));
+  const cur = (await ref.get()).val();
+  if (!cur) return { ok: false, reason: 'not-found' };
+  await ref.remove();
+  return { ok: true, text: cur.text, date: cur.date };
+}
+
+/** All to-dos, sorted by date (soonest first) then creation order within a day. */
+export async function listTodos(limit = 100) {
+  const val = (await database().ref(PATHS.todos()).get()).val() || {};
+  return Object.values(val)
+    .filter((t) => t && t.text)
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : (a.id || 0) - (b.id || 0)))
+    .slice(0, limit);
+}

--- a/test/firebase-rules.test.js
+++ b/test/firebase-rules.test.js
@@ -51,7 +51,7 @@ runOrSkip('client WRITE to players is rejected and leaves no data', async () => 
 });
 
 runOrSkip('client WRITE to leaderboard/bosses/raids/config is rejected', async () => {
-  for (const path of ['leaderboard/t1/u1', 'bosses/t1/w1', 'raids/t1/w1/x', 'config/live', 'config/expMode', 'config/chatMuted']) {
+  for (const path of ['leaderboard/t1/u1', 'bosses/t1/w1', 'raids/t1/w1/x', 'config/live', 'config/expMode', 'config/chatMuted', 'todos/_client_attempt']) {
     const res = await fetch(restUrl(path), { method: 'PUT', body: JSON.stringify({ x: 1 }) });
     assert.equal(res.status, 401, `client write to ${path} must be denied`);
   }

--- a/test/todo.test.js
+++ b/test/todo.test.js
@@ -1,0 +1,55 @@
+// Behavioral tests for the TODO BOARD (/todo/): add (default + explicit date),
+// list ordering (by date, then creation order), remove, and validation. Mirrors
+// the market/fact emulator tests; skipped without the emulator host.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { addTodo, removeTodo, listTodos, channelDate, resolveDateToken } from '../src/db/todo.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+async function wipe() {
+  await Promise.all(['todos', 'counters'].map((p) => database().ref(p).remove().catch(() => {})));
+}
+
+before(async () => { if (host) initFirebase(); });
+after(async () => { if (host) { await wipe(); await closeFirebase(); } });
+beforeEach(async () => { if (host) await wipe(); });
+
+runOrSkip('todo: add assigns short ids, cleans text, defaults to today', async () => {
+  const a = await addTodo({ text: '  stream   setup  ', by: 'Mod' });
+  const b = await addTodo({ text: 'call the vet for Ghost', by: 'Mod' });
+  assert.deepEqual([a.ok, a.id, b.id], [true, 1, 2], 'short ids 1,2');
+  assert.equal(a.todo.text, 'stream setup', 'whitespace collapsed');
+  assert.equal(a.todo.date, channelDate(), 'defaults to the channel today');
+});
+
+runOrSkip('todo: explicit date honored; list sorts by date then id', async () => {
+  await addTodo({ text: 'later thing', date: '2099-12-31' });
+  await addTodo({ text: 'today A' });
+  await addTodo({ text: 'today B' });
+  const list = await listTodos();
+  assert.deepEqual(list.map((t) => t.text), ['today A', 'today B', 'later thing'], 'soonest day first, then id order');
+});
+
+runOrSkip('todo: date tokens resolve; a bad token stays part of the text', async () => {
+  assert.equal(resolveDateToken('2026-07-20'), '2026-07-20');
+  assert.equal(resolveDateToken('today'), channelDate());
+  assert.equal(resolveDateToken('groceries'), null, 'non-date token → null (kept as text)');
+  // An invalid date passed straight to addTodo falls back to today, never stored raw.
+  assert.equal((await addTodo({ text: 'x', date: 'nope' })).todo.date, channelDate());
+});
+
+runOrSkip('todo: validation rejects empty and over-long', async () => {
+  assert.equal((await addTodo({ text: '   ' })).reason, 'empty');
+  assert.equal((await addTodo({ text: 'x'.repeat(201) })).reason, 'too-long');
+});
+
+runOrSkip('todo: remove clears an item; a missing id reports not-found', async () => {
+  const a = await addTodo({ text: 'to be removed' });
+  assert.equal((await removeTodo(a.id)).ok, true, 'removed');
+  assert.equal((await listTodos()).length, 0, 'board empty');
+  assert.equal((await removeTodo(a.id)).reason, 'not-found', 'already gone');
+  assert.equal((await removeTodo(999)).reason, 'not-found');
+});


### PR DESCRIPTION
Adds a mod-only **`!todo`** command that manages a public, date-organized to-do board. Control is entirely chat-driven; the website page is read-only.

## Command (mod / broadcaster only)
- `!todo add <text>` — dated to today (channel timezone)
- `!todo add 2026-07-20 <text>` — or `today` / `tomorrow` as the date word
- `!todo remove <#>` — cross an item off by its number
- `!todo` / `!todo list` — echo the board in chat

The whole command is `mod: true`, so the dispatcher silently ignores non-mods.

## Data & safety
- Items live at `todos/<id>` (short numeric ids from an atomic counter).
- New RTDB rule: `"todos": { ".read": true, ".write": false }` — public-read (the site renders it), Admin-write only. Clients can never write it. Added to the write-rejection sweep in `firebase-rules.test.js`.

## Tests
- New `test/todo.test.js`: add (default + explicit date), date-token parsing, list ordering, remove, validation. **27/27 emulator tests pass.**
- Fixed a latent race: `node --test` runs test files concurrently against the one shared emulator DB, and the new file collided with `market.test.js` on the `counters/` wipe → the emulator suite now runs with `--test-concurrency=1`.

Verified end-to-end by driving the real command against the emulator (default-today, `tomorrow`, explicit date, list, remove, not-found, usage errors).

## Companion
Website PR adds the `/todo/` page (grouped by day, "Copy for Discord" Markdown button) — intentionally unlinked from the home page / footer (direct-URL only).

## Deploy note
On merge: `firebase deploy --only database` (new `todos` read rule) + redeploy the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
