### PR TITLE
Add !clip, !start clapperboard, Chat Bot badge send-path, and clip dev tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,10 @@ TWITCH_CLIENT_SECRET=
 # ─── Bot chat account ───
 # Display name of the account the bot logs in as (used to ignore its own echoes).
 TWITCH_BOT_USERNAME=theKennyBot
-# One-time bootstrap refresh token for the bot account (scopes: chat:read chat:edit).
+# One-time bootstrap refresh token for the bot account.
+#   Scopes: chat:read chat:edit
+#   (+ user:bot user:write:chat when TWITCH_SEND_MODE=helix — earns the Chat Bot
+#    badge; see the Runtime section below.)
 # After first run the live token store (TOKEN_STORE_DIR) is authoritative and this
 # is ignored. Obtain via the Twitch OAuth authorization-code flow.
 TWITCH_BOT_REFRESH_TOKEN=
@@ -45,3 +48,9 @@ FIREBASE_PROJECT_ID=okrafans
 # INSTANCE_ID=
 # debug | info | warn | error
 LOG_LEVEL=info
+# Chat send transport: 'irc' (default — twurple ChatClient) or 'helix' (Send Chat
+# Message API via an app token, which earns the Twitch Chat Bot badge). 'helix'
+# requires the bot token to include `user:bot user:write:chat` AND the bot to be a
+# moderator in the channel (or the broadcaster to grant `channel:bot`). Reading
+# always stays on IRC. See https://dev.twitch.tv/docs/chat/.
+# TWITCH_SEND_MODE=irc

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ serviceAccount*.json.*
 
 # persisted Twitch refresh-token store (the writable runtime volume; §F)
 /.tokens/
+/.tokens-dev/
 /data/
 
 # local Firebase emulator artifacts

--- a/database.rules.json
+++ b/database.rules.json
@@ -44,6 +44,12 @@
     // the client. Its counter (counters/) stays fully locked (default deny).
     "todos": { ".read": true, ".write": false },
 
+    // CLIP SYNC (clapperboard): per-stream sync anchors written by kennyBot on
+    // `!start`, read by the separate okra-clip-archiver tool to align Twitch
+    // clips to the local 4K recording. Public-READABLE (anchors aren't
+    // sensitive) so the archiver needs no admin key; Admin-write only.
+    "clipSync": { ".read": true, ".write": false },
+
     // OKRAMARKET: okra-buck balances and market state are public-READABLE (the
     // site renders the board + odds) but Admin-write only — points can never be
     // minted client-side; bets/opens/resolves all go through kennyBot. The bet

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ import { startConfigMirror, setLive, isChatMuted } from './src/db/configStore.js
 import { acquireLock, startHeartbeat, releaseLock, defaultInstanceId } from './src/db/lock.js';
 import { TokenStore } from './src/db/tokenStore.js';
 import { buildAuth } from './src/twitch/auth.js';
+import { createSender } from './src/twitch/sender.js';
+import { initClips } from './src/twitch/clips.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
@@ -181,6 +183,11 @@ async function main() {
   }
   const channelUserId = channelUser.id;
 
+  // Clip service (Helix Create Clip). Clips in the BOT's user context, so the bot
+  // token needs clips:edit and the channel must be live; wired here so the !clip
+  // command reaches it without threading the ApiClient through the chat handler.
+  initClips({ apiClient, broadcasterId: channelUserId, botUserId });
+
   // ── Resolve-on-boot: advance raid phases by stored timestamps, never a timer
   //    a restart could lose (§H.5 / §L.1). Loop to catch up after downtime
   //    (e.g. signup→locked→live→done all overdue).
