### PR TITLE
Add !duel — head-to-head credit wager settled by a coin flip

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",
     "dev:all": "bash scripts/dev-all.sh"

--- a/src/commands/duel.js
+++ b/src/commands/duel.js
@@ -1,0 +1,73 @@
+// !duel — challenge another viewer to a credit wager, settled by a fair coin flip.
+//   !duel <@user> <amount>  — throw down the gauntlet
+//   !duel accept            — take the challenge waiting on you (both sides staked)
+//   !duel deny              — decline it
+//   !duel                   — show the challenge waiting on you (if any)
+// Open to everyone (credits, not the sub-only raid game). Winner takes the whole
+// pot; credits are only moved between the two duelists — never minted.
+import { challenge, accept, deny, getPendingFor, cleanLogin, DUEL_TTL_MS } from '../db/duel.js';
+import { config } from '../config.js';
+
+const n = (v) => (v || 0).toLocaleString('en-US');
+const ttlMin = Math.round(DUEL_TTL_MS / 60_000);
+
+export default {
+  names: ['duel'],
+  mod: false,
+  cooldownMs: 3_000,
+  help: '!duel <@user> <amount> — wager credits on a coin-flip duel · !duel accept | deny',
+  async run({ user, args, reply }) {
+    const sub = (args[0] || '').toLowerCase();
+
+    // ── accept ──
+    if (sub === 'accept' || sub === 'yes') {
+      const res = await accept({ toId: user.id, toLogin: user.login, toName: user.displayName });
+      if (!res.ok) {
+        if (res.reason === 'none') reply(`@${user.displayName} you have no duel to accept right now.`);
+        else if (res.reason === 'challenger-broke') reply(`@${user.displayName} ${res.fromName} can't cover that wager anymore — duel's off.`);
+        else if (res.reason === 'insufficient') reply(`@${user.displayName} you don't have enough credits for that wager (balance: ${n(res.balance)}).`);
+        else reply(`@${user.displayName} couldn't start the duel — try again.`);
+        return;
+      }
+      reply(`⚔️ ${res.winnerName} beat ${res.loserName} in a duel and takes the ${n(res.pot)}-credit pot! 💰 (balance: ${n(res.winnerBalance)})`);
+      return;
+    }
+
+    // ── deny ──
+    if (sub === 'deny' || sub === 'decline' || sub === 'no') {
+      const res = await deny({ toLogin: user.login });
+      reply(res.ok
+        ? `🏳️ @${user.displayName} declined ${res.fromName}'s duel. Another time.`
+        : `@${user.displayName} you have no duel to decline.`);
+      return;
+    }
+
+    // ── no args → show any challenge waiting on you ──
+    if (!sub) {
+      const pending = await getPendingFor(user.login);
+      reply(pending
+        ? `@${user.displayName} ${pending.fromName} has challenged you to a ${n(pending.amount)}-credit duel — !duel accept or !duel deny.`
+        : `@${user.displayName} usage: !duel <@user> <amount> to challenge someone to a credit duel.`);
+      return;
+    }
+
+    // ── otherwise: challenge — !duel <@user> <amount> ──
+    const targetDisplay = String(args[0]).replace(/^@+/, '');
+    const res = await challenge({
+      fromId: user.id, fromLogin: user.login, fromName: user.displayName,
+      toRaw: args[0], amount: args[1],
+    });
+    if (!res.ok) {
+      switch (res.reason) {
+        case 'need-target': reply(`@${user.displayName} who are you challenging? !duel <@user> <amount>`); break;
+        case 'self': reply(`@${user.displayName} you can't duel yourself. 🪞`); break;
+        case 'bad-amount': reply(`@${user.displayName} wager a whole number of credits (min ${n(res.min)}). !duel <@user> <amount>`); break;
+        case 'insufficient': reply(`@${user.displayName} you don't have that many credits (balance: ${n(res.balance)}).`); break;
+        case 'target-busy': reply(`@${user.displayName} ${cleanLogin(args[0])} already has a duel pending (from ${res.challenger}). Wait for it to settle.`); break;
+        default: reply(`@${user.displayName} couldn't set up that duel.`);
+      }
+      return;
+    }
+    reply(`⚔️ @${targetDisplay}, ${user.displayName} challenges you to a ${n(res.amount)}-credit duel! Type "!duel accept" to throw down or "!duel deny" to bow out. (expires in ${ttlMin} min)`);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -14,6 +14,7 @@ import kennycommands from './kennycommands.js';
 import points from './points.js';
 import daily from './daily.js';
 import bet from './bet.js';
+import duel from './duel.js';
 import market from './mod/market.js';
 import todo from './mod/todo.js';
 import exp from './mod/exp.js';
@@ -24,7 +25,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, exp, mute, drop, drops, boss, raidnight, season, market, todo];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, exp, mute, drop, drops, boss, raidnight, season, market, todo];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/db/duel.js
+++ b/src/db/duel.js
@@ -1,0 +1,132 @@
+// DUELS — head-to-head credit wagers between viewers. A challenger stakes an
+// amount against a target; the target accepts or denies. On accept BOTH sides are
+// debited into a pot and a fair 50/50 coin flip picks the winner, who takes the
+// whole pot — so credits are conserved, never minted (same stance as the market).
+// Bot-owned (Admin SDK only). Pending challenges are keyed by the TARGET's login
+// so the target can accept/deny with just `!duel accept`; they expire after
+// DUEL_TTL_MS and are cleared on resolve/deny. No history is kept.
+
+import { database, PATHS } from './firebase.js';
+import { ensureWallet, debit, credit, getBalance } from './wallet.js';
+import { config } from '../config.js';
+
+// How long a challenge stays open before it's treated as expired (lazy — checked
+// on read/accept, never a timer). Keeps stale challenges from lingering forever.
+export const DUEL_TTL_MS = 3 * 60 * 1000;
+
+const minBet = () => config.economy.minBet || 1;
+
+/** Normalize a target token ("@Bob", "bob") to a bare lowercase login. */
+export function cleanLogin(raw) {
+  return String(raw || '').trim().replace(/^@+/, '').toLowerCase();
+}
+
+/** A pending challenge is stale once older than the TTL. */
+function isExpired(duel, now) {
+  return !duel || now - (duel.at || 0) >= DUEL_TTL_MS;
+}
+
+/**
+ * Issue a challenge: `<from>` wagers `amount` against `<toLogin>`. Validates the
+ * challenger can currently cover it (no escrow — both sides are debited only on
+ * accept). Fails if the target already has a live challenge pending.
+ * @returns {Promise<{ok:true,toLogin:string,amount:number}|{ok:false,reason:string,[k:string]:any}>}
+ */
+export async function challenge({ fromId, fromLogin, fromName, toRaw, amount }) {
+  const toLogin = cleanLogin(toRaw);
+  if (!toLogin) return { ok: false, reason: 'need-target' };
+  if (toLogin === cleanLogin(fromLogin)) return { ok: false, reason: 'self' };
+
+  const amt = Math.floor(Number(amount));
+  if (!Number.isFinite(amt) || amt < minBet()) return { ok: false, reason: 'bad-amount', min: minBet() };
+
+  // Challenger must currently have the funds (final check is at accept time).
+  const wallet = await ensureWallet({ userId: fromId, login: fromLogin, displayName: fromName });
+  if ((wallet.balance || 0) < amt) return { ok: false, reason: 'insufficient', balance: wallet.balance || 0 };
+
+  const now = Date.now();
+  const ref = database().ref(PATHS.duelPending(toLogin));
+  const existing = (await ref.get()).val();
+  if (!isExpired(existing, now)) {
+    return { ok: false, reason: 'target-busy', challenger: existing.fromName };
+  }
+
+  await ref.set({ fromId: String(fromId), fromLogin: cleanLogin(fromLogin), fromName: fromName || fromLogin, toLogin, amount: amt, at: now });
+  return { ok: true, toLogin, amount: amt };
+}
+
+/** The live challenge awaiting `toLogin`, or null (also null if expired). */
+export async function getPendingFor(toLogin) {
+  const login = cleanLogin(toLogin);
+  const duel = (await database().ref(PATHS.duelPending(login)).get()).val();
+  return isExpired(duel, Date.now()) ? null : duel;
+}
+
+/**
+ * Accept the challenge awaiting `toLogin`: atomically claim it, debit both sides
+ * into a pot, flip a fair coin, and pay the whole pot to the winner. Refunds the
+ * challenger if the accepter can't cover the stake.
+ * @returns {Promise<{ok:true,...}|{ok:false,reason:string,[k:string]:any}>}
+ */
+export async function accept({ toId, toLogin, toName, rng = Math.random }) {
+  const login = cleanLogin(toLogin);
+  const ref = database().ref(PATHS.duelPending(login));
+  const now = Date.now();
+
+  // Atomic claim so a double-accept can't pay out twice.
+  let claimed = null;
+  const res = await ref.transaction((c) => {
+    if (c === null) return null; // empty cache → refetch (or truly absent → abort as no-op)
+    if (isExpired(c, now)) return null; // stale → delete
+    if (c.claimed) return; // already being settled → abort
+    claimed = c;
+    return { ...c, claimed: true };
+  });
+  if (!res.committed || !claimed) return { ok: false, reason: 'none' };
+
+  const { fromId, fromName, fromLogin, amount } = claimed;
+  const toDisplay = toName || login;
+
+  // Both sides stake into the pot. Debit challenger first; if that fails the
+  // challenge is void. Debit accepter next; if THAT fails, refund the challenger.
+  await ensureWallet({ userId: fromId, login: fromLogin, displayName: fromName });
+  await ensureWallet({ userId: toId, login, displayName: toDisplay });
+
+  const dFrom = await debit(fromId, amount);
+  if (!dFrom.ok) {
+    await ref.remove();
+    return { ok: false, reason: 'challenger-broke', fromName };
+  }
+  const dTo = await debit(toId, amount);
+  if (!dTo.ok) {
+    await credit(fromId, amount, { login: fromLogin, displayName: fromName }); // undo the challenger's stake
+    await ref.remove();
+    return { ok: false, reason: 'insufficient', balance: dTo.balance || 0 };
+  }
+
+  const pot = amount * 2;
+  const challengerWins = rng() < 0.5;
+  const winnerId = challengerWins ? fromId : toId;
+  const winnerName = challengerWins ? fromName : toDisplay;
+  const loserName = challengerWins ? toDisplay : fromName;
+  const winnerLogin = challengerWins ? fromLogin : login;
+
+  await credit(winnerId, pot, { login: winnerLogin, displayName: winnerName });
+  await ref.remove();
+
+  const winnerBalance = await getBalance(winnerId);
+  return { ok: true, winnerId, winnerName, loserName, fromName, toName: toDisplay, amount, pot, winnerBalance };
+}
+
+/** Decline the challenge awaiting `toLogin`. */
+export async function deny({ toLogin }) {
+  const login = cleanLogin(toLogin);
+  const ref = database().ref(PATHS.duelPending(login));
+  const duel = (await ref.get()).val();
+  if (isExpired(duel, Date.now())) {
+    if (duel) await ref.remove(); // tidy up an expired one
+    return { ok: false, reason: 'none' };
+  }
+  await ref.remove();
+  return { ok: true, fromName: duel.fromName };
+}

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -113,6 +113,12 @@ export const PATHS = {
   marketSuggestions: () => 'marketSuggestions',
   marketSuggestion: (id) => `marketSuggestions/${id}`,
   marketSuggestionCounter: () => 'counters/marketSug',
+  // DUELS: transient PvP credit wagers. A pending challenge is keyed by the
+  // TARGET's login (so the target accepts/denies with just `!duel accept`), and
+  // is Admin-only (default-deny — the site never reads it). Cleared on
+  // resolve/deny/expiry; no history kept.
+  duelsPending: () => 'duels/pending',
+  duelPending: (toLogin) => `duels/pending/${toLogin}`,
   botToken: () => 'config/secrets/botToken',
   items: () => 'items',
   dropActive: () => 'drops/active',

--- a/test/duel.test.js
+++ b/test/duel.test.js
@@ -1,0 +1,102 @@
+// Behavioral tests for DUELS: challenge → accept/deny, the coin-flip payout
+// (pot conserved, winner takes all), and the guards (self, bad amount, broke
+// challenger/accepter with refund, target-busy, expiry, double-accept). Run via
+// `npm run test:emulator` (skipped without the emulator host).
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase, PATHS } from '../src/db/firebase.js';
+import { ensureWallet, getBalance, debit } from '../src/db/wallet.js';
+import { challenge, accept, deny, getPendingFor, DUEL_TTL_MS } from '../src/db/duel.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+async function wipe() {
+  await Promise.all(['duels', 'wallets', 'counters'].map((p) => database().ref(p).remove().catch(() => {})));
+}
+
+before(async () => { if (host) initFirebase(); });
+after(async () => { if (host) { await wipe(); await closeFirebase(); } });
+beforeEach(async () => { if (host) await wipe(); });
+
+const seed = async (id, name) => ensureWallet({ userId: id, login: name.toLowerCase(), displayName: name });
+
+runOrSkip('duel: accept pays the whole pot to the winner and conserves credits', async () => {
+  await seed('A', 'Alice'); // 500
+  await seed('B', 'Bob'); // 500
+
+  const c = await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@Bob', amount: 100 });
+  assert.deepEqual([c.ok, c.toLogin, c.amount], [true, 'bob', 100]);
+
+  // rng < 0.5 → challenger (Alice) wins.
+  const r = await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0 });
+  assert.deepEqual([r.ok, r.winnerName, r.pot], [true, 'Alice', 200]);
+  assert.equal(await getBalance('A'), 600, 'winner: 500 - 100 stake + 200 pot');
+  assert.equal(await getBalance('B'), 400, 'loser: 500 - 100');
+  assert.equal(await getPendingFor('bob'), null, 'challenge cleared');
+});
+
+runOrSkip('duel: the coin flip can pick the target too', async () => {
+  await seed('A', 'Alice');
+  await seed('B', 'Bob');
+  await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: 'bob', amount: 100 });
+  const r = await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0.9 }); // target wins
+  assert.equal(r.winnerName, 'Bob');
+  assert.deepEqual([await getBalance('A'), await getBalance('B')], [400, 600]);
+});
+
+runOrSkip('duel: deny cancels with no credits moved', async () => {
+  await seed('A', 'Alice');
+  await seed('B', 'Bob');
+  await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 250 });
+  const d = await deny({ toLogin: 'bob' });
+  assert.deepEqual([d.ok, d.fromName], [true, 'Alice']);
+  assert.equal(await getPendingFor('bob'), null);
+  assert.deepEqual([await getBalance('A'), await getBalance('B')], [500, 500], 'nothing staked');
+  assert.equal((await deny({ toLogin: 'bob' })).reason, 'none', 'nothing left to deny');
+});
+
+runOrSkip('duel: challenge guards (self, bad amount, insufficient, target-busy)', async () => {
+  await seed('A', 'Alice');
+  assert.equal((await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@alice', amount: 10 })).reason, 'self');
+  assert.equal((await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 0 })).reason, 'bad-amount');
+  assert.equal((await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 'lots' })).reason, 'bad-amount');
+  assert.equal((await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 99999 })).reason, 'insufficient');
+
+  assert.equal((await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 100 })).ok, true);
+  const busy = await challenge({ fromId: 'C', fromLogin: 'carol', fromName: 'Carol', toRaw: '@bob', amount: 50 });
+  assert.deepEqual([busy.reason, busy.challenger], ['target-busy', 'Alice'], 'one pending challenge per target');
+});
+
+runOrSkip('duel: accepter who cannot cover the wager → challenger refunded, no pot', async () => {
+  await seed('A', 'Alice'); // 500
+  await seed('B', 'Bob');
+  await debit('B', 450); // Bob down to 50
+  await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 100 });
+
+  const r = await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0 });
+  assert.deepEqual([r.ok, r.reason], [false, 'insufficient']);
+  assert.equal(await getBalance('A'), 500, 'challenger fully refunded (net zero)');
+  assert.equal(await getBalance('B'), 50, 'accepter untouched');
+  assert.equal(await getPendingFor('bob'), null, 'dead challenge cleared');
+});
+
+runOrSkip('duel: expired challenge cannot be accepted', async () => {
+  await seed('A', 'Alice');
+  await seed('B', 'Bob');
+  await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 100 });
+  // Age the challenge past the TTL.
+  await database().ref(PATHS.duelPending('bob')).child('at').set(Date.now() - DUEL_TTL_MS - 1);
+  assert.equal(await getPendingFor('bob'), null, 'reads as expired');
+  assert.equal((await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0 })).reason, 'none');
+  assert.deepEqual([await getBalance('A'), await getBalance('B')], [500, 500], 'no credits moved');
+});
+
+runOrSkip('duel: a second accept after settlement pays nothing (no double payout)', async () => {
+  await seed('A', 'Alice');
+  await seed('B', 'Bob');
+  await challenge({ fromId: 'A', fromLogin: 'alice', fromName: 'Alice', toRaw: '@bob', amount: 100 });
+  assert.equal((await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0 })).ok, true);
+  assert.equal((await accept({ toId: 'B', toLogin: 'bob', toName: 'Bob', rng: () => 0 })).reason, 'none', 'nothing left to accept');
+  assert.deepEqual([await getBalance('A'), await getBalance('B')], [600, 400], 'balances unchanged by the 2nd accept');
+});


