### PR TITLE
Rename loot claim !grab → !loot (alias !claim) to avoid bot collisions

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ async function main() {
       if (activated) {
         const secs = Math.round(config.loot.windowMs / 1000);
         out
-          .say(channel, `⏭️ Next up — a ${activated.rarity} ${activated.name} is open! !grab within ${secs}s to enter the draw.`)
+          .say(channel, `⏭️ Next up — a ${activated.rarity} ${activated.name} is open! !loot within ${secs}s to enter the draw.`)
           .catch(() => {});
       }
     } catch (err) {

--- a/src/commands/bag.js
+++ b/src/commands/bag.js
@@ -15,7 +15,7 @@ export default {
     }
     const inventory = Array.isArray(player.inventory) ? player.inventory : [];
     if (inventory.length === 0) {
-      reply(`@${user.displayName} your bag is empty. !grab drops while live to fill it.`);
+      reply(`@${user.displayName} your bag is empty. !loot drops while live to fill it.`);
       return;
     }
     const names = inventory

--- a/src/commands/loot.js
+++ b/src/commands/loot.js
@@ -1,16 +1,20 @@
-// !grab / !loot — enter the active drop's LOTTERY (spec §5.2). Every grab within
+// !loot / !claim — enter the active drop's LOTTERY (spec §5.2). Every claim within
 // the window enters you exactly once; when the window closes a single winner is
 // drawn and gets the single item, so a drop never mints duplicates. You need a
 // character to enter (loot has to land somewhere).
+//
+// NOTE: this used to be `!grab`, but that trigger collides with the quote/points
+// bots common in Twitch chat (they answer !grab too), so the primary is now !loot
+// (alias !claim) — kennyBot no longer listens on !grab.
 import { getPlayer } from '../db/players.js';
 import { enterDrop } from '../db/drops.js';
 
 export default {
-  names: ['grab', 'loot'],
+  names: ['loot', 'claim'],
   mod: false,
   subOnly: true, // subscriber-only loot claims (owner decision)
   cooldownMs: 2_000,
-  help: '!grab — enter the drawing for the active loot drop',
+  help: '!loot — enter the drawing for the active loot drop (alias: !claim)',
   async run({ user, reply }) {
     const player = await getPlayer(user.id);
     if (!player) {

--- a/src/commands/mod/drop.js
+++ b/src/commands/mod/drop.js
@@ -28,7 +28,7 @@ export default {
 
     const drop = await setDrop(itemId);
     const secs = Math.round(config.loot.windowMs / 1000);
-    if (drop.status === 'open') reply(`A ${drop.rarity} ${drop.name} dropped! Type !grab within ${secs}s to enter the draw.`);
+    if (drop.status === 'open') reply(`A ${drop.rarity} ${drop.name} dropped! Type !loot within ${secs}s to enter the draw.`);
     else if (drop.status === 'queued') reply(`A ${drop.rarity} ${drop.name} is queued (#${drop.position}) — it opens when the current drop closes.`);
     else reply(`Drop queue is full (max ${config.loot.maxQueue}); ${drop.name} was skipped — try again once some resolve.`);
   },

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -6,7 +6,7 @@ import char from './char.js';
 import bag from './bag.js';
 import equip from './equip.js';
 import unequip from './unequip.js';
-import grab from './grab.js';
+import loot from './loot.js';
 import raid from './raid.js';
 import top from './top.js';
 import fact from './fact.js';
@@ -24,7 +24,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market, todo];
+const defs = [create, char, bag, equip, unequip, loot, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market, todo];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/config.js
+++ b/src/config.js
@@ -72,7 +72,7 @@ export const config = {
     // BOSS-battle rewards roll on a HIGHER-rarity table (clearing a raid should
     // feel better than a chat drop — owner request).
     bossRarityWeights: { common: 18, uncommon: 34, rare: 28, epic: 14, legendary: 6 },
-    // Claim is a LOTTERY over a window (spec §5.2): every !grab in the window
+    // Claim is a LOTTERY over a window (spec §5.2): every !loot in the window
     // ENTERS the viewer; at window close ONE winner is drawn for the ONE item, so
     // a drop never mints duplicates. TIER-FAIR — every entrant has equal odds in
     // the draw (sub tier gives no loot edge; owner decision).

--- a/src/db/drops.js
+++ b/src/db/drops.js
@@ -1,5 +1,5 @@
 // Active loot-drop persistence (spec §5.2). A drop is a LOTTERY over a claim
-// WINDOW: every !grab within the window ENTERS the viewer; when the window closes
+// WINDOW: every !loot within the window ENTERS the viewer; when the window closes
 // a single winner is drawn and gets the single item — so a drop never mints
 // duplicates no matter how many people grab.
 //

--- a/src/events/dropScheduler.js
+++ b/src/events/dropScheduler.js
@@ -37,7 +37,7 @@ export function startDropScheduler({ chat, channel, logger }) {
           const drop = await setDrop(itemId);
           const secs = Math.round(config.loot.windowMs / 1000);
           if (drop.status === 'open') {
-            chat.say(channel, `🎁 A ${drop.rarity} ${drop.name} dropped! Type !grab within ${secs}s to enter the draw — one winner!`).catch(() => {});
+            chat.say(channel, `🎁 A ${drop.rarity} ${drop.name} dropped! Type !loot within ${secs}s to enter the draw — one winner!`).catch(() => {});
           } else if (drop.status === 'queued') {
             chat.say(channel, `🎁 A ${drop.rarity} ${drop.name} is queued (#${drop.position}) — opens when the current drop closes.`).catch(() => {});
           }

--- a/src/events/twitchEvents.js
+++ b/src/events/twitchEvents.js
@@ -34,7 +34,7 @@ function lootTable() {
 export function attachTwitchEvents({ chat, channel, logger }) {
   const listeners = [];
   // Outbound mute (`!mute`): these communal-drop announcements are suppressed
-  // while muted, but the drop itself is still created so !grab keeps working.
+  // while muted, but the drop itself is still created so !loot keeps working.
   const say = (text) => { if (!isChatMuted()) chat.say(channel, text).catch(() => {}); };
 
   const onSubLike = (label) => async (_ch, _user, info, msg) => {
@@ -69,8 +69,8 @@ export function attachTwitchEvents({ chat, channel, logger }) {
       const lead = `Raid incoming (${raidInfo?.viewerCount ?? '?'})!`;
       const line =
         drop.status === 'open'
-          ? `${lead} A ${drop.rarity} ${drop.name} dropped — !grab to enter the draw!`
-          : `${lead} A ${drop.rarity} ${drop.name} is queued up — !grab when it opens!`;
+          ? `${lead} A ${drop.rarity} ${drop.name} dropped — !loot to enter the draw!`
+          : `${lead} A ${drop.rarity} ${drop.name} is queued up — !loot when it opens!`;
       say(line);
     } catch (err) {
       logger.error('raid handler failed', { err: String(err) });
@@ -91,8 +91,8 @@ export function attachTwitchEvents({ chat, channel, logger }) {
       if (drop.status === 'full') return;
       const line =
         drop.status === 'open'
-          ? `${bits} bits! A ${drop.rarity} ${drop.name} dropped — !grab to enter the draw!`
-          : `${bits} bits! A ${drop.rarity} ${drop.name} is queued — !grab when it opens!`;
+          ? `${bits} bits! A ${drop.rarity} ${drop.name} dropped — !loot to enter the draw!`
+          : `${bits} bits! A ${drop.rarity} ${drop.name} is queued — !loot when it opens!`;
       say(line);
     } catch (err) {
       logger.error('cheer handler failed', { err: String(err) });

--- a/src/rules/loot.js
+++ b/src/rules/loot.js
@@ -60,7 +60,7 @@ export function pickDrop(lootTable, getItem, rng, config, weights) {
 
 /**
  * Draw exactly ONE winner uniformly from a drop's entrants (spec §5.2). The claim
- * window is a LOTTERY, not per-user rolls: everyone who !grabs in the window is
+ * window is a LOTTERY, not per-user rolls: everyone who !loots in the window is
  * entered, then a single winner takes the single item — so a drop never mints
  * duplicates no matter how many people grab. Pure + RNG-injected for testing.
  * @param {Record<string, unknown>} entries  map of entrant userId → entry


### PR DESCRIPTION
## The report
`!grab` after a drop didn't enter the viewer — kennyBot replied *"there's nothing to grab right now"* and a **foreign** "no items available" line also appeared.

## What I found
- The **drops/lottery engine is correct.** I drove the full production sequence against the emulator — mod drops → 10s draw timer ticks → `!grab` enters → window closes → winner drawn → next drop → grab again — and every grab entered correctly across repeat cycles, no stuck state.
- **"no items is available" is not a string kennyBot ever sends.** `!grab` is one of the most contested triggers on Twitch — quote grabbers / points bots on Nightbot/StreamElements answer it too. That second bot produced the "no items available" line; kennyBot's own *"nothing to grab"* just meant no drop was active at that instant.

## The fix (per owner: rename the trigger)
- kennyBot **no longer listens on `!grab`** — the loot claim is now **`!loot`** (primary) + **`!claim`** (alias), so the other bot can own `!grab` without colliding.
- Every drop announcement now says **`!loot`**: mod `!drop`, the auto-scheduler, the raid-in / cheer communal drops, and the "next up" promote line. Empty-`!bag` hint updated too.
- `src/commands/grab.js` → `loot.js`. **Behavior is unchanged** — still sub-only, same 60s lottery.

## Verified
27/27 emulator tests; site builds with `!grab` gone from `/commands/` and `/how-to-play/` (companion website PR).

## Note on "nothing to grab"
That reply is correct when no drop is live — it means the 60s window had closed or none was open (a mod `!drop`, or `!drops on` while live, opens one). If 60s feels too short for chat to react, say the word and I'll bump `loot.windowMs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