@@ -192,16 +199,37 @@ async function main() {
 
   // ── Chat ──
   const chat = new ChatClient({ authProvider, channels: [channel] });
-  // Mute-aware sender for spontaneous (non-command) announcements. When a mod
-  // mutes the bot (`!mute`) every outbound send is suppressed while the bot
-  // keeps listening, granting EXP, processing drops, and holding the lease.
-  // Command replies are gated inside the message handler (which also lets the
-  // !mute control itself bypass, so mods still get confirmation).
-  const out = {
-    say: (ch, text) => (isChatMuted() ? Promise.resolve() : chat.say(ch, text)),
-    action: (ch, text) => (isChatMuted() ? Promise.resolve() : chat.action(ch, text)),
+
+  // Outbound sender (src/twitch/sender.js). 'irc' sends via the ChatClient;
+  // 'helix' sends via the Send Chat Message API on an app token to earn the Chat
+  // Bot badge. Default stays 'irc' so behaviour is byte-for-byte unchanged until
+  // the bot token carries the extra scopes (user:bot, user:write:chat) and the
+  // flag is flipped — reading always stays on the ChatClient either way.
+  const sendMode = (process.env.TWITCH_SEND_MODE || 'irc').toLowerCase() === 'helix' ? 'helix' : 'irc';
+  if ((process.env.TWITCH_SEND_MODE || 'irc').toLowerCase() !== sendMode) {
+    logger.warn('unknown TWITCH_SEND_MODE — using irc', { value: process.env.TWITCH_SEND_MODE });
+  }
+  const sender = createSender({
+    mode: sendMode,
+    chat,
+    apiClient,
+    channel,
+    broadcasterId: channelUserId,
+    botUserId,
+    logger,
+  });
+  logger.info('chat sender ready', { mode: sender.mode });
+
+  // Mute-aware wrapper for spontaneous (non-command) announcements — loot draws +
+  // the auto-drop scheduler. When a mod mutes the bot (`!mute`) these are
+  // suppressed while the bot keeps listening, granting EXP, processing drops, and
+  // holding the lease. Command replies + level-ups do their own mute gating inside
+  // the handler (which also lets the !mute control itself bypass for confirmation).
+  const send = {
+    say: (text) => (isChatMuted() ? Promise.resolve() : sender.say(text)),
+    action: (text) => (isChatMuted() ? Promise.resolve() : sender.action(text)),
   };
-  chat.onMessage(createMessageHandler({ chat, channel, botUserId, logger, onActivity: touchHeartbeat }));
+  chat.onMessage(createMessageHandler({ sender, channel, botUserId, logger, onActivity: touchHeartbeat }));
   chat.onConnect(() => {
     health.chatConnected = true;
     touchHeartbeat();
@@ -212,12 +240,12 @@ async function main() {
     touchHeartbeat();
     logger.warn('chat disconnected', { manual, reason: String(reason || '') });
   });
-  shutdownHooks.push(attachTwitchEvents({ chat, channel, logger }));
+  shutdownHooks.push(attachTwitchEvents({ chat, sender, logger }));
   await chat.connect();
   shutdownHooks.push(() => chat.quit());
 
   // Auto chat-drop scheduler (mod-toggled via !drops; fires only while live).
-  shutdownHooks.push(startDropScheduler({ chat: out, channel, logger }));
+  shutdownHooks.push(startDropScheduler({ send, logger }));
 
   // ── Live gate: Helix poll (always) + EventSub (when broadcaster auth fits) ──
   const setLiveBound = (live, source) => {
@@ -277,12 +305,9 @@ async function main() {
       const { drawResult, activated } = await processDrops();
       if (drawResult) {
         if (drawResult.winner) {
-          out
-            .say(
-              channel,
-              `🎉 @${drawResult.winner.name || 'a lucky grabber'} won the ${drawResult.item?.rarity ?? ''} ${drawResult.item?.name ?? 'drop'}! (${drawResult.count} entered) — it's in their !bag.`,
-            )
-            .catch(() => {});
+          send.say(
+            `🎉 @${drawResult.winner.name || 'a lucky grabber'} won the ${drawResult.item?.rarity ?? ''} ${drawResult.item?.name ?? 'drop'}! (${drawResult.count} entered) — it's in their !bag.`,
+          );
           logger.info('drop drawn', { item: drawResult.itemId, winner: drawResult.winner.userId, entrants: drawResult.count });
         } else {
           logger.info('drop expired with no entrants', { item: drawResult.itemId });
@@ -290,9 +315,7 @@ async function main() {
       }
       if (activated) {
         const secs = Math.round(config.loot.windowMs / 1000);
-        out
-          .say(channel, `⏭️ Next up — a ${activated.rarity} ${activated.name} is open! !grab within ${secs}s to enter the draw.`)
-          .catch(() => {});
+        send.say(`⏭️ Next up — a ${activated.rarity} ${activated.name} is open! !grab within ${secs}s to enter the draw.`);
       }
     } catch (err) {
       logger.error('drop draw tick failed', { err: String(err) });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "node --watch index.js",
+    "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
     "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",

--- a/scripts/dev-live.sh
+++ b/scripts/dev-live.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# dev-live — run the REAL bot against a live Twitch channel for local testing,
+# backed by a throwaway Firebase emulator DB. Safe against production:
+#   • emulator DB  → no writes to prod game state
+#   • no single-instance-lease fight with the faraday bot (separate, empty DB)
+#   • separate token store (.tokens-dev) that BOOTSTRAPS from .env's
+#     TWITCH_BOT_REFRESH_TOKEN — so re-issued scopes (e.g. clips:edit) take effect
+#     without touching the prod token file. Re-issued the token? `rm -rf .tokens-dev`.
+#
+#   npm run dev:live                 # channel = $DEV_CHANNEL or scasplte2
+#   npm run dev:live -- yourchannel  # or pass a channel
+#
+# Then: go live, wait ~45s for the Helix live-poll, and try !clip / !start in chat.
+set -uo pipefail
+
+BOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$BOT_DIR"
+
+CHANNEL="${1:-${DEV_CHANNEL:-scasplte2}}"
+export TWITCH_CHANNEL="$CHANNEL"
+export TWITCH_BROADCASTER_REFRESH_TOKEN=""            # broadcaster EventSub is prod-only → Helix poll here
+export TOKEN_STORE_DIR="${TOKEN_STORE_DIR:-./.tokens-dev}"
+
+echo "▶ local bot → #$CHANNEL   (emulator DB — ephemeral; Ctrl-C to stop)"
+echo "▶ token store: $TOKEN_STORE_DIR   (seeded from .env; rm -rf it to re-bootstrap new scopes)"
+echo "▶ go live, wait ~45s for the live-poll, then try !clip / !start in chat"
+echo
+
+exec ./node_modules/.bin/firebase emulators:exec --only database --project okrafans "node index.js"

--- a/scripts/get-token.mjs
+++ b/scripts/get-token.mjs
@@ -1,0 +1,83 @@
+// One-off dev helper: obtain a bot (or broadcaster) refresh token carrying the
+// scopes kennyBot needs. NOT part of the running bot — the bot is outbound-only;
+// this briefly listens on localhost:3000 only to catch the OAuth redirect, then
+// exits. Uses YOUR app's client id/secret so the resulting token refreshes
+// cleanly under the same RefreshingAuthProvider.
+//
+// Prereqs:
+//   1. TWITCH_CLIENT_ID / TWITCH_CLIENT_SECRET in .env (already there for the bot).
+//   2. Register  http://localhost:3000  as an OAuth Redirect URL in the Twitch app
+//      console (https://dev.twitch.tv/console/apps → your app → add + save).
+//   3. Log into twitch.tv as the account you want the token FOR (the bot account
+//      for the bot token) before opening the URL below.
+//
+// Run:
+//   node scripts/get-token.mjs
+//   # custom scopes (space-separated):
+//   OAUTH_SCOPES="chat:read chat:edit" node scripts/get-token.mjs
+//
+// The printed TWITCH_BOT_REFRESH_TOKEN goes into .env. If a token is already
+// stored (TOKEN_STORE_DIR, default ./.tokens), delete .tokens/bot* so the new
+// token re-bootstraps instead of the stored (old-scope) one winning.
+import 'dotenv/config';
+import http from 'node:http';
+import { exchangeCode } from '@twurple/auth';
+
+const clientId = process.env.TWITCH_CLIENT_ID;
+const clientSecret = process.env.TWITCH_CLIENT_SECRET;
+const redirectUri = process.env.OAUTH_REDIRECT_URI || 'http://localhost:3000';
+// Default = everything discussed: IRC read/send + badge (app-token send) + !clip.
+const scopes = (process.env.OAUTH_SCOPES || 'chat:read chat:edit user:bot user:write:chat clips:edit')
+  .split(/\s+/)
+  .filter(Boolean);
+
+if (!clientId || !clientSecret) {
+  console.error('Missing TWITCH_CLIENT_ID / TWITCH_CLIENT_SECRET (set them in .env).');
+  process.exit(1);
+}
+
+const authUrl =
+  'https://id.twitch.tv/oauth2/authorize?' +
+  new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: scopes.join(' '),
+    force_verify: 'true', // always re-prompt, so switching account / re-consenting works
+  });
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, redirectUri);
+  if (!url.pathname.startsWith('/') || url.searchParams.get('error')) {
+    res.writeHead(400, { 'content-type': 'text/plain' });
+    res.end('OAuth error: ' + (url.searchParams.get('error_description') || 'no code'));
+    return;
+  }
+  const code = url.searchParams.get('code');
+  if (!code) {
+    res.writeHead(204).end();
+    return; // ignore favicon.ico etc.
+  }
+  try {
+    const token = await exchangeCode(clientId, clientSecret, code, redirectUri);
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('Authorized. You can close this tab and return to the terminal.');
+    console.log('\n✅ Token obtained.');
+    console.log('   scopes:', token.scope.join(' '));
+    console.log('\n   TWITCH_BOT_REFRESH_TOKEN=' + token.refreshToken + '\n');
+  } catch (err) {
+    res.writeHead(500, { 'content-type': 'text/plain' });
+    res.end('Token exchange failed: ' + String(err));
+    console.error('\n❌ exchange failed:', err);
+  } finally {
+    setTimeout(() => server.close(() => process.exit(0)), 250);
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Requesting scopes:', scopes.join(' '));
+  console.log('\n1) Log into twitch.tv as the target account (the BOT for the bot token).');
+  console.log('2) Open this URL in a browser:\n');
+  console.log('   ' + authUrl + '\n');
+  console.log('Waiting for the redirect on ' + redirectUri + ' …  (Ctrl-C to abort)');
+});

--- a/scripts/list-clips.mjs
+++ b/scripts/list-clips.mjs
@@ -1,0 +1,55 @@
+// scripts/list-clips.mjs — read-only demo of the "get timestamps from Twitch"
+// step for the 4K-vertical pipeline. Pulls the channel's recent clips and prints
+// the ONLY fields that step needs: which VOD (videoId) + in/out offsets
+// (vodOffset .. vodOffset+duration). No OBS, no recording, no upload — just the
+// public Clips API via an app token (no user login needed).
+//
+//   node scripts/list-clips.mjs [--days 14]
+//   TWITCH_CHANNEL=someoneelse node scripts/list-clips.mjs --days 60
+//
+import 'dotenv/config';
+import { ApiClient } from '@twurple/api';
+import { AppTokenAuthProvider } from '@twurple/auth';
+
+const { TWITCH_CLIENT_ID: clientId, TWITCH_CLIENT_SECRET: clientSecret, TWITCH_CHANNEL: channel } = process.env;
+if (!clientId || !clientSecret || !channel) {
+  console.error('Need TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET, TWITCH_CHANNEL in .env');
+  process.exit(1);
+}
+
+const dIdx = process.argv.indexOf('--days');
+const days = dIdx >= 0 && process.argv[dIdx + 1] ? Number(process.argv[dIdx + 1]) : 14;
+
+const api = new ApiClient({ authProvider: new AppTokenAuthProvider(clientId, clientSecret) });
+
+const user = await api.users.getUserByName(channel);
+if (!user) { console.error(`channel not found: ${channel}`); process.exit(1); }
+
+const startDate = new Date(Date.now() - days * 86_400_000).toISOString();
+const { data: clips } = await api.clips.getClipsForBroadcaster(user.id, { startDate, limit: 100 });
+
+const short = clips.filter((c) => c.duration <= 60);
+console.log(`\n${channel}: ${clips.length} clips in the last ${days}d — ${short.length} are ≤60s (Shorts-eligible)\n`);
+
+let mappable = 0;
+for (const c of short) {
+  const has = c.vodOffset != null;
+  if (has) mappable += 1;
+  const inOut = has
+    ? `in=${c.vodOffset}s out=${c.vodOffset + Math.round(c.duration)}s`
+    : 'in/out=PENDING (vod_offset null — VOD not processed yet, or VODs off)';
+  console.log(
+    [
+      c.creationDate.toISOString().slice(0, 19).replace('T', ' '),
+      `${Math.round(c.duration)}s`.padStart(4),
+      `vod=${c.videoId || '—'}`.padEnd(14),
+      inOut.padEnd(58),
+      c.title.slice(0, 40),
+    ].join('  '),
+  );
+}
+console.log(
+  `\n${mappable}/${short.length} clips are mappable now (vod_offset present).\n` +
+    `Pipeline per clip: cut [in−pad, out+pad] from the LOCAL 4K recording of vod=<videoId>, then crop+stack to 9:16.\n`,
+);
+process.exit(0);

--- a/scripts/list-clips.mjs
+++ b/scripts/list-clips.mjs
@@ -25,8 +25,11 @@ const api = new ApiClient({ authProvider: new AppTokenAuthProvider(clientId, cli
 const user = await api.users.getUserByName(channel);
 if (!user) { console.error(`channel not found: ${channel}`); process.exit(1); }
 
-const startDate = new Date(Date.now() - days * 86_400_000).toISOString();
-const { data: clips } = await api.clips.getClipsForBroadcaster(user.id, { startDate, limit: 100 });
+// Bound the window with endDate — Twitch defaults ended_at to one WEEK after
+// started_at, so a large --days window silently drops anything more recent.
+const now = new Date();
+const startDate = new Date(now.getTime() - days * 86_400_000).toISOString();
+const { data: clips } = await api.clips.getClipsForBroadcaster(user.id, { startDate, endDate: now.toISOString(), limit: 100 });
 
 const short = clips.filter((c) => c.duration <= 60);
 console.log(`\n${channel}: ${clips.length} clips in the last ${days}d — ${short.length} are ≤60s (Shorts-eligible)\n`);

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -1,0 +1,30 @@
+// !clip — create a Twitch clip of the last ~30s of the live stream (Helix Create
+// Clip). Open to everyone with a per-user cooldown; only works while live. The
+// Twitch clip is capped at the stream resolution — a local high-res / 4K copy is a
+// separate capture (obs-websocket replay buffer / post-hoc archive).
+import { getConfig } from '../db/configStore.js';
+import { createChannelClip, clipsReady } from '../twitch/clips.js';
+
+export default {
+  names: ['clip'],
+  mod: false,
+  cooldownMs: 60_000, // per-user: a viewer can clip at most once a minute
+  help: '!clip — clip the last ~30s of the stream (posts a Twitch clip link)',
+  async run({ user, reply, logger }) {
+    if (!clipsReady()) {
+      reply(`@${user.displayName} clipping isn't set up right now.`);
+      return;
+    }
+    if (!getConfig().live) {
+      reply(`@${user.displayName} I can only clip while the stream is live!`);
+      return;
+    }
+    try {
+      const { url } = await createChannelClip();
+      reply(`@${user.displayName} 🎬 clipped it! ${url}`);
+    } catch (err) {
+      logger?.warn?.('clip failed', { userId: user.id, err: String(err) });
+      reply(`@${user.displayName} couldn't make a clip just now — try again in a moment.`);
+    }
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -17,6 +17,8 @@ import bet from './bet.js';
 import duel from './duel.js';
 import trade from './trade.js';
 import offer from './offer.js';
+import clip from './clip.js';
+import start from './start.js';
 import market from './mod/market.js';
 import todo from './mod/todo.js';
 import exp from './mod/exp.js';
@@ -27,7 +29,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, exp, mute, drop, drops, boss, raidnight, season, market, todo];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, mute, drop, drops, boss, raidnight, season, market, todo];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -1,0 +1,35 @@
+// !start — the "clapperboard". Drops a per-stream sync anchor in RTDB (clipSync)
+// so the separate okra-clip-archiver tool can align this stream's Twitch clips to
+// the local 4K recording. When live, best-effort also creates a MARKER Twitch clip
+// whose vod_offset pins the VOD timeline precisely. Broadcaster/mod only.
+import { getConfig } from '../db/configStore.js';
+import { startSession } from '../db/clipSync.js';
+import { createChannelClip, clipsReady } from '../twitch/clips.js';
+
+export default {
+  names: ['start', 'slate'],
+  mod: true,
+  cooldownMs: 10_000,
+  help: '!start — set a stream sync point for the clip archiver (mods)',
+  async run({ user, reply, channel, logger }) {
+    // Marker clip is a precision bonus, never a hard requirement — only attempt it
+    // while live, and never let its failure block the anchor write.
+    let markerClipId = null;
+    if (getConfig().live && clipsReady()) {
+      try {
+        markerClipId = (await createChannelClip()).id;
+      } catch (err) {
+        logger?.warn?.('start: marker clip failed', { err: String(err) });
+      }
+    }
+    try {
+      const { sessionId } = await startSession({ channel, startedBy: user.login, markerClipId });
+      reply(
+        `🎬 Sync point set${markerClipId ? ' (+ marker clip)' : ''} — the clip archiver can align this stream. [${sessionId.slice(0, 6)}]`,
+      );
+    } catch (err) {
+      logger?.warn?.('start: anchor write failed', { err: String(err) });
+      reply(`@${user.displayName} couldn't set the sync point — try again.`);
+    }
+  },
+};

--- a/src/db/clipSync.js
+++ b/src/db/clipSync.js
@@ -1,0 +1,27 @@
+// Clip-sync "clapperboard" anchors. On `!start` kennyBot stamps a per-stream sync
+// point in RTDB; the SEPARATE okra-clip-archiver tool reads it (public-read) to
+// align a stream's Twitch clips to the local 4K recording. kennyBot only writes
+// the anchor — it does no clip processing itself.
+import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
+
+/**
+ * Record a stream sync anchor. Returns the generated session id.
+ * @param {{ channel: string, startedBy: string, markerClipId?: string|null }} args
+ * @returns {Promise<{ sessionId: string }>}
+ */
+export async function startSession({ channel, startedBy, markerClipId = null }) {
+  const ref = database().ref(PATHS.clipSync()).push();
+  await ref.set({
+    startedAt: SERVER_TIMESTAMP, // the clapperboard instant (server wall-clock)
+    channel,
+    startedBy,
+    ...(markerClipId ? { markerClipId } : {}),
+  });
+  return { sessionId: ref.key };
+}
+
+/** Best-effort: stamp an end time on a session (optional `!end`). */
+export async function endSession(sessionId) {
+  await database().ref(`${PATHS.clipSession(sessionId)}/endedAt`).set(SERVER_TIMESTAMP);
+  return sessionId;
+}

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -141,4 +141,7 @@ export const PATHS = {
   team: (seasonId, weekId) => `raids/${seasonId}/${weekId}/team`,
   combat: (seasonId, weekId) => `raids/${seasonId}/${weekId}/combat`,
   leaderboardEntry: (seasonId, userId) => `leaderboard/${seasonId}/${userId}`,
+  // CLIP SYNC (clapperboard): per-stream anchors for the okra-clip-archiver tool.
+  clipSync: () => 'clipSync',
+  clipSession: (id) => `clipSync/${id}`,
 };

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -17,7 +17,7 @@ import { applyChatTick } from '../db/players.js';
 
 /**
  * @param {{
- *   chat: { say: Function, action: Function },
+ *   sender: { say: (t: string) => Promise<void>, action: (t: string) => Promise<void> },
  *   channel: string,
  *   botUserId: string,
  *   logger: any,
@@ -25,12 +25,13 @@ import { applyChatTick } from '../db/players.js';
  * }} deps
  * @returns {(channel: string, user: string, text: string, msg: any) => Promise<void>}
  */
-export function createMessageHandler({ chat, channel, botUserId, logger, onActivity }) {
+export function createMessageHandler({ sender, channel, botUserId, logger, onActivity }) {
   const expCooldown = new Map(); // userId -> last grant ms
   const cmdCooldown = new Map(); // `${userId}:${cmd}` -> last run ms
 
-  const rawSay = (t) => chat.say(channel, t).catch((e) => logger.warn('say failed', { err: String(e) }));
-  const rawAction = (t) => chat.action(channel, t).catch(() => {});
+  // Transport-only sender (src/twitch/sender.js); it catches its own send errors.
+  const rawSay = (t) => sender.say(t);
+  const rawAction = (t) => sender.action(t);
 
   async function dispatchCommand(user, args, name) {
     const def = getCommand(name);
@@ -87,7 +88,7 @@ export function createMessageHandler({ chat, channel, botUserId, logger, onActiv
     }
     if (!tick) return; // not a player → nothing accrues (non-subs never created one)
     if (tick.leveledUp && !isChatMuted()) {
-      chat.say(channel, `@${user.displayName} reached level ${tick.toLevel}! ⚔️`).catch(() => {});
+      sender.say(`@${user.displayName} reached level ${tick.toLevel}! ⚔️`);
     }
   }
 

--- a/src/events/dropScheduler.js
+++ b/src/events/dropScheduler.js
@@ -10,10 +10,12 @@ import { getItem, DEFAULT_LOOT_TABLE } from '../content/items.js';
 import { config, shouldGrantExp } from '../config.js';
 
 /**
- * @param {{ chat: { say: Function }, channel: string, logger: any }} deps
+ * @param {{ send: { say: (t: string) => Promise<void> }, logger: any }} deps
+ *   `send` is the mute-aware sender wrapper (announcements are suppressed while
+ *   the bot is muted, but the drop itself is still created so !grab keeps working).
  * @returns {() => void} stop function
  */
-export function startDropScheduler({ chat, channel, logger }) {
+export function startDropScheduler({ send, logger }) {
   let timer = null;
   let stopped = false;
 
@@ -37,9 +39,9 @@ export function startDropScheduler({ chat, channel, logger }) {
           const drop = await setDrop(itemId);
           const secs = Math.round(config.loot.windowMs / 1000);
           if (drop.status === 'open') {
-            chat.say(channel, `🎁 A ${drop.rarity} ${drop.name} dropped! Type !grab within ${secs}s to enter the draw — one winner!`).catch(() => {});
+            send.say(`🎁 A ${drop.rarity} ${drop.name} dropped! Type !grab within ${secs}s to enter the draw — one winner!`);
           } else if (drop.status === 'queued') {
-            chat.say(channel, `🎁 A ${drop.rarity} ${drop.name} is queued (#${drop.position}) — opens when the current drop closes.`).catch(() => {});
+            send.say(`🎁 A ${drop.rarity} ${drop.name} is queued (#${drop.position}) — opens when the current drop closes.`);
           }
           logger.info?.('auto drop', { item: itemId, rarity: drop.rarity, status: drop.status });
         }

--- a/src/events/twitchEvents.js
+++ b/src/events/twitchEvents.js
@@ -28,14 +28,15 @@ function lootTable() {
 
 /**
  * Attach native chat-event listeners. Returns a cleanup function that removes
- * them (twurple listeners expose .unbind()).
- * @param {{ chat: import('@twurple/chat').ChatClient, channel: string, logger: any }} deps
+ * them (twurple listeners expose .unbind()). `chat` is still the read side (the
+ * sub/raid/cheer listeners); `sender` is the transport for anything we say back.
+ * @param {{ chat: import('@twurple/chat').ChatClient, sender: { say: (t: string) => Promise<void> }, logger: any }} deps
  */
-export function attachTwitchEvents({ chat, channel, logger }) {
+export function attachTwitchEvents({ chat, sender, logger }) {
   const listeners = [];
   // Outbound mute (`!mute`): these communal-drop announcements are suppressed
   // while muted, but the drop itself is still created so !grab keeps working.
-  const say = (text) => { if (!isChatMuted()) chat.say(channel, text).catch(() => {}); };
+  const say = (text) => { if (!isChatMuted()) sender.say(text); };
 
   const onSubLike = (label) => async (_ch, _user, info, msg) => {
     const userId = msg?.userInfo?.userId;

--- a/src/twitch/clips.js
+++ b/src/twitch/clips.js
@@ -1,0 +1,43 @@
+// Twitch clip creation (Helix Create Clip). A small init-once service so command
+// modules can make a clip without threading the ApiClient through the chat
+// handler — the same shape as the db/* stores and configStore (infra is imported,
+// not passed via ctx).
+//
+// Create Clip needs a USER token carrying the `clips:edit` scope, and the channel
+// must be LIVE (Twitch rejects the call otherwise). We clip in the BOT user's
+// context (apiClient.asUser) so the bot's own grant is used — the bot only has to
+// be a normal user with clips:edit, no broadcaster involvement. The clip needs a
+// few seconds to finish processing, but the returned URL is valid immediately.
+//
+// NOTE: a Twitch clip is capped at the STREAM resolution (≤1080p here) — a local
+// 4K copy is a separate capture (obs-websocket replay buffer / post-hoc archive),
+// tracked in the aitum-badge-initiative notes.
+
+let createFn = null;
+
+/**
+ * @param {{ apiClient: import('@twurple/api').ApiClient, broadcasterId: string, botUserId: string }} deps
+ */
+export function initClips({ apiClient, broadcasterId, botUserId }) {
+  createFn = () => apiClient.asUser(botUserId, (ctx) => ctx.clips.createClip({ channel: broadcasterId }));
+}
+
+/** Test seam: inject a fake clip creator that resolves to a clip id. */
+export function initClipsWith(fn) {
+  createFn = fn;
+}
+
+/** True once a clip creator (real or injected) is wired. */
+export function clipsReady() {
+  return typeof createFn === 'function';
+}
+
+/**
+ * Create a clip of the channel's live stream.
+ * @returns {Promise<{ id: string, url: string }>}
+ */
+export async function createChannelClip() {
+  if (!createFn) throw new Error('clips service not initialized');
+  const id = await createFn();
+  return { id, url: `https://clips.twitch.tv/${id}` };
+}

--- a/src/twitch/sender.js
+++ b/src/twitch/sender.js
@@ -1,0 +1,65 @@
+// Outbound chat sender — the single seam every bot-authored message flows
+// through, so the transport is swappable without touching call sites.
+//
+//   mode 'irc'   → twurple ChatClient (chat:edit). The historical path.
+//   mode 'helix' → Send Chat Message API via an APP access token
+//                  (apiClient.chat.sendChatMessageAsApp). This is the ONLY way a
+//                  bot earns the Twitch "Chat Bot" badge on its own messages
+//                  (dev.twitch.tv/docs/chat) — a user-token / IRC send never gets
+//                  it, which is why the badge needs this seam and not a setting.
+//
+// Requirements for helix mode (enforced by Twitch, NOT the library — twurple's
+// own JSDoc on sendChatMessageAsApp says the scopes "can not be checked by the
+// library"): the bot user must have granted `user:bot` + `user:write:chat`, and
+// the broadcaster must have granted `channel:bot` OR the bot must be a moderator
+// in the channel. The app token itself is minted from the client id/secret by the
+// existing RefreshingAuthProvider — no new auth wiring, and no inbound surface, so
+// the outbound-only invariant (§B) still holds.
+//
+// Reading always stays on the ChatClient; only sending switches here. Mute is
+// applied by callers (the handler's per-command `bypassMute` lives there), so the
+// sender is transport-only and never swallows a message on its own.
+
+/**
+ * @param {{
+ *   mode?: 'irc' | 'helix',
+ *   chat: { say: Function, action: Function },
+ *   apiClient: import('@twurple/api').ApiClient,
+ *   channel: string,
+ *   broadcasterId: string,
+ *   botUserId: string,
+ *   logger?: any,
+ * }} deps
+ * @returns {{ say: (text: string) => Promise<void>, action: (text: string) => Promise<void>, mode: string }}
+ */
+export function createSender({ mode = 'irc', chat, apiClient, channel, broadcasterId, botUserId, logger = console }) {
+  const helix = mode === 'helix';
+
+  async function say(text) {
+    try {
+      if (helix) {
+        await apiClient.chat.sendChatMessageAsApp(botUserId, broadcasterId, text);
+      } else {
+        await chat.say(channel, text);
+      }
+    } catch (err) {
+      // Never throw at a send site — a failed line must not abort a command or a
+      // draw tick. Warn so a misconfigured helix grant (401/403) is visible.
+      logger.warn?.('chat send failed', { mode, err: String(err) });
+    }
+  }
+
+  // The Send Chat Message API has no `/me` action, so in helix mode an action
+  // degrades to a normal message — the content still lands (and carries the
+  // badge); only the italic styling is lost. IRC keeps true actions.
+  async function action(text) {
+    if (helix) return say(text);
+    try {
+      await chat.action(channel, text);
+    } catch {
+      /* actions are cosmetic — never surface a failure */
+    }
+  }
+
+  return { say, action, mode };
+}

--- a/test/e2e/commands.e2e.test.js
+++ b/test/e2e/commands.e2e.test.js
@@ -30,7 +30,7 @@ const runOrSkip = host ? test : test.skip;
 const GAME_PATHS = [
   'players', 'usernames', 'wallets', 'markets', 'marketSuggestions', 'drops',
   'raids', 'bosses', 'facts', 'factSubmissions', 'todos', 'duels', 'trades',
-  'leaderboard', 'items', 'counters',
+  'leaderboard', 'items', 'counters', 'clipSync',
 ];
 async function wipeGame() {
   await Promise.all(GAME_PATHS.map((p) => database().ref(p).remove().catch(() => {})));

--- a/test/e2e/harness.js
+++ b/test/e2e/harness.js
@@ -46,14 +46,14 @@ export function user(id, opts = {}) {
  */
 export function makeBot({ channel = CHANNEL, botUserId = BOT_USER_ID } = {}) {
   const replies = [];
-  const chat = {
-    say: async (_ch, text) => { replies.push({ kind: 'say', text }); },
-    action: async (_ch, text) => { replies.push({ kind: 'action', text }); },
+  const sender = {
+    say: async (text) => { replies.push({ kind: 'say', text }); },
+    action: async (text) => { replies.push({ kind: 'action', text }); },
   };
 
   async function send(u, text) {
     replies.length = 0;
-    const handler = createMessageHandler({ chat, channel, botUserId, logger: silentLogger, onActivity() {} });
+    const handler = createMessageHandler({ sender, channel, botUserId, logger: silentLogger, onActivity() {} });
     const msg = {
       userInfo: {
         userId: u.id,
@@ -68,5 +68,5 @@ export function makeBot({ channel = CHANNEL, botUserId = BOT_USER_ID } = {}) {
     return replies.map((r) => r.text).join(' ⏎ ');
   }
 
-  return { send, replies, chat };
+  return { send, replies, sender };
 }

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -13,7 +13,8 @@ import { openMarket } from '../../src/db/market.js';
 import { setDrop } from '../../src/db/drops.js';
 import { setupRaidWeek, enlist } from '../../src/db/raid.js';
 import { seedCuratedFacts } from '../../src/db/facts.js';
-import { getRaidPointer } from '../../src/db/configStore.js';
+import { getRaidPointer, getConfig, setLive } from '../../src/db/configStore.js';
+import { initClipsWith } from '../../src/twitch/clips.js';
 import { defaultBoss } from '../../src/content/bosses.js';
 import { until } from './harness.js';
 
@@ -60,6 +61,28 @@ export const fixtures = { player, loot, wallet, market, drop, facts, leaderboard
 
 // ── scenarios (one per command primary name) ─────────────────────────────────
 export const SCENARIOS = [
+  {
+    command: 'clip', title: 'clips the live stream and posts a link',
+    run: async ({ bot, u }) => {
+      const alice = u('e2e_clip', { login: 'alice', name: 'Alice' });
+      initClipsWith(async () => 'TestClipId123'); // fake Helix Create Clip
+      await setLive(true, 'test');
+      await until(() => getConfig().live === true); // mirror is async
+      const reply = await bot.send(alice, '!clip');
+      assert.match(reply, /clips\.twitch\.tv\/TestClipId123/);
+      await setLive(false, 'test'); // reset shared live state for later scenarios
+    },
+  },
+  {
+    command: 'start', title: 'a mod drops a clip-sync anchor',
+    run: async ({ bot, u }) => {
+      const mod = u('e2e_start', { login: 'nikki', name: 'Nikki', mod: true });
+      const reply = await bot.send(mod, '!start'); // not live → anchor only, no marker
+      assert.match(reply, /sync point set/i);
+      const snap = await database().ref('clipSync').get();
+      assert.ok(snap.exists(), 'a clipSync anchor was written');
+    },
+  },
   {
     command: 'create', title: 'a subscriber makes a hero',
     run: async ({ bot, u }) => {

--- a/test/mute.test.js
+++ b/test/mute.test.js
@@ -19,9 +19,9 @@ const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
 
 // Records outbound chat so we can assert on what the bot said (or didn't).
 const sent = [];
-const fakeChat = {
-  say: (_ch, text) => { sent.push(text); return Promise.resolve(); },
-  action: (_ch, text) => { sent.push(text); return Promise.resolve(); },
+const fakeSender = {
+  say: (text) => { sent.push(text); return Promise.resolve(); },
+  action: (text) => { sent.push(text); return Promise.resolve(); },
 };
 
 let handler;
@@ -48,7 +48,7 @@ before(async () => {
   if (!host) return;
   initFirebase();
   await startConfigMirror(noopLogger);
-  handler = createMessageHandler({ chat: fakeChat, channel: '#test', botUserId: 'bot', logger: noopLogger, onActivity() {} });
+  handler = createMessageHandler({ sender: fakeSender, channel: '#test', botUserId: 'bot', logger: noopLogger, onActivity() {} });
 });
 
 after(async () => {


### PR DESCRIPTION
Supports the okra-clip-archiver initiative plus the Twitch Chat Bot badge. Nothing is enabled by default — the badge and clip paths are opt-in.

## What's here
- **Chat Bot badge send-path** — new `src/twitch/sender.js` is the single seam every outbound message flows through. `TWITCH_SEND_MODE=irc` (default) keeps today's IRC behaviour byte-for-byte; `helix` sends via Helix `sendChatMessageAsApp` (app token) to earn the badge. Reading always stays on IRC. All 5 send sites refactored.
- **`!clip`** — Helix Create Clip in the bot's user context (needs `clips:edit`), live-gated, 60s/user cooldown.
- **`!start` / `!slate`** (mod-only) — the clapperboard: writes a `clipSync/{id}` sync anchor for the archiver, plus a best-effort marker clip when live. Adds a public-read `clipSync` rule + `PATHS.clipSync/clipSession`.
- **Dev tooling** — `scripts/get-token.mjs` (OAuth token with the needed scopes), `scripts/list-clips.mjs` (clip-timestamp diagnostic), and `scripts/dev-live.sh` / `npm run dev:live` (run the real bot against a channel via the emulator — safe from prod: separate DB + `.tokens-dev` store).

## Tests
e2e scenarios added for `!clip` and `!start`; the `sender` rename is threaded through the mute/e2e harness. **rules 44 · e2e 28 · emulator 48 — all green.**

## To activate later
- Badge: re-issue the bot token with `user:bot user:write:chat` (+ `clips:edit`), mod the bot (or broadcaster grants `channel:bot`), set `TWITCH_SEND_MODE=helix`.
- `firebase deploy --only database` to publish the `clipSync` read rule for the archiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)