### PR TITLE
Default chat send to Helix (Chat Bot badge) with automatic IRC fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,9 +48,15 @@ FIREBASE_PROJECT_ID=okrafans
 # INSTANCE_ID=
 # debug | info | warn | error
 LOG_LEVEL=info
-# Chat send transport: 'irc' (default — twurple ChatClient) or 'helix' (Send Chat
-# Message API via an app token, which earns the Twitch Chat Bot badge). 'helix'
-# requires the bot token to include `user:bot user:write:chat` AND the bot to be a
-# moderator in the channel (or the broadcaster to grant `channel:bot`). Reading
-# always stays on IRC. See https://dev.twitch.tv/docs/chat/.
-# TWITCH_SEND_MODE=irc
+# Chat send transport. Default 'auto': send via the Helix Send Chat Message API
+# (an app token) so the bot carries the Twitch Chat Bot badge, and automatically
+# fall back to IRC if Twitch refuses — the bot can never go silent because a grant
+# is missing. 'helix' forces the API (failures are surfaced, not worked around);
+# 'irc' pins the old ChatClient path.
+#
+# For the badge, Twitch requires ALL of:
+#   • the bot token includes `user:bot` and `user:write:chat`
+#   • the bot is a MODERATOR in the channel (or the broadcaster grants `channel:bot`)
+# Without those the API call is REFUSED outright — it isn't just a missing badge.
+# Reading always stays on IRC. See https://dev.twitch.tv/docs/chat/.
+# TWITCH_SEND_MODE=auto

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const HEARTBEAT_FILE = process.env.HEARTBEAT_FILE || '/tmp/kennybot.heartbeat';
 // than a liveness ping: it records whether the Twitch chat socket is actually
 // connected, so a "process alive but chat wedged" zombie reads unhealthy and the
 // orchestrator restarts it, rather than the check passing on a dead connection.
-const health = { version: APP_VERSION, chatConnected: false, live: false };
+const health = { version: APP_VERSION, chatConnected: false, live: false, sendMode: null };
 
 // Shutdown is wired up inside main(); module scope holds the reference so signal
 // handlers and the lease-lost callback can trigger it cleanly.
