### PR TITLE
Add end-to-end command tests; move CI + runtime to Node 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
       # The Firebase RTDB emulator (firebase-tools@15) requires JDK 21+.
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -30,12 +30,14 @@ jobs:
       - run: npm test
       # Firebase rules + client-write-rejection test against the emulator.
       - run: npm run test:emulator
+      # End-to-end: every command driven through the real dispatcher (emulator).
+      - run: npm run test:e2e
 
   docker:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # docker-container driver — required to attach the SBOM/provenance attestations below.
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,19 @@
 #
 # PRODUCTION: pin the base by digest so a rebuild is reproducible and a poisoned
 # upstream tag can't silently change your base, e.g.
-#   FROM node:20-bookworm-slim@sha256:<digest> AS build
+#   FROM node:22-bookworm-slim@sha256:<digest> AS build
 # Bump it deliberately. slim (glibc), NOT alpine — firebase-admin's gRPC native
 # bits make glibc the path of least resistance.
 
 # ---- build ----
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY . .
 
 # ---- runtime ----
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 ENV NODE_ENV=production
 ENV HEARTBEAT_FILE=/tmp/kennybot.heartbeat
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "node --watch index.js",
     "test": "node --test \"test/rules/**/*.test.js\"",
     "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js\"",
+    "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",
     "dev:all": "bash scripts/dev-all.sh"

--- a/scripts/dev-all.sh
+++ b/scripts/dev-all.sh
@@ -13,6 +13,10 @@
 #   npm run dev:all           # or:  bash scripts/dev-all.sh
 #   SITE_DIR=/path/to/site npm run dev:all      # if the website isn't at ~/git/nikkibreanne.github.io
 #
+# Or run the automated end-to-end command suite against a fresh emulator DB (no
+# website, no console) — a thorough regression check that every command still works:
+#   npm run dev:all -- test    # (or: bash scripts/dev-all.sh test)  ==  npm run test:e2e
+#
 set -uo pipefail
 
 BOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -24,6 +28,14 @@ PATH="$BOT_DIR/node_modules/.bin:$PATH"
 # Ensure bundler is reachable (user gem bin isn't always on PATH).
 if ! command -v bundle >/dev/null 2>&1; then
   for d in "$HOME/.local/share/gem/ruby/"*/bin; do [ -d "$d" ] && PATH="$d:$PATH"; done
