### PR TITLE
Unify curated + submitted facts in one shared Firebase source

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import { buildAuth } from './src/twitch/auth.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
+import { seedCuratedFacts } from './src/db/facts.js';
 import { createMessageHandler } from './src/events/chat.js';
 import { attachTwitchEvents } from './src/events/twitchEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
@@ -128,6 +129,16 @@ async function main() {
     }),
   );
   shutdownHooks.push(() => releaseLock({ instanceId }));
+
+  // ── Seed the curated fun facts (idempotent upsert) so `!fact` and the /info/
+  //    page read ONE source. Lease-gated (only the active instance seeds) and
+  //    non-fatal — a seed hiccup must never block the bot from coming up. ──
+  try {
+    const seeded = await seedCuratedFacts();
+    logger.info('curated facts seeded', seeded);
+  } catch (err) {
+    logger.warn('curated fact seed failed (non-fatal)', { err: String(err) });
+  }
 
   // ── Twitch auth (persisted refresh token) ──
   const tokenStore = new TokenStore(process.env.TOKEN_STORE_DIR || './.tokens');

--- a/src/content/facts.js
+++ b/src/content/facts.js
@@ -1,0 +1,19 @@
+// Curated "Nikki Fun Facts" — the canonical inside-joke set and the SINGLE source
+// of truth for the curated facts. On boot the bot upserts these into Firebase
+// `facts/` (see seedCuratedFacts in ../db/facts.js), where BOTH `!fact` and the
+// /info/ page read them alongside viewer-submitted facts. The website's
+// _data/facts.yml is only an offline snapshot/fallback — keep it in sync with this.
+export const CURATED_FACTS = [
+  "🎂 Freshly harvested every June 14th — and, for the record, a perpetual 25.",
+  "Ghost, her mini Pomeranian, is the actual star of the channel. Nikki just works here. 🐾",
+  "Her heart belongs to fictional men: Link, Leon Kennedy, and a rotating roster of anime boyfriends. 3D men could never. 💘",
+  "Wayne the delivery robot is the one that got away. She's still not over it. 🤖💔",
+  "Yes, she has a foot phone. Yes, it is a phone shaped like a foot. No further questions. 📞🦶",
+  "Certified WoW Horde raider — Mythic+ is her cardio. Would uninstall before she'd roll Alliance. Who even plays Alliance? For the Horde, bby. 💀",
+  "Her subscribers are Sith Lords. She's a clumsy ninja with Vader style. It all checks out.",
+  "A real-deal LA actress — turns up on How I Met Your Mother, Workaholics, and in films with Bruce Willis.",
+  "Raised by a Nintendo 64. Ocarina of Time and Majora's Mask did most of the parenting.",
+  "Space-obsessed science geek, anime nerd, ex-NCAA golfer, and RC-car menace. The range is genuinely unhinged.",
+  "Runs on horror and stealth in equal measure — Resident Evil screams and Metal Gear sneaking (and yes, more Leon).",
+  "Will cosplay Harley Quinn at the faintest provocation.",
+];

--- a/src/db/facts.js
+++ b/src/db/facts.js
@@ -5,9 +5,37 @@
 // — client-READ-ONLY — which the website renders. All writes are Admin-SDK only.
 
 import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
+import { CURATED_FACTS } from '../content/facts.js';
 
 const MIN_LEN = 3;
 const MAX_LEN = 200;