@@ -200,14 +200,15 @@ async function main() {
   // ── Chat ──
   const chat = new ChatClient({ authProvider, channels: [channel] });
 
-  // Outbound sender (src/twitch/sender.js). 'irc' sends via the ChatClient;
-  // 'helix' sends via the Send Chat Message API on an app token to earn the Chat
-  // Bot badge. Default stays 'irc' so behaviour is byte-for-byte unchanged until
-  // the bot token carries the extra scopes (user:bot, user:write:chat) and the
-  // flag is flipped — reading always stays on the ChatClient either way.
-  const sendMode = (process.env.TWITCH_SEND_MODE || 'irc').toLowerCase() === 'helix' ? 'helix' : 'irc';
-  if ((process.env.TWITCH_SEND_MODE || 'irc').toLowerCase() !== sendMode) {
-    logger.warn('unknown TWITCH_SEND_MODE — using irc', { value: process.env.TWITCH_SEND_MODE });
+  // Outbound sender (src/twitch/sender.js). Default 'auto': prefer the Helix
+  // Send Chat Message API (the only path that earns the Chat Bot badge) and fall
+  // back to IRC if Twitch refuses the grant, so the bot can never go silent
+  // because a token or mod status is missing. Reading always stays on the
+  // ChatClient. 'helix' forces it (failures surface); 'irc' pins the old path.
+  const rawSendMode = (process.env.TWITCH_SEND_MODE || 'auto').toLowerCase();
+  const sendMode = ['auto', 'helix', 'irc'].includes(rawSendMode) ? rawSendMode : 'auto';
+  if (rawSendMode !== sendMode) {
+    logger.warn('unknown TWITCH_SEND_MODE — using auto', { value: process.env.TWITCH_SEND_MODE });
   }
   const sender = createSender({
     mode: sendMode,
@@ -218,7 +219,7 @@ async function main() {
     botUserId,
     logger,
   });
-  logger.info('chat sender ready', { mode: sender.mode });
+  logger.info('chat sender ready', { mode: sender.mode, sending: sender.effectiveMode() });
 
   // Mute-aware wrapper for spontaneous (non-command) announcements — loot draws +
   // the auto-drop scheduler. When a mod mutes the bot (`!mute`) these are
@@ -229,6 +230,7 @@ async function main() {
     say: (text) => (isChatMuted() ? Promise.resolve() : sender.say(text)),
     action: (text) => (isChatMuted() ? Promise.resolve() : sender.action(text)),
   };
+  health.sendMode = sender.effectiveMode();
   chat.onMessage(createMessageHandler({ sender, channel, botUserId, logger, onActivity: touchHeartbeat }));
   chat.onConnect(() => {
     health.chatConnected = true;

--- a/src/twitch/sender.js
+++ b/src/twitch/sender.js
@@ -1,28 +1,40 @@
 // Outbound chat sender — the single seam every bot-authored message flows
 // through, so the transport is swappable without touching call sites.
 //
-//   mode 'irc'   → twurple ChatClient (chat:edit). The historical path.
-//   mode 'helix' → Send Chat Message API via an APP access token
-//                  (apiClient.chat.sendChatMessageAsApp). This is the ONLY way a
-//                  bot earns the Twitch "Chat Bot" badge on its own messages
-//                  (dev.twitch.tv/docs/chat) — a user-token / IRC send never gets
-//                  it, which is why the badge needs this seam and not a setting.
+//   'helix' → Send Chat Message API on an APP access token
+//             (apiClient.chat.sendChatMessageAsApp). The ONLY way a bot earns the
+//             Twitch "Chat Bot" badge on its own messages (dev.twitch.tv/docs/chat):
+//             an IRC / user-token send never gets it.
+//   'irc'   → twurple ChatClient (chat:edit). The historical path.
+//   'auto'  → DEFAULT. Try helix; if Twitch rejects it as unauthorized, fall back
+//             to IRC for the rest of the run and say exactly why.
 //
-// Requirements for helix mode (enforced by Twitch, NOT the library — twurple's
-// own JSDoc on sendChatMessageAsApp says the scopes "can not be checked by the
-// library"): the bot user must have granted `user:bot` + `user:write:chat`, and
-// the broadcaster must have granted `channel:bot` OR the bot must be a moderator
-// in the channel. The app token itself is minted from the client id/secret by the
-// existing RefreshingAuthProvider — no new auth wiring, and no inbound surface, so
-// the outbound-only invariant (§B) still holds.
+// Why 'auto' is the default rather than plain 'helix': helix sending is not just
+// "IRC plus a badge" — Twitch REFUSES the call unless the bot user granted
+// `user:bot` + `user:write:chat` AND the broadcaster granted `channel:bot` (or the
+// bot is a moderator there). Defaulting to bare 'helix' would make a bot with an
+// older token or without mod status go completely SILENT. With 'auto' the bot
+// always talks, and upgrades itself to the badge the moment the grants are in
+// place. Set TWITCH_SEND_MODE=helix to force it (and surface failures loudly), or
+// =irc to pin the old path.
 //
-// Reading always stays on the ChatClient; only sending switches here. Mute is
-// applied by callers (the handler's per-command `bypassMute` lives there), so the
-// sender is transport-only and never swallows a message on its own.
+// NOTE: the ChatClient is NOT removable — it is how the bot RECEIVES chat. Only
+// the send direction is switchable, so keeping the IRC fallback costs nothing.
+//
+// Mute is applied by callers (the handler's per-command `bypassMute` lives there),
+// so the sender is transport-only and never swallows a message on its own.
+
+/** Twitch says "you may not send this" — a grant problem, not a transient blip. */
+export function isAuthzFailure(err) {
+  const status = err?.statusCode ?? err?.status ?? err?.response?.status;
+  if (status === 401 || status === 403) return true;
+  const text = String(err?.body ?? err?.message ?? err);
+  return /\b40[13]\b/.test(text) || /unauthoriz|forbidden|missing scope|not permitted/i.test(text);
+}
 
 /**
  * @param {{
- *   mode?: 'irc' | 'helix',
+ *   mode?: 'auto' | 'irc' | 'helix',
  *   chat: { say: Function, action: Function },
  *   apiClient: import('@twurple/api').ApiClient,
  *   channel: string,
@@ -30,36 +42,54 @@
  *   botUserId: string,
  *   logger?: any,
  * }} deps
- * @returns {{ say: (text: string) => Promise<void>, action: (text: string) => Promise<void>, mode: string }}
+ * @returns {{ say: Function, action: Function, mode: string, effectiveMode: () => string }}
  */
-export function createSender({ mode = 'irc', chat, apiClient, channel, broadcasterId, botUserId, logger = console }) {
-  const helix = mode === 'helix';
+export function createSender({ mode = 'auto', chat, apiClient, channel, broadcasterId, botUserId, logger = console }) {
+  // What we're actually using right now — 'helix' until Twitch refuses it.
+  let current = mode === 'irc' ? 'irc' : 'helix';
+  const allowFallback = mode === 'auto';
+
+  async function sendIrc(text) {
+    try {
+      await chat.say(channel, text);
+    } catch (err) {
+      logger.warn?.('chat send failed', { mode: 'irc', err: String(err) });
+    }
+  }
 
   async function say(text) {
+    if (current === 'irc') return sendIrc(text);
     try {
-      if (helix) {
-        await apiClient.chat.sendChatMessageAsApp(botUserId, broadcasterId, text);
-      } else {
-        await chat.say(channel, text);
-      }
+      await apiClient.chat.sendChatMessageAsApp(botUserId, broadcasterId, text);
     } catch (err) {
-      // Never throw at a send site — a failed line must not abort a command or a
-      // draw tick. Warn so a misconfigured helix grant (401/403) is visible.
-      logger.warn?.('chat send failed', { mode, err: String(err) });
+      if (allowFallback && isAuthzFailure(err)) {
+        current = 'irc';
+        logger.warn?.(
+          'helix chat send refused — falling back to IRC for this run (so no Chat Bot badge). ' +
+            'Fix: re-issue the bot token with user:bot + user:write:chat, and make the bot a ' +
+            'moderator in the channel (or have the broadcaster grant channel:bot).',
+          { err: String(err) },
+        );
+        return sendIrc(text); // the message still goes out
+      }
+      // Transient (rate limit, 5xx) or forced helix: report, don't downgrade.
+      logger.warn?.('chat send failed', { mode: current, err: String(err) });
     }
+    return undefined;
   }
 
   // The Send Chat Message API has no `/me` action, so in helix mode an action
   // degrades to a normal message — the content still lands (and carries the
   // badge); only the italic styling is lost. IRC keeps true actions.
   async function action(text) {
-    if (helix) return say(text);
+    if (current !== 'irc') return say(text);
     try {
       await chat.action(channel, text);
     } catch {
       /* actions are cosmetic — never surface a failure */
     }
+    return undefined;
   }
 
-  return { say, action, mode };
+  return { say, action, mode, effectiveMode: () => current };
 }

--- a/test/rules/sender.test.js
+++ b/test/rules/sender.test.js
@@ -1,0 +1,111 @@
+// Sender transport tests. The important guarantee: defaulting to the Helix send
+// (for the Chat Bot badge) must never be able to silence the bot — if Twitch
+// refuses the grant, the message still reaches chat over IRC.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSender, isAuthzFailure } from '../../src/twitch/sender.js';
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+/** Fakes for the two transports, recording what each was asked to send. */
+function harness({ helixError } = {}) {
+  const irc = [];
+  const helix = [];
+  const chat = {
+    say: async (_ch, text) => { irc.push(text); },
+    action: async (_ch, text) => { irc.push(`/me ${text}`); },
+  };
+  const apiClient = {
+    chat: {
+      sendChatMessageAsApp: async (_bot, _bc, text) => {
+        if (helixError) throw helixError;
+        helix.push(text);
+      },
+    },
+  };
+  return { irc, helix, chat, apiClient };
+}
+
+const build = (h, mode) =>
+  createSender({
+    mode,
+    chat: h.chat,
+    apiClient: h.apiClient,
+    channel: '#test',
+    broadcasterId: 'b1',
+    botUserId: 'u1',
+    logger: noopLogger,
+  });
+
+test('auto (default) sends over helix while Twitch allows it', async () => {
+  const h = harness();
+  const s = build(h);
+  await s.say('hello');
+  assert.deepEqual(h.helix, ['hello']);
+  assert.deepEqual(h.irc, []);
+  assert.equal(s.effectiveMode(), 'helix');
+});
+
+test('auto falls back to IRC when helix is refused — the message still lands', async () => {
+  const err = Object.assign(new Error('Forbidden'), { statusCode: 403 });
+  const h = harness({ helixError: err });
+  const s = build(h);
+  await s.say('hello');
+  assert.deepEqual(h.irc, ['hello'], 'the line must not be lost');
+  assert.equal(s.effectiveMode(), 'irc', 'downgraded for the rest of the run');
+});
+
+test('after falling back, later sends go straight to IRC', async () => {
+  const h = harness({ helixError: Object.assign(new Error('Unauthorized'), { statusCode: 401 }) });
+  const s = build(h);
+  await s.say('first');
+  await s.say('second');
+  assert.deepEqual(h.irc, ['first', 'second']);
+});
+
+test('a transient helix error does NOT downgrade the transport', async () => {
+  const h = harness({ helixError: Object.assign(new Error('server error'), { statusCode: 500 }) });
+  const s = build(h);
+  await s.say('hello');
+  assert.equal(s.effectiveMode(), 'helix', '5xx is a blip, not a grant problem');
+  assert.deepEqual(h.irc, [], 'no double-send on a transient failure');
+});
+
+test('mode=helix never falls back (failures stay visible)', async () => {
+  const h = harness({ helixError: Object.assign(new Error('Forbidden'), { statusCode: 403 }) });
+  const s = build(h, 'helix');
+  await s.say('hello');
+  assert.equal(s.effectiveMode(), 'helix');
+  assert.deepEqual(h.irc, [], 'forced helix must not silently reroute');
+});
+
+test('mode=irc pins the old path and keeps true /me actions', async () => {
+  const h = harness();
+  const s = build(h, 'irc');
+  await s.say('hello');
+  await s.action('waves');
+  assert.deepEqual(h.helix, []);
+  assert.deepEqual(h.irc, ['hello', '/me waves']);
+});
+
+test('helix actions degrade to plain messages (the API has no /me)', async () => {
+  const h = harness();
+  const s = build(h);
+  await s.action('waves');
+  assert.deepEqual(h.helix, ['waves'], 'content lands, styling is lost');
+});
+
+test('a send never throws, whatever the transport does', async () => {
+  const h = harness({ helixError: Object.assign(new Error('403'), { statusCode: 403 }) });
+  h.chat.say = async () => { throw new Error('irc down too'); };
+  const s = build(h);
+  await assert.doesNotReject(() => s.say('hello'));
+});
+
+test('isAuthzFailure distinguishes grant problems from blips', () => {
+  assert.equal(isAuthzFailure({ statusCode: 401 }), true);
+  assert.equal(isAuthzFailure({ statusCode: 403 }), true);
+  assert.equal(isAuthzFailure(new Error('HTTP 403 Forbidden')), true);
+  assert.equal(isAuthzFailure({ statusCode: 500 }), false);
+  assert.equal(isAuthzFailure(new Error('socket hang up')), false);
+});


### PR DESCRIPTION
Makes the Chat Bot badge the default path, safely.

`TWITCH_SEND_MODE` now defaults to **`auto`**: send via the Helix Send Chat Message API (the only path that earns the badge) and fall back to IRC if Twitch refuses.

## Why not just default to `helix`
Helix sending isn't "IRC plus a badge" — Twitch **refuses the call outright** unless:
- the bot token carries `user:bot` + `user:write:chat`, **and**
- the bot is a **moderator** in the channel (or the broadcaster granted `channel:bot`)

So a bare `helix` default would make a bot with an older token or no mod status go **completely silent**. With `auto` the bot always talks, logs exactly which grant is missing, and upgrades itself to the badge once the grants land.

Only a 401/403-style refusal downgrades the transport — a 5xx or rate limit is treated as transient, so a blip can't cost the badge for the whole run. The effective transport is logged at boot and exposed in the health snapshot.

`helix` still forces the API (failures surface); `irc` pins the old path.

## On removing twurple
Not possible, and not desirable: the `ChatClient` is how the bot **receives** chat. Only the send direction is switchable, so keeping IRC as the fallback costs nothing.

## Tests
New `test/rules/sender.test.js` (9 cases): helix while permitted, fallback still delivers the message, stickiness after downgrade, 5xx does *not* downgrade, both forced modes, `/me` degradation, and never-throws. **53 rules · 28 e2e · 48 emulator — all green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)