### PR DESCRIPTION
Adds **`!duel`** — a head-to-head credit wager between viewers, settled by a fair coin flip.

## Commands (open to everyone — credits, not the sub-only raid game)
- `!duel <@user> <amount>` — challenge someone to a credit duel
- `!duel accept` — take the challenge waiting on you (needs no args — challenges are keyed to you)
- `!duel deny` — decline it
- `!duel` — show the challenge waiting on you, if any

## How it settles
On **accept**, both duelists are debited the wager into a pot, a fair **50/50** flip picks the winner, and the winner takes the **whole pot**. Credits only move between the two players — never minted (same conservation stance as the OKRAMARKET).

## Safety / edge cases (all tested)
- **Refund**: if the accepter can't cover the stake, the challenger's debit is rolled back — net zero, no pot.
- **Conservation**: winner +wager, loser −wager; pot = 2× wager.
- **Guards**: no self-duel, whole-number wager ≥ `minBet`, challenger must have the funds, one pending challenge per target (`target-busy`).
- **Expiry**: pending challenges lapse after **3 minutes** (lazy — checked on read/accept; no timer).
- **No double-pay**: accept atomically claims the challenge, so a double-accept settles once.

## Data
Pending challenges live at `duels/pending/<targetLogin>` — **Admin-only** (the site never reads them; default-deny, no rules change). Cleared on resolve/deny/expiry; no history kept.

## Verified
34/34 emulator tests (7 new duel tests) + drove the real command end-to-end (challenge → accept → payout, and deny). Companion website PR documents it on `/commands/`.

Deploy: redeploy the bot (no DB-rules change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