+
+// Stable key for a curated fact by its 1-based position (curated-01, curated-02…).
+// Fixed keys make the seed an idempotent UPSERT — re-running never duplicates.
+const curatedKey = (i) => `curated-${String(i + 1).padStart(2, '0')}`;
+
+/**
+ * Upsert the curated fun facts (../content/facts.js) into `facts/` so `!fact` and
+ * the /info/ page share ONE source. Idempotent: fixed keys overwrite in place, and
+ * curated-* keys beyond the current list are pruned (so the list can shrink). Runs
+ * on every boot. Curated facts carry `source:'curated'` + an `order` (stable
+ * display) and have no `by` attribution.
+ * @returns {Promise<{count:number}>}
+ */
+export async function seedCuratedFacts() {
+  const ref = database().ref(PATHS.facts());
+  const existing = (await ref.get()).val() || {};
+  const updates = {};
+  CURATED_FACTS.forEach((text, i) => {
+    updates[curatedKey(i)] = { text, source: 'curated', order: i + 1 };
+  });
+  // Prune orphaned curated-* entries if the canonical list got shorter.
+  for (const key of Object.keys(existing)) {
+    if (key.startsWith('curated-') && !(key in updates)) updates[key] = null;
+  }
+  await ref.update(updates);
+  return { count: CURATED_FACTS.length };
+}
 
 /** Normalize submitted text: collapse whitespace, trim. */
 export function cleanFactText(raw) {

--- a/test/market.test.js
+++ b/test/market.test.js
@@ -7,7 +7,8 @@ import { test, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
 import { ensureWallet, claimDaily, getBalance, credit } from '../src/db/wallet.js';
-import { suggestFact, listPendingFacts, approveFact, rejectFact, randomApprovedFact } from '../src/db/facts.js';
+import { suggestFact, listPendingFacts, approveFact, rejectFact, randomApprovedFact, seedCuratedFacts } from '../src/db/facts.js';
+import { CURATED_FACTS } from '../src/content/facts.js';
 import { openMarket, placeBet, closeMarket, resolveMarket, cancelMarket, getMarket, listOpenMarkets } from '../src/db/market.js';
 import { suggestMarket, listPendingMarketSuggestions, approveMarketSuggestion, rejectMarketSuggestion } from '../src/db/market.js';
 import { config } from '../src/config.js';
@@ -40,6 +41,26 @@ runOrSkip('facts: suggest → moderate → publish', async () => {
   await rejectFact(2);
   assert.equal((await listPendingFacts()).length, 0, 'queue clears');
   assert.equal((await randomApprovedFact()).text, 'nikki is okra');
+});
+
+runOrSkip('facts: curated seed is idempotent and !fact pulls it (shared source)', async () => {
+  const r = await seedCuratedFacts();
+  assert.equal(r.count, CURATED_FACTS.length, 'seeds the whole curated list');
+
+  await seedCuratedFacts(); // re-run must not duplicate (fixed keys)
+  const all = (await database().ref('facts').get()).val() || {};
+  assert.equal(Object.keys(all).length, CURATED_FACTS.length, 'no duplication on re-seed');
+  assert.ok(Object.values(all).every((f) => f.source === 'curated' && f.text), 'all curated, all have text');
+
+  // !fact returns a curated fact even with ZERO viewer submissions — the split is gone.
+  const f = await randomApprovedFact();
+  assert.ok(f && f.text, 'a random fact is available from the seed alone');
+
+  // Curated + a later approved submission coexist under facts/.
+  await suggestFact({ userId: 'z', displayName: 'Zed', text: 'a brand new submitted fact' });
+  await approveFact(1);
+  const merged = (await database().ref('facts').get()).val() || {};
+  assert.equal(Object.keys(merged).length, CURATED_FACTS.length + 1, 'submission adds alongside curated');
 });
 
 runOrSkip('wallet: grubstake, daily, cooldown', async () => {


### PR DESCRIPTION
`!fact` could only ever return **viewer-submitted** facts (Firebase `facts/`). The 12 **curated** fun facts lived only in the website source (`_data/facts.yml`), baked in at build time, so the bot couldn't see them. This unifies both into one shared source.

## Approach — single source of truth in Firebase
- New `src/content/facts.js` — the **canonical** curated list.
- `seedCuratedFacts()` upserts it into `facts/` on boot: **idempotent** (fixed `curated-NN` keys, so re-running never duplicates; prunes orphans if the list shrinks), **lease-gated** (only the active instance seeds), and **non-fatal** (a seed hiccup never blocks startup).
- `!fact` needs **no change** — it already reads `facts/`, which now holds curated + submitted facts. The split is gone.
- Curated entries carry `source: 'curated'` + an `order`; submissions keep their `by`. The site uses those to render curated first, then newest submissions.

## Verification
- **28/28 emulator tests** (new test: seed count, idempotent re-seed, `!fact` pulls from the seed alone, curated + a later approved submission coexist).
- Drove it on real emulator data: 12 curated (in order) → 2 submissions (newest first), 14 total, no duplication.

## Companion
Website PR renders the unified list on `/info/` (curated fallback baked in for offline).

## Deploy note
Just **redeploy the bot** — the seed runs on boot and populates prod `facts/`. No manual DB step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
