### PR TITLE
Split tests into a CI workflow that gates PRs into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+# Continuous integration — the merge gate for `main`.
+#
+# Runs the full test suite (unit + Firebase-rules emulator + end-to-end command
+# dispatch) on every pull request into main and every push to main. Branch
+# protection on `main` requires this workflow's `test` check to pass before a PR
+# can merge, so a change that breaks any command can't land.
+#
+# `publish.yml` reuses this exact job via `workflow_call`, so a release tag can't
+# build an image that skipped the suite — one source of truth for "the tests".
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_call: {} # let publish.yml run this same job before building the image
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      # The Firebase RTDB emulator (firebase-tools@15) requires JDK 21+.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - run: npm ci
+      # Pure engine unit tests (offline).
+      - run: npm test
+      # Firebase rules + client-write-rejection test against the emulator.
+      - run: npm run test:emulator
+      # End-to-end: every command driven through the real dispatcher (emulator).
+      - run: npm run test:e2e

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,26 +12,10 @@ permissions:
   packages: write # lets GITHUB_TOKEN push to GHCR — no PAT in CI
 
 jobs:
+  # Reuse the same suite that gates PRs into main (.github/workflows/ci.yml) so a
+  # release tag can't ship an image that skipped the tests — one source of truth.
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-      # The Firebase RTDB emulator (firebase-tools@15) requires JDK 21+.
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-      - run: npm ci
-      # Pure engine unit tests (offline).
-      - run: npm test
-      # Firebase rules + client-write-rejection test against the emulator.
-      - run: npm run test:emulator
-      # End-to-end: every command driven through the real dispatcher (emulator).
-      - run: npm run test:e2e
+    uses: ./.github/workflows/ci.yml
 
   docker:
     needs: test


### PR DESCRIPTION
## Why

The test suite (unit + Firebase-rules emulator + end-to-end command dispatch) lived **inside `publish.yml`**, whose only trigger is `push: tags: ['v*']`. So it ran **only when a release tag was pushed** — never on a PR, never on a push to `main`. It gated nothing on the way into `main`.

## What

- **New `.github/workflows/ci.yml`** — the `test` job, triggered on `pull_request → main` and `push → main`. This is the merge gate.
- **`publish.yml`** now *reuses* that job via `workflow_call` (`uses: ./.github/workflows/ci.yml`) instead of carrying its own copy. A release tag still runs the full suite before the `docker` build — one source of truth for "the tests", no duplication.

## Branch protection

Once this merges, `main` gets a protection rule requiring the **`test`** status check to pass before a PR can merge, so a change that breaks any command can't land. (Being set up alongside this PR.)

## Note

This PR dogfoods itself: the new `ci.yml` runs on this very PR (GitHub uses the workflow file from the PR head for `pull_request` events), so you'll see the `test` check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)