+fi
+
+# ── E2E mode (`dev:all test`): run the automated command suite against a fresh
+#    emulator DB and exit — no website, no interactive console. ────────────────
+if [ "${1:-}" = "test" ] || [ "${1:-}" = "--e2e" ]; then
+  echo "▶ E2E: driving every command through the dispatcher against a fresh emulator DB…"
+  cd "$BOT_DIR"
+  exec firebase emulators:exec --only database --project okrafans "node --test test/e2e/commands.e2e.test.js"
 fi
 
 SITE_PID=""

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,64 @@
+# End-to-end command tests
+
+These tests drive **every chat command through the real dispatcher**
+(`src/events/chat.js`) against the Firebase emulator — the same path a live
+Twitch message takes: parsing → mod/sub/mute gates → `def.run` → DB writes. If a
+command breaks anywhere in that path, a test fails.
+
+## Run it
+
+```bash
+npm run test:e2e            # emulator + the suite, then exit
+npm run dev:all -- test     # same thing, via the dev harness
+```
+
+Requires the Firebase emulator deps (JDK 21+, `firebase-tools`), same as
+`npm run test:emulator`. CI runs it on every release tag.
+
+## Files
+
+- **`harness.js`** — the fake `chat` driver. `makeBot()` gives you `send(user, text)`
+  which runs one chat line through a real handler and returns the captured reply
+  text. `user(id, opts)` builds a chat user (flags: `mod`, `broadcaster`, `sub`).
+- **`scenarios.js`** — the `fixtures` (set up game state) and the `SCENARIOS` array
+  (one entry per command).
+- **`commands.e2e.test.js`** — the runner (`before`/`beforeEach` reset a clean
+  emulator slate) + the **coverage** test.
+
+## Adding a test when you add a command
+
+The registry↔test sync is **automated**: `commands.e2e.test.js` has a coverage
+test that reads `listCommands()` and fails if any command's primary name has no
+scenario. So you can't forget — a new command without a scenario breaks the build.
+
+To add one, append an entry to `SCENARIOS` in `scenarios.js`, keyed by your
+command's **primary** name (`def.names[0]`):
+
+```js
+{
+  command: 'mycmd',                       // must equal def.names[0]
+  title: 'does the thing',
+  run: async ({ bot, u, fx }) => {
+    const alice = u('e2e_mycmd', { login: 'alice', name: 'Alice' });
+    await fx.player(alice);               // set up any needed state via fixtures
+    const reply = await bot.send(alice, '!mycmd arg');
+    assert.match(reply, /expected reply/i);
+    // ...and/or assert on DB state via the db helpers.
+  },
+}
+```
+
+### Fixtures (`fx.*`)
+
+`player(u, class?)`, `loot(u, itemId)`, `wallet(u)`, `market(question?)` → id,
+`drop(itemId?)`, `facts()`, `leaderboard(u, damage)`, `raidWeek({ bossName?, enlistUsers? })`.
+Add more as new commands need new state — keep them in `scenarios.js`.
+
+### Notes
+
+- A **fresh handler is built per `send`**, so the per-user/per-command cooldown
+  never trips across a multi-step scenario (e.g. a trade's open→counter→accept).
+- `beforeEach` resets config to a clean slate (season `e2e`, passive EXP off, not
+  muted, no active raid) and waits for the async config mirror to settle.
+- Mod-only commands need `{ mod: true }` on the user; sub-only commands need
+  `{ sub: true }` (the default).

--- a/test/e2e/commands.e2e.test.js
+++ b/test/e2e/commands.e2e.test.js
@@ -1,0 +1,83 @@
+// END-TO-END command tests. Every scenario in ./scenarios.js is driven through
+// the REAL chat dispatcher (see ./harness.js) against the Firebase emulator, so a
+// break anywhere in a command's path — parsing, gates, handler, or DB writes —
+// fails a test. A COVERAGE test cross-checks the command registry so that adding
+// a new command WITHOUT an E2E scenario fails the build (the sync is automatic —
+// you can't forget). Run via `npm run test:e2e`.
+//
+// ── HOW TO ADD A TEST WHEN YOU ADD A COMMAND ────────────────────────────────
+//   1. Open test/e2e/scenarios.js.
+//   2. Add one `{ command, title, run }` entry to the SCENARIOS array, keyed by
+//      your command's PRIMARY name (registry def.names[0]).
+//   3. In `run({ bot, u, fx })`, use `bot.send(user, '!yourcmd ...')` to drive it
+//      and assert on the returned reply text and/or DB state. Use `fx.*` helpers
+//      to set up any needed state (a player, wallet, market, drop, raid, …).
+//   The coverage test below then passes. That's it.
+// ────────────────────────────────────────────────────────────────────────────
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../../src/db/firebase.js';
+import { startConfigMirror, setSeason, setExpMode, setChatMuted, isChatMuted } from '../../src/db/configStore.js';
+import { listCommands } from '../../src/commands/registry.js';
+import { silentLogger, makeBot, user, until } from './harness.js';
+import { getConfig, getSeason, getRaidPointer } from '../../src/db/configStore.js';
+import { SCENARIOS, fixtures } from './scenarios.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+// Everything a command might touch; wiped between scenarios for isolation.
+const GAME_PATHS = [
+  'players', 'usernames', 'wallets', 'markets', 'marketSuggestions', 'drops',
+  'raids', 'bosses', 'facts', 'factSubmissions', 'todos', 'duels', 'trades',
+  'leaderboard', 'items', 'counters',
+];
+async function wipeGame() {
+  await Promise.all(GAME_PATHS.map((p) => database().ref(p).remove().catch(() => {})));
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(silentLogger);
+});
+
+after(async () => {
+  if (host) { await wipeGame(); await closeFirebase(); }
+});
+
+beforeEach(async () => {
+  if (!host) return;
+  await wipeGame();
+  // Reset every config lever a scenario might flip back to a known baseline, then
+  // WAIT for the in-memory mirror to reflect it — a stale mute/exp/season/raid
+  // pointer would otherwise leak into the next scenario (swallowed replies, wrong
+  // season, a raid pointing at wiped data). Season 'e2e' + passive EXP off + not
+  // muted + no active raid is the clean slate every scenario starts from.
+  await database().ref('config/raid').remove().catch(() => {});
+  await setChatMuted(false);
+  await setExpMode('off'); // passive EXP off → replies aren't polluted by level-ups
+  await setSeason({ id: 'e2e', name: 'E2E Season', startsAt: Date.now() });
+  await until(() => !isChatMuted() && getConfig().expMode === 'off' && getSeason()?.id === 'e2e' && getRaidPointer() == null);
+});
+
+// One subtest per scenario, driven through the real dispatcher.
+for (const scenario of SCENARIOS) {
+  runOrSkip(`!${scenario.command} — ${scenario.title}`, async () => {
+    const bot = makeBot();
+    await scenario.run({ bot, u: user, fx: fixtures });
+  });
+}
+
+// COVERAGE — the automated registry↔test sync. Fails if any registered command
+// lacks a scenario, so a new command can't ship without an E2E test.
+runOrSkip('coverage: every registered command has an E2E scenario', () => {
+  const covered = new Set(SCENARIOS.map((s) => s.command));
+  const missing = listCommands()
+    .map((def) => def.names[0])
+    .filter((name) => !covered.has(name));
+  assert.deepEqual(
+    missing, [],
+    `these commands have no E2E scenario (add one in test/e2e/scenarios.js): ${missing.join(', ')}`,
+  );
+});

--- a/test/e2e/harness.js
+++ b/test/e2e/harness.js
@@ -1,0 +1,72 @@
+// E2E harness: drive real chat commands end-to-end through the ACTUAL dispatcher
+// (src/events/chat.js `createMessageHandler`) against the Firebase emulator, and
+// capture what the bot would say. This exercises the whole path a live message
+// takes — parsing, the mod/sub/mute gates, `def.run`, and the DB writes — not just
+// a command's inner function. See commands.e2e.test.js for the scenarios.
+
+import { createMessageHandler } from '../../src/events/chat.js';
+
+/** A logger that swallows everything (the dispatcher logs warns/errors). */
+export const silentLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+export const CHANNEL = '#nikkibreanne';
+export const BOT_USER_ID = 'bot-self';
+
+/** Poll `pred` until it's truthy or `ms` elapses (the config mirror is async). */
+export async function until(pred, ms = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+  return pred();
+}
+
+/**
+ * Build a chat user for a synthetic message. `id`/`login`/`name` identify them;
+ * the boolean flags drive the mod / broadcaster / subscriber gates.
+ */
+export function user(id, opts = {}) {
+  return {
+    id: String(id),
+    login: opts.login || String(id),
+    name: opts.name || opts.login || String(id),
+    mod: !!opts.mod,
+    broadcaster: !!opts.broadcaster,
+    sub: opts.sub !== false, // default: a subscriber (most game commands are sub-only)
+  };
+}
+
+/**
+ * A fake bot: `send(user, text)` runs one chat line through the real handler and
+ * returns the combined reply text; `replies` holds the structured captures from
+ * the LAST send. A FRESH handler is built per send so the per-user/per-command
+ * cooldown map never carries between steps (multi-step scenarios — e.g. a trade's
+ * open→counter→accept from the same user — would otherwise trip the 3s cooldown).
+ */
+export function makeBot({ channel = CHANNEL, botUserId = BOT_USER_ID } = {}) {
+  const replies = [];
+  const chat = {
+    say: async (_ch, text) => { replies.push({ kind: 'say', text }); },
+    action: async (_ch, text) => { replies.push({ kind: 'action', text }); },
+  };
+
+  async function send(u, text) {
+    replies.length = 0;
+    const handler = createMessageHandler({ chat, channel, botUserId, logger: silentLogger, onActivity() {} });
+    const msg = {
+      userInfo: {
+        userId: u.id,
+        userName: u.login,
+        displayName: u.name,
+        isMod: !!u.mod,
+        isBroadcaster: !!u.broadcaster,
+        isSubscriber: u.sub !== false,
+      },
+    };
+    await handler(channel, u.login, text, msg);
+    return replies.map((r) => r.text).join(' ⏎ ');
+  }
+
+  return { send, replies, chat };
+}

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -1,0 +1,284 @@
+// E2E scenarios — one per command, each driven end-to-end through the real chat
+// dispatcher (see harness.js) against the Firebase emulator. `fixtures` (fx) set
+// up the minimal game state a command's happy path needs; each scenario then
+// sends the chat line(s) and asserts on the reply text and/or resulting state.
+//
+// To add a command: append a { command, title, run } entry keyed by the command's
+// PRIMARY registry name. commands.e2e.test.js's coverage test enforces this.
+import assert from 'node:assert/strict';
+import { database } from '../../src/db/firebase.js';
+import { createPlayer, getPlayer, addLoot } from '../../src/db/players.js';
+import { ensureWallet } from '../../src/db/wallet.js';
+import { openMarket } from '../../src/db/market.js';
+import { setDrop } from '../../src/db/drops.js';
+import { setupRaidWeek, enlist } from '../../src/db/raid.js';
+import { seedCuratedFacts } from '../../src/db/facts.js';
+import { getRaidPointer } from '../../src/db/configStore.js';
+import { defaultBoss } from '../../src/content/bosses.js';
+import { until } from './harness.js';
+
+// A few catalog item ids used as loot (see src/content/items.js).
+const DPS_ITEM = 'itm_s1_thornnettle_dirk'; // dps common weapon
+const DPS_RARE = 'itm_s1_stormcaller_edge'; // dps rare weapon
+const TANK_RARE = 'itm_s1_ashbark_aegis';   // tank rare armor
+const DROP_ITEM = 'itm_starter_dps_weapon_01';
+
+// ── fixtures: establish pre-state via the db layer directly ──────────────────
+async function player(u, className = 'Berserker') {
+  const { player: p } = await createPlayer({
+    userId: u.id, login: u.login, displayName: u.name, className, isSubscriber: u.sub !== false,
+  });
+  return p;
+}
+async function loot(u, itemId) { return addLoot(u.id, itemId); }
+async function wallet(u) { return ensureWallet({ userId: u.id, login: u.login, displayName: u.name }); }
+async function market(question = 'Will we clear the boss tonight?') {
+  const r = await openMarket({ question });
+  return r.market.id;
+}
+async function drop(itemId = DROP_ITEM) { return setDrop(itemId); }
+async function facts() { return seedCuratedFacts(); }
+async function leaderboard(u, damage) {
+  await player(u);
+  await database().ref(`leaderboard/e2e/${u.id}`).set({ damage });
+}
+/** Stand up a signup-phase raid week and wait for the config mirror to see it. */
+async function raidWeek({ bossName = 'The Test Warden', enlistUsers = [] } = {}) {
+  const seasonId = 'e2e';
+  const weekId = 'w1';
+  const now = Date.now();
+  await setupRaidWeek({ seasonId, weekId, boss: defaultBoss(bossName), locksAt: now + 3_600_000, startsAt: now + 7_200_000 });
+  for (const u of enlistUsers) {
+    const p = await player(u, u.className || 'Berserker');
+    await enlist({ seasonId, weekId, userId: u.id, player: p });
+  }
+  await until(() => getRaidPointer()?.seasonId === seasonId && getRaidPointer()?.phase === 'signup');
+  return { seasonId, weekId };
+}
+
+export const fixtures = { player, loot, wallet, market, drop, facts, leaderboard, raidWeek };
+
+// ── scenarios (one per command primary name) ─────────────────────────────────
+export const SCENARIOS = [
+  {
+    command: 'create', title: 'a subscriber makes a hero',
+    run: async ({ bot, u }) => {
+      const alice = u('e2e_create', { login: 'alice', name: 'Alice' });
+      const reply = await bot.send(alice, '!create Berserker');
+      assert.match(reply, /you are a Berserker \(dps\)/i);
+      assert.ok(await getPlayer(alice.id), 'player persisted');
+    },
+  },
+  {
+    command: 'char', title: 'shows your character sheet',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_char', { login: 'alice', name: 'Alice' });
+      await fx.player(alice);
+      const reply = await bot.send(alice, '!char');
+      assert.match(reply, /Berserker \(dps\)/);
+      assert.match(reply, /Lv 1/);
+    },
+  },
+  {
+    command: 'bag', title: 'lists numbered unequipped loot',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_bag', { login: 'alice', name: 'Alice' });
+      await fx.player(alice);
+      await fx.loot(alice, DPS_ITEM);
+      const reply = await bot.send(alice, '!bag');
+      assert.match(reply, /bag: 1\. /);
+    },
+  },
+  {
+    command: 'equip', title: 'equips a bag item by number',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_equip', { login: 'alice', name: 'Alice' });
+      await fx.player(alice);
+      await fx.loot(alice, DPS_ITEM);
+      const reply = await bot.send(alice, '!equip 1');
+      assert.match(reply, /equipped .* \(weapon\)/);
+    },
+  },
+  {
+    command: 'unequip', title: 'returns an equipped slot to the bag',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_unequip', { login: 'alice', name: 'Alice' });
+      await fx.player(alice); // starter weapon is equipped
+      const reply = await bot.send(alice, '!unequip weapon');
+      assert.match(reply, /unequipped/i);
+      const p = await getPlayer(alice.id);
+      assert.ok((p.inventory || []).length > 0, 'item returned to bag');
+    },
+  },
+  {
+    command: 'grab', title: 'enters the active loot drop',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_grab', { login: 'alice', name: 'Alice' });
+      await fx.player(alice);
+      await fx.drop();
+      const reply = await bot.send(alice, '!grab');
+      assert.match(reply, /you're entered for/i);
+    },
+  },
+  {
+    command: 'muster', title: 'enlists your hero in the signup-phase raid',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_muster', { login: 'alice', name: 'Alice' });
+      await fx.raidWeek();
+      await fx.player(alice);
+      const reply = await bot.send(alice, '!muster');
+      assert.match(reply, /mustered/i);
+    },
+  },
+  {
+    command: 'top', title: 'shows the season damage leaderboard',
+    run: async ({ bot, u, fx }) => {
+      const hero = u('e2e_top', { login: 'topper', name: 'Topper' });
+      await fx.leaderboard(hero, 500);
+      const reply = await bot.send(u('e2e_top_viewer', { login: 'viewer' }), '!top');
+      assert.match(reply, /Season damage/);
+      assert.match(reply, /Topper/);
+    },
+  },
+  {
+    command: 'fact', title: 'returns a random fun fact',
+    run: async ({ bot, u, fx }) => {
+      await fx.facts();
+      const reply = await bot.send(u('e2e_fact', { login: 'viewer' }), '!fact');
+      assert.match(reply, /FUN FACT/i);
+    },
+  },
+  {
+    command: 'kennycommands', title: 'links the command reference',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_kc', { login: 'viewer' }), '!kennycommands');
+      assert.match(reply, /\/commands\//);
+    },
+  },
+  {
+    command: 'credits', title: 'reports your credit balance',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_credits', { login: 'viewer', name: 'Viewer' }), '!credits');
+      assert.match(reply, /\d+ credits/);
+    },
+  },
+  {
+    command: 'daily', title: 'claims the daily allowance',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_daily', { login: 'viewer', name: 'Viewer' }), '!daily');
+      assert.match(reply, /\+200 credits/);
+    },
+  },
+  {
+    command: 'bet', title: 'wagers credits on the only open market',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_bet', { login: 'alice', name: 'Alice' });
+      await fx.wallet(alice);
+      await fx.market();
+      const reply = await bot.send(alice, '!bet yes 100');
+      assert.match(reply, /bet on #/i);
+    },
+  },
+  {
+    command: 'duel', title: 'challenge → accept settles a coin-flip pot',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_duel_a', { login: 'alice', name: 'Alice' });
+      const bob = u('e2e_duel_b', { login: 'bob', name: 'Bob' });
+      await fx.wallet(alice); await fx.wallet(bob);
+      const challenge = await bot.send(alice, '!duel @bob 50');
+      assert.match(challenge, /challenges you/i);
+      const settle = await bot.send(bob, '!duel accept');
+      assert.match(settle, /pot!/);
+    },
+  },
+  {
+    command: 'trade', title: 'swap requires a counter, then settles',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_trade_a', { login: 'alice', name: 'Alice' });
+      const bob = u('e2e_trade_b', { login: 'bob', name: 'Bob' });
+      await fx.player(alice); await fx.loot(alice, DPS_RARE);
+      await fx.player(bob, 'Guardian'); await fx.loot(bob, TANK_RARE);
+      assert.match(await bot.send(alice, '!trade @bob 1'), /wants to trade/i);
+      assert.match(await bot.send(bob, '!trade counter 1'), /counters/i);
+      assert.match(await bot.send(alice, '!trade accept'), /Trade done/i);
+    },
+  },
+  {
+    command: 'offer', title: 'one-way gift is accepted',
+    run: async ({ bot, u, fx }) => {
+      const alice = u('e2e_offer_a', { login: 'alice', name: 'Alice' });
+      const bob = u('e2e_offer_b', { login: 'bob', name: 'Bob' });
+      await fx.player(alice); await fx.loot(alice, DPS_RARE);
+      await fx.player(bob, 'Guardian');
+      assert.match(await bot.send(alice, '!offer @bob 1'), /offers you/i);
+      assert.match(await bot.send(bob, '!offer accept'), /received/i);
+    },
+  },
+  {
+    command: 'market', title: 'lists the open OKRAMARKETs',
+    run: async ({ bot, u, fx }) => {
+      await fx.market();
+      const reply = await bot.send(u('e2e_market', { login: 'viewer' }), '!market');
+      assert.match(reply, /OKRAMARKET/);
+    },
+  },
+  {
+    command: 'todo', title: 'mod adds a to-do item',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_todo', { login: 'mod', name: 'Mod', mod: true }), '!todo add Water the okra');
+      assert.match(reply, /To-do #\d+ added/i);
+    },
+  },
+  {
+    command: 'exp', title: 'mod sets the EXP gate',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_exp', { login: 'mod', name: 'Mod', mod: true }), '!exp on');
+      assert.match(reply, /EXP mode set to on/i);
+    },
+  },
+  {
+    command: 'mute', title: 'mod mutes (ack bypasses the mute)',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_mute', { login: 'mod', name: 'Mod', mod: true }), '!mute on');
+      assert.match(reply, /Muted/i);
+    },
+  },
+  {
+    command: 'drop', title: 'mod forces a specific loot drop',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_drop', { login: 'mod', name: 'Mod', mod: true }), `!drop ${DPS_ITEM}`);
+      assert.match(reply, /dropped/i);
+      assert.match(reply, /!grab/);
+    },
+  },
+  {
+    command: 'drops', title: 'mod toggles the auto-drop scheduler',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_drops', { login: 'mod', name: 'Mod', mod: true }), '!drops on');
+      assert.match(reply, /Auto-drops ON/i);
+    },
+  },
+  {
+    command: 'boss', title: 'mod opens muster with a custom boss',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_boss', { login: 'mod', name: 'Mod', mod: true }), '!boss set Grumblehoof');
+      assert.match(reply, /Grumblehoof/);
+    },
+  },
+  {
+    command: 'raidnight', title: 'mod locks the roster and runs the battle',
+    run: async ({ bot, u, fx }) => {
+      await fx.raidWeek({ enlistUsers: [u('e2e_rn_hero', { login: 'hero', name: 'Hero' })] });
+      const reply = await bot.send(u('e2e_rn_mod', { login: 'mod', name: 'Mod', mod: true }), '!raidnight');
+      assert.match(reply, /RAID NIGHT/i);
+    },
+  },
+  {
+    command: 'season', title: 'mod starts a new season',
+    run: async ({ bot, u }) => {
+      const reply = await bot.send(u('e2e_season', { login: 'mod', name: 'Mod', mod: true }), '!season start t2');
+      assert.match(reply, /Season started/i);
+      assert.match(reply, /t2/);
+    },
+  },
+];


### PR DESCRIPTION
## What

Two related bits of hardening as the command surface keeps growing.

### End-to-end command tests (`test/e2e/`)
Drives **every chat command through the real dispatcher** (`src/events/chat.js`) against the Firebase emulator — the same path a live Twitch message takes: parse → mod/sub/mute gates → `def.run` → DB writes. If a command breaks anywhere in that path, a test fails.

- **`harness.js`** — fake `chat` driver; `makeBot()` gives `send(user, text)` → captured reply text. A fresh handler is built per `send` so the per-user cooldown never trips inside a multi-step scenario (e.g. a trade open→counter→accept).
- **`scenarios.js`** — `fixtures` (set up game state: player/loot/wallet/market/drop/facts/leaderboard/raidWeek) + one `SCENARIOS` entry per command.
- **`commands.e2e.test.js`** — runner + a **coverage guard**: it reads `listCommands()` and fails if any command's primary name has no scenario. This is the automated registry↔test sync — you can't add a command without a matching test, or the build breaks.
- **`README.md`** — how to run it and how to add a scenario.

Run it:
```
npm run test:e2e            # emulator + suite, then exit
npm run dev:all -- test     # same, via the dev harness
```

### Node 22
- `Dockerfile`: `node:20-bookworm-slim` → `node:22-bookworm-slim` (build + runtime).
- `.github/workflows/publish.yml`: `actions/{checkout,setup-node,setup-java}@v4` → `@v5` (clears the Node-16/20 action-deprecation warnings), Node 22 in CI, and a new `npm run test:e2e` step after `test:emulator`.

## Verification
- `npm run test:e2e` → 26/26
- `npm test` → 44/44
- `npm run test:emulator` → green
- `bash scripts/dev-all.sh test` → 26/26
- Coverage guard confirmed: dropping a scenario makes the suite report the missing command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)