### PR TITLE
!clip: local full-quality capture via obs-websocket, local-only by default (CLIP_MODE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,20 +43,30 @@ FIREBASE_PROJECT_ID=okrafans
 # credentials are needed. Leave EMPTY in production.
 # FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000
 
-# ─── Local capture (OPTIONAL — the full-quality half of !clip) ───
-# A Twitch clip is capped at your STREAM resolution, so !clip alone can't give you
-# a 4K keepsake. Point this at the streamer's OBS (obs-websocket, built into OBS
-# 28+ under Tools → WebSocket Server Settings) and !clip will ALSO save the replay
-# buffer locally at full recording quality — which okra-clip-archiver then picks up.
+# ─── !clip behaviour ───
+# What !clip does. A Twitch clip is capped at your STREAM resolution, so it can
+# never be a 4K keepsake — hence the default is the LOCAL capture, not Twitch:
+#   local  — trigger the streamer's OBS/Aitum capture only; nothing is posted to
+#            Twitch. Needs OBS_WEBSOCKET_URL below, or !clip has nothing to do.
+#   twitch — Twitch clip only (Helix Create Clip; needs clips:edit + a live channel)
+#   both   — do each; the reply carries the Twitch link plus a local-capture note
+# An unrecognised value falls back to 'local' with a warning at boot.
+# CLIP_MODE=local
+
+# ─── Local capture (the default half of !clip) ───
+# Point this at the streamer's OBS (obs-websocket, built into OBS 28+ under
+# Tools → WebSocket Server Settings) and !clip saves the replay buffer locally at
+# full recording quality — which okra-clip-archiver then picks up.
 #
 # Reach it over the tailnet, e.g. ws://100.82.136.16:4455. Leave unset to disable;
-# every failure here is non-fatal (the Twitch clip is made regardless).
+# every failure here is non-fatal — !clip reports it in chat and moves on.
 # OBS_WEBSOCKET_URL=
 # OBS_WEBSOCKET_PASSWORD=
 # OBS_TIMEOUT_MS=8000
 # Channel-wide minimum gap between local captures (ms). !clip's own cooldown is
 # PER-USER, so without this a burst of viewers each firing !clip would write one
-# huge file apiece. Twitch clips stay ungated — only the local save is limited.
+# huge file apiece. Only the local save is gated; Twitch clips (CLIP_MODE=twitch
+# or both) stay ungated because they cost nothing to make.
 # CAPTURE_MIN_INTERVAL_MS=60000
 # Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.
 # CAPTURE_BACKEND=obs-websocket

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,20 @@ FIREBASE_PROJECT_ID=okrafans
 # credentials are needed. Leave EMPTY in production.
 # FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000
 
+# ─── Local capture (OPTIONAL — the full-quality half of !clip) ───
+# A Twitch clip is capped at your STREAM resolution, so !clip alone can't give you
+# a 4K keepsake. Point this at the streamer's OBS (obs-websocket, built into OBS
+# 28+ under Tools → WebSocket Server Settings) and !clip will ALSO save the replay
+# buffer locally at full recording quality — which okra-clip-archiver then picks up.
+#
+# Reach it over the tailnet, e.g. ws://100.82.136.16:4455. Leave unset to disable;
+# every failure here is non-fatal (the Twitch clip is made regardless).
+# OBS_WEBSOCKET_URL=
+# OBS_WEBSOCKET_PASSWORD=
+# OBS_TIMEOUT_MS=8000
+# Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.
+# CAPTURE_BACKEND=obs-websocket
+
 # ─── Runtime ───
 # Stable id for the single-instance lease (defaults to hostname:pid if unset).
 # INSTANCE_ID=

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ FIREBASE_PROJECT_ID=okrafans
 # OBS_WEBSOCKET_URL=
 # OBS_WEBSOCKET_PASSWORD=
 # OBS_TIMEOUT_MS=8000
+# Channel-wide minimum gap between local captures (ms). !clip's own cooldown is
+# PER-USER, so without this a burst of viewers each firing !clip would write one
+# huge file apiece. Twitch clips stay ungated — only the local save is limited.
+# CAPTURE_MIN_INTERVAL_MS=60000
 # Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.
 # CAPTURE_BACKEND=obs-websocket
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ gitignored). Secrets arrive at runtime, never baked into the image.
 | `FIREBASE_DATABASE_URL` / `FIREBASE_PROJECT_ID` | RTDB URL + project (`okrafans`) |
 | `FIREBASE_DATABASE_EMULATOR_HOST` | *local only* — targets the emulator; leave empty in prod |
 | `TOKEN_STORE_DIR` | dir for the persisted refresh-token store (the `/data` volume) |
+| `TWITCH_SEND_MODE` | chat transport — `auto` (default, Helix + IRC fallback) · `helix` (Chat Bot badge) · `irc` |
+| `CLIP_MODE` | what `!clip` does — `local` (**default**: OBS/Aitum capture only, nothing posted to Twitch) · `twitch` · `both` |
+| `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` | the streamer's OBS (obs-websocket, over the tailnet) — required for the local capture |
+| `OBS_TIMEOUT_MS` / `CAPTURE_MIN_INTERVAL_MS` / `CAPTURE_BACKEND` | *optional* capture knobs — request deadline, channel-wide gap between local saves, backend |
 | `INSTANCE_ID` / `LOG_LEVEL` / `HEARTBEAT_FILE` | optional runtime knobs |
 
 ## Production (containerized, outbound-only)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import { TokenStore } from './src/db/tokenStore.js';
 import { buildAuth } from './src/twitch/auth.js';
 import { createSender } from './src/twitch/sender.js';
 import { initClips } from './src/twitch/clips.js';
+import { initCapture } from './src/integrations/capture.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
@@ -187,6 +188,10 @@ async function main() {
   // token needs clips:edit and the channel must be live; wired here so the !clip
   // command reaches it without threading the ApiClient through the chat handler.
   initClips({ apiClient, broadcasterId: channelUserId, botUserId });
+
+  // Local full-quality capture on the streamer's PC (obs-websocket over the
+  // tailnet). Optional: with no OBS_WEBSOCKET_URL, !clip just makes Twitch clips.
+  initCapture({}, logger);
 
   // ── Resolve-on-boot: advance raid phases by stored timestamps, never a timer
   //    a restart could lose (§H.5 / §L.1). Loop to catch up after downtime

--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ import { TokenStore } from './src/db/tokenStore.js';
 import { buildAuth } from './src/twitch/auth.js';
 import { createSender } from './src/twitch/sender.js';
 import { initClips } from './src/twitch/clips.js';
-import { initCapture } from './src/integrations/capture.js';
+import { initCapture, captureReady } from './src/integrations/capture.js';
+// The !clip command owns CLIP_MODE; index.js only resolves it once at boot so a
+// typo is caught in the startup log rather than on the first viewer's !clip.
+import { resolveClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
@@ -45,7 +48,7 @@ const HEARTBEAT_FILE = process.env.HEARTBEAT_FILE || '/tmp/kennybot.heartbeat';
 // than a liveness ping: it records whether the Twitch chat socket is actually
 // connected, so a "process alive but chat wedged" zombie reads unhealthy and the
 // orchestrator restarts it, rather than the check passing on a dead connection.
-const health = { version: APP_VERSION, chatConnected: false, live: false, sendMode: null };
+const health = { version: APP_VERSION, chatConnected: false, live: false, sendMode: null, clipMode: null };
 
 // Shutdown is wired up inside main(); module scope holds the reference so signal
 // handlers and the lease-lost callback can trigger it cleanly.
@@ -190,8 +193,25 @@ async function main() {
   initClips({ apiClient, broadcasterId: channelUserId, botUserId });
 
   // Local full-quality capture on the streamer's PC (obs-websocket over the
-  // tailnet). Optional: with no OBS_WEBSOCKET_URL, !clip just makes Twitch clips.
+  // tailnet), reached whenever !clip's mode includes the local half.
   initCapture({}, logger);
+
+  // What !clip actually does. Default 'local': trigger the streamer's OBS/Aitum
+  // capture and post NO Twitch clip — a Twitch clip is capped at the stream
+  // resolution, so the local recording is the copy worth keeping. 'twitch'
+  // restores the Helix-clip-only behaviour; 'both' does each.
+  const rawClipMode = (process.env.CLIP_MODE || '').toLowerCase();
+  const clipMode = resolveClipMode(rawClipMode);
+  if (rawClipMode && rawClipMode !== clipMode) {
+    logger.warn('unknown CLIP_MODE — using local', { value: process.env.CLIP_MODE });
+  }
+  health.clipMode = clipMode;
+  logger.info('clip mode', { mode: clipMode, localCapture: captureReady() });
+  if (clipMode === 'local' && !captureReady()) {
+    logger.warn(
+      '!clip has nothing to do: CLIP_MODE=local but no capture backend is configured — set OBS_WEBSOCKET_URL, or CLIP_MODE=twitch/both',
+    );
+  }
 
   // ── Resolve-on-boot: advance raid phases by stored timestamps, never a timer
   //    a restart could lose (§H.5 / §L.1). Loop to catch up after downtime

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -25,19 +25,19 @@ export function resolveClipMode(raw = process.env.CLIP_MODE) {
 }
 
 /**
- * Chat wording for a local-only capture. Deliberately never names the saved file
- * — that's the streamer's disk layout, not something to post in public chat.
+ * Chat wording for a local-only capture: a bare confirmation and nothing else.
+ * Viewers get no signal about HOW the clip is made — no file path, no OBS, no
+ * second machine, not even that a local recording exists. Every diagnostic
+ * detail belongs in the log (see integrations/capture.js), never in public chat.
  */
 function localOnlyReply(res) {
-  if (res?.ok) {
-    return res.started
-      ? "🎬 the recording buffer wasn't running — I've started it, so the next !clip will catch it."
-      : '🎬 clipped it! Saved a full-quality local capture.';
-  }
+  if (res?.ok && !res.started) return '🎬 clipped it!';
   if (res?.reason === 'rate-limited') {
-    return `🎬 just captured one — try again in ${Math.ceil((res.retryInMs || 0) / 1000)}s.`;
+    return `🎬 just clipped that — try again in ${Math.ceil((res.retryInMs || 0) / 1000)}s.`;
   }
-  return "couldn't reach the recording PC just now — try again in a moment.";
+  // `started` means the buffer wasn't running, so nothing was actually saved.
+  // To a viewer that's indistinguishable from any other miss — say the same thing.
+  return "couldn't clip that one — try again in a moment.";
 }
 
 export default {
@@ -50,12 +50,10 @@ export default {
     let twitch = mode !== 'local' && clipsReady();
     const local = mode !== 'twitch' && captureReady();
 
+    // One wording for every unconfigured mode — which half is missing is an
+    // operator concern (the boot log spells it out), not a thing to tell chat.
     if (!twitch && !local) {
-      reply(
-        mode === 'local'
-          ? `@${user.displayName} local clip capture isn't set up right now.`
-          : `@${user.displayName} clipping isn't set up right now.`,
-      );
+      reply(`@${user.displayName} clipping isn't set up right now.`);
       return;
     }
     // Twitch's Create Clip only works while live. The local replay buffer doesn't
@@ -81,15 +79,8 @@ export default {
 
     try {
       const { url } = await createChannelClip();
-      const res = await capture;
-      // `started` means the replay buffer wasn't running and we just turned it on
-      // — nothing was captured this time, but the next !clip will have content.
-      const note = res?.ok
-        ? res.started
-          ? ' (local recording buffer just started — the next !clip will capture it too)'
-          : ' (+ full-quality local capture saved)'
-        : '';
-      reply(`@${user.displayName} 🎬 clipped it! ${url}${note}`);
+      await capture; // settle the local save so its outcome still reaches the log
+      reply(`@${user.displayName} 🎬 clipped it! ${url}`);
     } catch (err) {
       logger?.warn?.('clip failed', { userId: user.id, err: String(err) });
       await capture; // let the local save settle so its result is still logged

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -1,37 +1,91 @@
-// !clip — create a Twitch clip of the last ~30s of the live stream (Helix Create
-// Clip). Open to everyone with a per-user cooldown; only works while live. The
-// Twitch clip is capped at the stream resolution — a local high-res / 4K copy is a
-// separate capture (obs-websocket replay buffer / post-hoc archive).
+// !clip — grab the last ~30–60s of the stream.
+//
+// TWO independent halves, selected by CLIP_MODE:
+//   local  (default) — tell the streamer's OBS/Aitum to save its replay buffer at
+//                      full recording quality. Nothing is posted to Twitch.
+//   twitch           — Helix Create Clip only (the original behaviour).
+//   both             — do each; the reply carries the Twitch link plus a note.
+//
+// Local is the default because a Twitch clip is capped at the STREAM resolution
+// (≤1080p here) while the local recording is whatever the camera actually shot —
+// the high-quality copy is the point of the command.
 import { getConfig } from '../db/configStore.js';
 import { createChannelClip, clipsReady } from '../twitch/clips.js';
 import { triggerCapture, captureReady } from '../integrations/capture.js';
+
+export const CLIP_MODES = ['local', 'twitch', 'both'];
+
+/**
+ * Resolve CLIP_MODE, defaulting to 'local'. An unrecognised value falls back to
+ * the default rather than failing boot — index.js warns about it once at startup.
+ */
+export function resolveClipMode(raw = process.env.CLIP_MODE) {
+  const v = String(raw ?? '').trim().toLowerCase();
+  return CLIP_MODES.includes(v) ? v : 'local';
+}
+
+/**
+ * Chat wording for a local-only capture. Deliberately never names the saved file
+ * — that's the streamer's disk layout, not something to post in public chat.
+ */
+function localOnlyReply(res) {
+  if (res?.ok) {
+    return res.started
+      ? "🎬 the recording buffer wasn't running — I've started it, so the next !clip will catch it."
+      : '🎬 clipped it! Saved a full-quality local capture.';
+  }
+  if (res?.reason === 'rate-limited') {
+    return `🎬 just captured one — try again in ${Math.ceil((res.retryInMs || 0) / 1000)}s.`;
+  }
+  return "couldn't reach the recording PC just now — try again in a moment.";
+}
 
 export default {
   names: ['clip'],
   mod: false,
   cooldownMs: 60_000, // per-user: a viewer can clip at most once a minute
-  help: '!clip — clip the last ~30s of the stream (posts a Twitch clip link)',
+  help: '!clip — clip the last ~30s of the stream',
   async run({ user, reply, logger }) {
-    if (!clipsReady()) {
-      reply(`@${user.displayName} clipping isn't set up right now.`);
+    const mode = resolveClipMode();
+    let twitch = mode !== 'local' && clipsReady();
+    const local = mode !== 'twitch' && captureReady();
+
+    if (!twitch && !local) {
+      reply(
+        mode === 'local'
+          ? `@${user.displayName} local clip capture isn't set up right now.`
+          : `@${user.displayName} clipping isn't set up right now.`,
+      );
       return;
     }
-    if (!getConfig().live) {
-      reply(`@${user.displayName} I can only clip while the stream is live!`);
+    // Twitch's Create Clip only works while live. The local replay buffer doesn't
+    // care — OBS can be recording with nothing streamed — so an offline !clip is
+    // still worth doing locally; we just drop the Twitch half.
+    if (twitch && !getConfig().live) {
+      if (!local) {
+        reply(`@${user.displayName} I can only clip while the stream is live!`);
+        return;
+      }
+      twitch = false;
+    }
+
+    // Fire the local capture FIRST and in parallel: the replay buffer holds the
+    // last N seconds, so the sooner it's told to save, the less the moment has
+    // aged out of it. Its failure never affects the Twitch clip.
+    const capture = local ? triggerCapture(logger) : null;
+
+    if (!twitch) {
+      reply(`@${user.displayName} ${localOnlyReply(await capture)}`);
       return;
     }
-    // Fire the local high-quality capture FIRST and in parallel: the replay
-    // buffer holds the last N seconds, so the sooner it's told to save, the less
-    // the moment has aged out of the buffer. Its failure never affects the clip.
-    const capture = captureReady() ? triggerCapture(logger) : null;
 
     try {
       const { url } = await createChannelClip();
-      const local = await capture;
+      const res = await capture;
       // `started` means the replay buffer wasn't running and we just turned it on
       // — nothing was captured this time, but the next !clip will have content.
-      const note = local?.ok
-        ? local.started
+      const note = res?.ok
+        ? res.started
           ? ' (local recording buffer just started — the next !clip will capture it too)'
           : ' (+ full-quality local capture saved)'
         : '';

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -4,6 +4,7 @@
 // separate capture (obs-websocket replay buffer / post-hoc archive).
 import { getConfig } from '../db/configStore.js';
 import { createChannelClip, clipsReady } from '../twitch/clips.js';
+import { triggerCapture, captureReady } from '../integrations/capture.js';
 
 export default {
   names: ['clip'],
@@ -19,11 +20,18 @@ export default {
       reply(`@${user.displayName} I can only clip while the stream is live!`);
       return;
     }
+    // Fire the local high-quality capture FIRST and in parallel: the replay
+    // buffer holds the last N seconds, so the sooner it's told to save, the less
+    // the moment has aged out of the buffer. Its failure never affects the clip.
+    const capture = captureReady() ? triggerCapture(logger) : null;
+
     try {
       const { url } = await createChannelClip();
-      reply(`@${user.displayName} 🎬 clipped it! ${url}`);
+      const local = await capture;
+      reply(`@${user.displayName} 🎬 clipped it! ${url}${local?.ok ? ' (+ full-quality local capture saved)' : ''}`);
     } catch (err) {
       logger?.warn?.('clip failed', { userId: user.id, err: String(err) });
+      await capture; // let the local save settle so its result is still logged
       reply(`@${user.displayName} couldn't make a clip just now — try again in a moment.`);
     }
   },

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -28,7 +28,14 @@ export default {
     try {
       const { url } = await createChannelClip();
       const local = await capture;
-      reply(`@${user.displayName} 🎬 clipped it! ${url}${local?.ok ? ' (+ full-quality local capture saved)' : ''}`);
+      // `started` means the replay buffer wasn't running and we just turned it on
+      // — nothing was captured this time, but the next !clip will have content.
+      const note = local?.ok
+        ? local.started
+          ? ' (local recording buffer just started — the next !clip will capture it too)'
+          : ' (+ full-quality local capture saved)'
+        : '';
+      reply(`@${user.displayName} 🎬 clipped it! ${url}${note}`);
     } catch (err) {
       logger?.warn?.('clip failed', { userId: user.id, err: String(err) });
       await capture; // let the local save settle so its result is still logged

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -1,24 +1,24 @@
 // Local high-quality capture trigger — the "grab the last N seconds on the
 // streamer's PC" half of a clip.
 //
-// A Twitch clip is capped at the STREAM resolution, so `!clip` alone can never
-// give you a 4K keepsake. This fires a second, local capture at full recording
-// quality on the streamer's machine (reached over the tailnet), which the
-// okra-clip-archiver then picks up.
+// A Twitch clip is capped at the STREAM resolution, so it can never be a 4K
+// keepsake. This fires a capture at full recording quality on the streamer's
+// machine (reached over the tailnet) — the default half of `!clip` (CLIP_MODE),
+// and what the okra-clip-archiver later picks up.
 //
 // Backend-agnostic on purpose: obs-websocket today (free, password-authed, built
 // into OBS 28+), Aitum's :7777 rule API later. Commands call `triggerCapture()`
 // and never learn which one is configured.
 //
-// EVERY failure here is non-fatal. The streamer's PC may be off, OBS may be
-// closed, the tailnet may be down — none of that may break `!clip`, which still
-// produces a perfectly good Twitch clip on its own.
+// EVERY failure here is non-fatal and RESOLVES rather than throwing. The
+// streamer's PC may be off, OBS may be closed, the tailnet may be down — the
+// caller gets `{ ok: false, reason }` and decides what to tell chat.
 //
 // RATE LIMITING is global, and deliberately separate from !clip's cooldown. That
-// cooldown is per-user, so N viewers can each clip within the same minute — fine
-// for Twitch clips (free, server-side) but not for local saves, where every
-// trigger writes hundreds of MB and then has to be shipped over the streamer's
-// upload. This gate is channel-wide: a burst of !clips yields one local capture.
+// cooldown is per-user, so N viewers can each clip within the same minute — free
+// for Twitch clips (server-side) but not for local saves, where every trigger
+// writes hundreds of MB and then has to be shipped over the streamer's upload.
+// This gate is channel-wide: a burst of !clips yields one local capture.
 
 import { saveReplayBuffer, websocketAvailable } from './obsWebsocket.js';
 
@@ -37,7 +37,7 @@ export function initCapture(opts = {}, logger = console) {
 
   if (backend === 'none' || !url) {
     cfg = null;
-    logger.info?.('local capture disabled (no OBS_WEBSOCKET_URL) — !clip will make Twitch clips only');
+    logger.info?.('local capture disabled (no OBS_WEBSOCKET_URL)');
     return;
   }
   if (backend !== 'obs-websocket') {
@@ -98,7 +98,7 @@ export async function triggerCapture(logger = console, now = Date.now()) {
     // retry immediately (the PC may have just come back).
     lastAt = 0;
     // Expected whenever the streamer's PC is off or OBS is closed — log, move on.
-    logger.warn?.('local capture failed (Twitch clip is unaffected)', { err: String(err?.message || err) });
+    logger.warn?.('local capture failed', { err: String(err?.message || err) });
     return { ok: false, reason: String(err?.message || err) };
   }
 }

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -13,11 +13,19 @@
 // EVERY failure here is non-fatal. The streamer's PC may be off, OBS may be
 // closed, the tailnet may be down — none of that may break `!clip`, which still
 // produces a perfectly good Twitch clip on its own.
+//
+// RATE LIMITING is global, and deliberately separate from !clip's cooldown. That
+// cooldown is per-user, so N viewers can each clip within the same minute — fine
+// for Twitch clips (free, server-side) but not for local saves, where every
+// trigger writes hundreds of MB and then has to be shipped over the streamer's
+// upload. This gate is channel-wide: a burst of !clips yields one local capture.
 
 import { saveReplayBuffer, websocketAvailable } from './obsWebsocket.js';
 
 /** Resolved once at boot from env; `null` when no capture backend is set up. */
 let cfg = null;
+/** When the last capture actually fired — the global rate gate. */
+let lastAt = 0;
 
 /**
  * @param {{ backend?: string, url?: string, password?: string, timeoutMs?: number }} [opts]
@@ -48,13 +56,16 @@ export function initCapture(opts = {}, logger = console) {
     url,
     password: opts.password ?? process.env.OBS_WEBSOCKET_PASSWORD ?? '',
     timeoutMs: opts.timeoutMs ?? Number(process.env.OBS_TIMEOUT_MS || 8000),
+    minIntervalMs: opts.minIntervalMs ?? Number(process.env.CAPTURE_MIN_INTERVAL_MS || 60_000),
   };
-  logger.info?.('local capture ready', { backend, url });
+  lastAt = 0;
+  logger.info?.('local capture ready', { backend, url, minIntervalMs: cfg.minIntervalMs });
 }
 
 /** Test seam: inject a fake trigger. Pass `null` to disable capture. */
-export function initCaptureWith(fn) {
-  cfg = fn ? { backend: 'test', trigger: fn } : null;
+export function initCaptureWith(fn, { minIntervalMs = 0 } = {}) {
+  cfg = fn ? { backend: 'test', trigger: fn, minIntervalMs } : null;
+  lastAt = 0;
 }
 
 /** True when a capture backend is configured. */
@@ -66,13 +77,26 @@ export function captureReady() {
  * Fire the local capture. Never throws.
  * @returns {Promise<{ ok: boolean, path?: string|null, started?: boolean, reason?: string }>}
  */
-export async function triggerCapture(logger = console) {
+export async function triggerCapture(logger = console, now = Date.now()) {
   if (!cfg) return { ok: false, reason: 'not configured' };
+
+  const since = now - lastAt;
+  if (cfg.minIntervalMs && lastAt && since < cfg.minIntervalMs) {
+    const retryInMs = cfg.minIntervalMs - since;
+    logger.info?.('local capture skipped — rate limited', { retryInMs });
+    return { ok: false, reason: 'rate-limited', retryInMs };
+  }
+  // Claim the slot BEFORE awaiting, so concurrent !clips can't both slip through.
+  lastAt = now;
+
   try {
     const res = cfg.backend === 'test' ? await cfg.trigger() : await saveReplayBuffer(cfg);
     logger.info?.('local capture saved', { path: res?.path ?? null, startedBuffer: Boolean(res?.started) });
     return { ok: true, path: res?.path ?? null, started: Boolean(res?.started) };
   } catch (err) {
+    // A failed attempt shouldn't burn the rate-limit window — let the next !clip
+    // retry immediately (the PC may have just come back).
+    lastAt = 0;
     // Expected whenever the streamer's PC is off or OBS is closed — log, move on.
     logger.warn?.('local capture failed (Twitch clip is unaffected)', { err: String(err?.message || err) });
     return { ok: false, reason: String(err?.message || err) };

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -1,0 +1,80 @@
+// Local high-quality capture trigger — the "grab the last N seconds on the
+// streamer's PC" half of a clip.
+//
+// A Twitch clip is capped at the STREAM resolution, so `!clip` alone can never
+// give you a 4K keepsake. This fires a second, local capture at full recording
+// quality on the streamer's machine (reached over the tailnet), which the
+// okra-clip-archiver then picks up.
+//
+// Backend-agnostic on purpose: obs-websocket today (free, password-authed, built
+// into OBS 28+), Aitum's :7777 rule API later. Commands call `triggerCapture()`
+// and never learn which one is configured.
+//
+// EVERY failure here is non-fatal. The streamer's PC may be off, OBS may be
+// closed, the tailnet may be down — none of that may break `!clip`, which still
+// produces a perfectly good Twitch clip on its own.
+
+import { saveReplayBuffer, websocketAvailable } from './obsWebsocket.js';
+
+/** Resolved once at boot from env; `null` when no capture backend is set up. */
+let cfg = null;
+
+/**
+ * @param {{ backend?: string, url?: string, password?: string, timeoutMs?: number }} [opts]
+ * @param {any} [logger]
+ */
+export function initCapture(opts = {}, logger = console) {
+  const url = opts.url ?? process.env.OBS_WEBSOCKET_URL ?? '';
+  const backend = (opts.backend ?? process.env.CAPTURE_BACKEND ?? (url ? 'obs-websocket' : 'none')).toLowerCase();
+
+  if (backend === 'none' || !url) {
+    cfg = null;
+    logger.info?.('local capture disabled (no OBS_WEBSOCKET_URL) — !clip will make Twitch clips only');
+    return;
+  }
+  if (backend !== 'obs-websocket') {
+    cfg = null;
+    logger.warn?.('unknown CAPTURE_BACKEND — local capture disabled', { backend });
+    return;
+  }
+  if (!websocketAvailable()) {
+    cfg = null;
+    logger.warn?.('local capture disabled — this Node build lacks WebSocket (needs Node 22+)');
+    return;
+  }
+
+  cfg = {
+    backend,
+    url,
+    password: opts.password ?? process.env.OBS_WEBSOCKET_PASSWORD ?? '',
+    timeoutMs: opts.timeoutMs ?? Number(process.env.OBS_TIMEOUT_MS || 8000),
+  };
+  logger.info?.('local capture ready', { backend, url });
+}
+
+/** Test seam: inject a fake trigger. Pass `null` to disable capture. */
+export function initCaptureWith(fn) {
+  cfg = fn ? { backend: 'test', trigger: fn } : null;
+}
+
+/** True when a capture backend is configured. */
+export function captureReady() {
+  return cfg !== null;
+}
+
+/**
+ * Fire the local capture. Never throws.
+ * @returns {Promise<{ ok: boolean, path?: string|null, started?: boolean, reason?: string }>}
+ */
+export async function triggerCapture(logger = console) {
+  if (!cfg) return { ok: false, reason: 'not configured' };
+  try {
+    const res = cfg.backend === 'test' ? await cfg.trigger() : await saveReplayBuffer(cfg);
+    logger.info?.('local capture saved', { path: res?.path ?? null, startedBuffer: Boolean(res?.started) });
+    return { ok: true, path: res?.path ?? null, started: Boolean(res?.started) };
+  } catch (err) {
+    // Expected whenever the streamer's PC is off or OBS is closed — log, move on.
+    logger.warn?.('local capture failed (Twitch clip is unaffected)', { err: String(err?.message || err) });
+    return { ok: false, reason: String(err?.message || err) };
+  }
+}

--- a/src/integrations/obsWebsocket.js
+++ b/src/integrations/obsWebsocket.js
@@ -124,30 +124,64 @@ export async function withObs({ url, password = '', timeoutMs = 8000 }, fn) {
 }
 
 /**
- * Save the last N seconds from OBS's replay buffer. Starts the buffer first if
- * it isn't running, so a streamer who forgot to enable it still gets the clip
- * (that save will be short — the buffer only just began filling).
+ * Save the last N seconds from OBS's replay buffer.
+ *
+ * If the buffer isn't running we START it — a streamer who forgot to enable it
+ * shouldn't silently get nothing from every future `!clip`. But we do NOT then
+ * pretend to save: OBS brings outputs up ASYNCHRONOUSLY, so an immediate save
+ * fails with 501 OutputNotRunning (found the hard way against a real OBS), and
+ * even once it is up the buffer holds ~nothing. So we wait for it to actually go
+ * active, report `started: true, path: null`, and let the NEXT clip have content.
  *
  * @returns {Promise<{ path: string|null, started: boolean }>}
  */
 export async function saveReplayBuffer({ url, password, timeoutMs }) {
-  return withObs({ url, password, timeoutMs }, async (request) => {
-    let started = false;
+  return withObs({ url, password, timeoutMs }, (request) => replayBufferSequence(request));
+}
+
+/**
+ * The request sequence itself, split out from the socket so it can be unit-tested
+ * with a fake `request`. Both bugs found against a real OBS lived here: saving
+ * before the output was actually up, and reporting the PREVIOUS file's path.
+ *
+ * @param {(type: string, data?: object) => Promise<any>} request
+ * @param {(ms: number) => Promise<void>} [sleep] injectable for tests
+ */
+export async function replayBufferSequence(request, sleep = (ms) => new Promise((r) => setTimeout(r, ms))) {
+  {
     const status = await request('GetReplayBufferStatus');
     if (!status.outputActive) {
       await request('StartReplayBuffer');
-      started = true;
+      // Poll until the output is genuinely up, so the buffer is filling from now on.
+      for (const wait of [150, 250, 500, 1000]) {
+        await sleep(wait);
+        const s = await request('GetReplayBufferStatus');
+        if (s.outputActive) break;
+      }
+      return { path: null, started: true };
     }
+    // Remember which file was last written BEFORE saving. OBS finalizes the new
+    // one asynchronously, so GetLastReplayBufferReplay keeps returning the
+    // PREVIOUS path for a moment — reporting that would name the wrong file
+    // (observed against a real OBS). Poll until it actually changes.
+    const previous = await request('GetLastReplayBufferReplay')
+      .then((r) => r?.savedReplayPath ?? null)
+      .catch(() => null);
+
     await request('SaveReplayBuffer');
-    // OBS writes the file asynchronously; the path may lag a beat, so a miss
-    // here is not an error — the save still happened.
+
     let path = null;
-    try {
-      const last = await request('GetLastReplayBufferReplay');
-      path = last?.savedReplayPath ?? null;
-    } catch {
-      /* path unavailable — the save itself already succeeded */
+    for (const wait of [200, 300, 500, 1000]) {
+      await sleep(wait);
+      const current = await request('GetLastReplayBufferReplay')
+        .then((r) => r?.savedReplayPath ?? null)
+        .catch(() => null);
+      if (current && current !== previous) {
+        path = current;
+        break;
+      }
     }
-    return { path, started };
-  });
+    // A null path just means the write hadn't landed yet — the save still happened.
+    return { path, started: false };
+  }
 }

--- a/src/integrations/obsWebsocket.js
+++ b/src/integrations/obsWebsocket.js
@@ -1,0 +1,153 @@
+// Minimal obs-websocket v5 client — just enough to trigger a replay-buffer save
+// on the streamer's machine over the tailnet.
+//
+// No dependency: Node 22 ships a global WebSocket, and the auth is two SHA-256
+// rounds. Adding obs-websocket-js for ~80 lines of protocol would widen the
+// supply-chain surface of an otherwise 4-dependency bot for no gain.
+//
+// We connect PER TRIGGER rather than holding a socket open. A clip is rare, the
+// handshake is ~100ms, and a short-lived connection means no reconnect/backoff
+// state machine and nothing to go stale while the streamer's PC sleeps. Every
+// step is deadline-bounded so an unreachable PC can never hang a chat command.
+//
+// Protocol (docs/generated/protocol.md): server says Hello(0) with an optional
+// {challenge, salt}; we reply Identify(1) with the derived auth; server confirms
+// Identified(2); then Request(6) / RequestResponse(7) correlated by requestId.
+
+import { createHash } from 'node:crypto';
+
+const OP = { HELLO: 0, IDENTIFY: 1, IDENTIFIED: 2, REQUEST: 6, REQUEST_RESPONSE: 7 };
+
+/**
+ * obs-websocket v5 auth string:
+ *   secret = base64(sha256(password + salt))
+ *   auth   = base64(sha256(secret + challenge))
+ */
+export function deriveAuth(password, salt, challenge) {
+  const sha256b64 = (s) => createHash('sha256').update(s).digest('base64');
+  return sha256b64(sha256b64(password + salt) + challenge);
+}
+
+/** True when this runtime can open a WebSocket at all (Node 22+ / 20 with a flag). */
+export function websocketAvailable() {
+  return typeof WebSocket === 'function';
+}
+
+/**
+ * Open a session, run `fn(request)`, and always close. `request(type, data)`
+ * resolves with responseData or rejects with the OBS failure comment.
+ *
+ * @param {{ url: string, password?: string, timeoutMs?: number }} opts
+ * @param {(request: (type: string, data?: object) => Promise<any>) => Promise<any>} fn
+ */
+export async function withObs({ url, password = '', timeoutMs = 8000 }, fn) {
+  if (!websocketAvailable()) throw new Error('this Node build has no WebSocket support (needs Node 22+)');
+
+  const ws = new WebSocket(url);
+  const pending = new Map(); // requestId -> {resolve, reject}
+  let seq = 0;
+  let settleReady;
+  let failAll;
+  const ready = new Promise((resolve, reject) => {
+    settleReady = resolve;
+    failAll = reject;
+  });
+
+  // One deadline for the whole exchange — connect, identify, and every request.
+  const timer = setTimeout(() => {
+    const err = new Error(`OBS did not respond within ${timeoutMs}ms`);
+    failAll(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+    try { ws.close(); } catch { /* already closing */ }
+  }, timeoutMs);
+
+  ws.addEventListener('message', (ev) => {
+    let msg;
+    try {
+      msg = JSON.parse(typeof ev.data === 'string' ? ev.data : String(ev.data));
+    } catch {
+      return; // ignore anything unparseable
+    }
+    if (msg.op === OP.HELLO) {
+      const d = { rpcVersion: msg.d?.rpcVersion ?? 1 };
+      const chal = msg.d?.authentication;
+      if (chal) {
+        if (!password) {
+          failAll(new Error('OBS requires a websocket password but none is configured'));
+          try { ws.close(); } catch { /* noop */ }
+          return;
+        }
+        d.authentication = deriveAuth(password, chal.salt, chal.challenge);
+      }
+      ws.send(JSON.stringify({ op: OP.IDENTIFY, d }));
+    } else if (msg.op === OP.IDENTIFIED) {
+      settleReady();
+    } else if (msg.op === OP.REQUEST_RESPONSE) {
+      const p = pending.get(msg.d?.requestId);
+      if (!p) return;
+      pending.delete(msg.d.requestId);
+      const st = msg.d.requestStatus || {};
+      if (st.result) p.resolve(msg.d.responseData || {});
+      else p.reject(new Error(st.comment || `OBS rejected ${msg.d.requestType} (code ${st.code})`));
+    }
+  });
+
+  ws.addEventListener('error', () => {
+    const err = new Error(`could not reach OBS at ${url}`);
+    failAll(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+  });
+  ws.addEventListener('close', () => {
+    const err = new Error('OBS closed the connection');
+    failAll(err);
+    for (const p of pending.values()) p.reject(err);
+    pending.clear();
+  });
+
+  function request(requestType, requestData) {
+    const requestId = `kb-${++seq}`;
+    return new Promise((resolve, reject) => {
+      pending.set(requestId, { resolve, reject });
+      ws.send(JSON.stringify({ op: OP.REQUEST, d: { requestType, requestId, requestData } }));
+    });
+  }
+
+  try {
+    await ready;
+    return await fn(request);
+  } finally {
+    clearTimeout(timer);
+    try { ws.close(); } catch { /* already closed */ }
+  }
+}
+
+/**
+ * Save the last N seconds from OBS's replay buffer. Starts the buffer first if
+ * it isn't running, so a streamer who forgot to enable it still gets the clip
+ * (that save will be short — the buffer only just began filling).
+ *
+ * @returns {Promise<{ path: string|null, started: boolean }>}
+ */
+export async function saveReplayBuffer({ url, password, timeoutMs }) {
+  return withObs({ url, password, timeoutMs }, async (request) => {
+    let started = false;
+    const status = await request('GetReplayBufferStatus');
+    if (!status.outputActive) {
+      await request('StartReplayBuffer');
+      started = true;
+    }
+    await request('SaveReplayBuffer');
+    // OBS writes the file asynchronously; the path may lag a beat, so a miss
+    // here is not an error — the save still happened.
+    let path = null;
+    try {
+      const last = await request('GetLastReplayBufferReplay');
+      path = last?.savedReplayPath ?? null;
+    } catch {
+      /* path unavailable — the save itself already succeeded */
+    }
+    return { path, started };
+  });
+}

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -72,8 +72,9 @@ export const SCENARIOS = [
       try {
         // Default CLIP_MODE=local: the streamer's OBS saves the moment at full
         // recording quality and nothing is posted to Twitch.
+        // The reply is a bare confirmation — chat learns nothing about the rig.
         const local = await bot.send(alice, '!clip');
-        assert.match(local, /local capture/i);
+        assert.match(local, /clipped it/i);
         assert.doesNotMatch(local, /clips\.twitch\.tv/, 'the default must not make a Twitch clip');
 
         // CLIP_MODE=both puts the Twitch clip back alongside it (needs live).

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -15,6 +15,7 @@ import { setupRaidWeek, enlist } from '../../src/db/raid.js';
 import { seedCuratedFacts } from '../../src/db/facts.js';
 import { getRaidPointer, getConfig, setLive } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
+import { initCaptureWith } from '../../src/integrations/capture.js';
 import { defaultBoss } from '../../src/content/bosses.js';
 import { until } from './harness.js';
 
@@ -62,15 +63,29 @@ export const fixtures = { player, loot, wallet, market, drop, facts, leaderboard
 // ── scenarios (one per command primary name) ─────────────────────────────────
 export const SCENARIOS = [
   {
-    command: 'clip', title: 'clips the live stream and posts a link',
+    command: 'clip', title: 'saves a full-quality local capture (and a Twitch clip in "both" mode)',
     run: async ({ bot, u }) => {
       const alice = u('e2e_clip', { login: 'alice', name: 'Alice' });
+      const bob = u('e2e_clip2', { login: 'bob', name: 'Bob' }); // !clip is per-user cooldowned
       initClipsWith(async () => 'TestClipId123'); // fake Helix Create Clip
-      await setLive(true, 'test');
-      await until(() => getConfig().live === true); // mirror is async
-      const reply = await bot.send(alice, '!clip');
-      assert.match(reply, /clips\.twitch\.tv\/TestClipId123/);
-      await setLive(false, 'test'); // reset shared live state for later scenarios
+      initCaptureWith(async () => ({ path: 'D:/rec/Replay.mkv' })); // fake OBS
+      try {
+        // Default CLIP_MODE=local: the streamer's OBS saves the moment at full
+        // recording quality and nothing is posted to Twitch.
+        const local = await bot.send(alice, '!clip');
+        assert.match(local, /local capture/i);
+        assert.doesNotMatch(local, /clips\.twitch\.tv/, 'the default must not make a Twitch clip');
+
+        // CLIP_MODE=both puts the Twitch clip back alongside it (needs live).
+        process.env.CLIP_MODE = 'both';
+        await setLive(true, 'test');
+        await until(() => getConfig().live === true); // mirror is async
+        assert.match(await bot.send(bob, '!clip'), /clips\.twitch\.tv\/TestClipId123/);
+      } finally {
+        delete process.env.CLIP_MODE;
+        initCaptureWith(null);
+        await setLive(false, 'test'); // reset shared live state for later scenarios
+      }
     },
   },
   {

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -1,6 +1,6 @@
 // Local-capture tests. The load-bearing guarantee: triggering the streamer's OBS
 // is BEST EFFORT — a PC that's off, an OBS that's closed, or a dead tailnet must
-// never break `!clip`, which still produces a perfectly good Twitch clip.
+// resolve as a reported failure, never throw out of `!clip`.
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initCapture, initCaptureWith, captureReady, triggerCapture } from '../../src/integrations/capture.js';

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -1,0 +1,64 @@
+// Local-capture tests. The load-bearing guarantee: triggering the streamer's OBS
+// is BEST EFFORT — a PC that's off, an OBS that's closed, or a dead tailnet must
+// never break `!clip`, which still produces a perfectly good Twitch clip.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initCapture, initCaptureWith, captureReady, triggerCapture } from '../../src/integrations/capture.js';
+import { deriveAuth, websocketAvailable } from '../../src/integrations/obsWebsocket.js';
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+afterEach(() => initCaptureWith(null)); // never leak config between tests
+
+test('capture is disabled when no OBS url is configured', () => {
+  initCapture({ url: '' }, noopLogger);
+  assert.equal(captureReady(), false);
+});
+
+test('an unknown backend disables capture rather than guessing', () => {
+  initCapture({ backend: 'aitum', url: 'ws://x:4455' }, noopLogger);
+  assert.equal(captureReady(), false, 'aitum is not implemented yet — must not silently use obs');
+});
+
+test('a valid obs-websocket config enables capture', () => {
+  initCapture({ backend: 'obs-websocket', url: 'ws://100.82.136.16:4455' }, noopLogger);
+  assert.equal(captureReady(), websocketAvailable(), 'enabled iff the runtime has WebSocket');
+});
+
+test('triggerCapture reports the saved path on success', async () => {
+  initCaptureWith(async () => ({ path: 'C:\\clips\\Replay 2026-07-27.mkv', started: false }));
+  const res = await triggerCapture(noopLogger);
+  assert.deepEqual(res, { ok: true, path: 'C:\\clips\\Replay 2026-07-27.mkv', started: false });
+});
+
+test('a save with no reported path still counts as success', async () => {
+  initCaptureWith(async () => ({ path: null, started: true }));
+  const res = await triggerCapture(noopLogger);
+  assert.equal(res.ok, true);
+  assert.equal(res.started, true, 'reports that it had to start the buffer');
+});
+
+test('an unreachable OBS resolves as a failure — it never throws', async () => {
+  initCaptureWith(async () => { throw new Error('could not reach OBS at ws://x:4455'); });
+  const res = await triggerCapture(noopLogger);
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /could not reach OBS/);
+});
+
+test('triggerCapture is a no-op when unconfigured', async () => {
+  initCaptureWith(null);
+  const res = await triggerCapture(noopLogger);
+  assert.deepEqual(res, { ok: false, reason: 'not configured' });
+});
+
+test('obs-websocket auth is the documented two-round derivation', () => {
+  // secret = base64(sha256(password + salt)); auth = base64(sha256(secret + challenge))
+  const auth = deriveAuth('pw', 'salt', 'chal');
+  assert.match(auth, /^[A-Za-z0-9+/]+=*$/, 'base64');
+  assert.equal(Buffer.from(auth, 'base64').length, 32, 'sha256 digest');
+  // Every input participates — a change in any one changes the result.
+  assert.notEqual(auth, deriveAuth('pw2', 'salt', 'chal'));
+  assert.notEqual(auth, deriveAuth('pw', 'salt2', 'chal'));
+  assert.notEqual(auth, deriveAuth('pw', 'salt', 'chal2'));
+  assert.equal(auth, deriveAuth('pw', 'salt', 'chal'), 'deterministic');
+});

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -4,7 +4,7 @@
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initCapture, initCaptureWith, captureReady, triggerCapture } from '../../src/integrations/capture.js';
-import { deriveAuth, websocketAvailable } from '../../src/integrations/obsWebsocket.js';
+import { deriveAuth, websocketAvailable, replayBufferSequence } from '../../src/integrations/obsWebsocket.js';
 
 const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
 
@@ -98,4 +98,63 @@ test('obs-websocket auth is the documented two-round derivation', () => {
   assert.notEqual(auth, deriveAuth('pw', 'salt2', 'chal'));
   assert.notEqual(auth, deriveAuth('pw', 'salt', 'chal2'));
   assert.equal(auth, deriveAuth('pw', 'salt', 'chal'), 'deterministic');
+});
+
+
+// ── the request sequence itself ─────────────────────────────────────────────
+// Both bugs found against a real OBS lived here, so they get regression tests.
+const noSleep = async () => {};
+
+/** A fake OBS: scripted responses per request type, recording the call order. */
+function fakeObs({ active, lastPaths = [], onSave } = {}) {
+  const calls = [];
+  let activeNow = active;
+  let idx = 0;
+  return {
+    calls,
+    request: async (type) => {
+      calls.push(type);
+      switch (type) {
+        case 'GetReplayBufferStatus':
+          return { outputActive: activeNow };
+        case 'StartReplayBuffer':
+          activeNow = true; // OBS flips it asynchronously; here, on the next poll
+          return {};
+        case 'SaveReplayBuffer':
+          onSave?.();
+          return {};
+        case 'GetLastReplayBufferReplay': {
+          const p = lastPaths[Math.min(idx, lastPaths.length - 1)];
+          idx += 1;
+          return { savedReplayPath: p };
+        }
+        default:
+          throw new Error(`unexpected request ${type}`);
+      }
+    },
+  };
+}
+
+test('cold buffer: starts it and does NOT claim a save (regression: 501 OutputNotRunning)', async () => {
+  let saved = false;
+  const obs = fakeObs({ active: false, onSave: () => { saved = true; } });
+  const res = await replayBufferSequence(obs.request, noSleep);
+  assert.deepEqual(res, { path: null, started: true });
+  assert.equal(saved, false, 'must not save into a buffer that was not running');
+  assert.ok(obs.calls.includes('StartReplayBuffer'));
+});
+
+test('warm buffer: saves and reports the NEW path, never the previous one', async () => {
+  // GetLastReplayBufferReplay returns the OLD file first (OBS finalizes async).
+  const obs = fakeObs({ active: true, lastPaths: ['C:/old.mp4', 'C:/old.mp4', 'C:/new.mp4'] });
+  const res = await replayBufferSequence(obs.request, noSleep);
+  assert.equal(res.started, false);
+  assert.equal(res.path, 'C:/new.mp4', 'regression: reported the stale path before');
+});
+
+test('warm buffer: a path that never changes is reported as null, not stale', async () => {
+  const obs = fakeObs({ active: true, lastPaths: ['C:/old.mp4'] });
+  const res = await replayBufferSequence(obs.request, noSleep);
+  assert.equal(res.path, null, 'better no path than the wrong one');
+  assert.ok(obs.calls.includes('SaveReplayBuffer'), 'the save still happened');
 });

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -51,6 +51,43 @@ test('triggerCapture is a no-op when unconfigured', async () => {
   assert.deepEqual(res, { ok: false, reason: 'not configured' });
 });
 
+test('a global rate limit stops a burst of !clips writing many huge files', async () => {
+  let fired = 0;
+  initCaptureWith(async () => { fired += 1; return { path: `f${fired}.mkv` }; }, { minIntervalMs: 60_000 });
+  const t0 = 1_000_000;
+  assert.equal((await triggerCapture(noopLogger, t0)).ok, true, 'first fires');
+  const second = await triggerCapture(noopLogger, t0 + 5_000);
+  assert.equal(second.ok, false);
+  assert.equal(second.reason, 'rate-limited');
+  assert.equal(second.retryInMs, 55_000, 'reports when it will be allowed again');
+  assert.equal(fired, 1, 'the expensive save ran once for the burst');
+  // …and it opens back up once the window passes.
+  assert.equal((await triggerCapture(noopLogger, t0 + 60_000)).ok, true);
+  assert.equal(fired, 2);
+});
+
+test('the rate limit is per-channel, not per-user (that is !clip\'s job)', async () => {
+  let fired = 0;
+  initCaptureWith(async () => { fired += 1; return { path: 'x.mkv' }; }, { minIntervalMs: 60_000 });
+  // Different viewers, same window — capture.js has no notion of who asked.
+  await triggerCapture(noopLogger, 1000);
+  await triggerCapture(noopLogger, 2000);
+  await triggerCapture(noopLogger, 3000);
+  assert.equal(fired, 1);
+});
+
+test('a failed capture does not burn the rate-limit window', async () => {
+  let calls = 0;
+  initCaptureWith(async () => {
+    calls += 1;
+    if (calls === 1) throw new Error('could not reach OBS');
+    return { path: 'ok.mkv' };
+  }, { minIntervalMs: 60_000 });
+  assert.equal((await triggerCapture(noopLogger, 1000)).ok, false, 'PC was off');
+  const retry = await triggerCapture(noopLogger, 2000); // immediately after
+  assert.equal(retry.ok, true, 'next !clip may retry straight away');
+});
+
 test('obs-websocket auth is the documented two-round derivation', () => {
   // secret = base64(sha256(password + salt)); auth = base64(sha256(secret + challenge))
   const auth = deriveAuth('pw', 'salt', 'chal');

--- a/test/rules/clip-command.test.js
+++ b/test/rules/clip-command.test.js
@@ -44,8 +44,27 @@ test('by default !clip captures locally and makes NO Twitch clip', async () => {
   const reply = await runClip();
   assert.equal(captures, 1);
   assert.equal(clips, 0, 'the Twitch half must not fire in the default mode');
-  assert.match(reply, /local capture/i);
-  assert.doesNotMatch(reply, /clips\.twitch\.tv/);
+  assert.equal(reply, '@Alice 🎬 clipped it!');
+});
+
+// Viewers must not be able to infer HOW a clip is made: no file path, no OBS, no
+// second machine, not even that a local recording exists. Every branch of the
+// local-only reply gets checked, so a future "helpful" message can't reopen this.
+test('no local-only reply leaks anything about the capture setup', async () => {
+  const outcomes = [
+    async () => ({ path: 'D:/streams/rec/Replay 2026-07-27.mkv' }), // saved
+    async () => ({ path: null, started: true }), // buffer was cold
+    async () => { throw new Error('could not reach OBS at ws://100.82.136.16:4455'); },
+  ];
+  const leaks = /obs|websocket|replay|buffer|recording|\bPC\b|4k|quality|\.mkv|\.mp4|[A-Z]:[/\\]|ws:\/\/|\d+\.\d+\.\d+\.\d+/i;
+  for (const outcome of outcomes) {
+    initCaptureWith(outcome);
+    assert.doesNotMatch(await runClip(), leaks);
+  }
+  // …and the rate-limited branch, which needs a second call inside the window.
+  initCaptureWith(async () => ({ path: 'a.mkv' }), { minIntervalMs: 60_000 });
+  await runClip();
+  assert.doesNotMatch(await runClip(), leaks);
 });
 
 test('local mode ignores the live gate — OBS records whether or not you are streaming', async () => {
@@ -63,7 +82,7 @@ test('local mode never falls back to Twitch when no capture backend is configure
 
   const reply = await runClip();
   assert.equal(clips, 0, 'silently posting a Twitch clip would defeat the mode');
-  assert.match(reply, /local clip capture isn't set up/i);
+  assert.match(reply, /clipping isn't set up/i);
 });
 
 test("CLIP_MODE=twitch restores the old behaviour and doesn't touch OBS", async () => {
@@ -85,12 +104,12 @@ test('CLIP_MODE=both while offline still saves locally instead of failing', asyn
 
   const reply = await runClip(); // not live → Twitch half is impossible
   assert.equal(clips, 0, 'Create Clip would be rejected offline — do not call it');
-  assert.match(reply, /local capture/i);
+  assert.match(reply, /clipped it/i);
 });
 
-test('a cold replay buffer tells the viewer the next !clip will work', async () => {
-  initCaptureWith(async () => ({ path: null, started: true }));
-  assert.match(await runClip(), /next !clip/i);
+test('a cold replay buffer reads as an ordinary miss, not a status report', async () => {
+  initCaptureWith(async () => ({ path: null, started: true })); // nothing saved
+  assert.match(await runClip(), /couldn't clip that one/i);
 });
 
 test('a rate-limited capture tells the viewer when to retry', async () => {
@@ -102,7 +121,5 @@ test('a rate-limited capture tells the viewer when to retry', async () => {
 
 test('an unreachable OBS gets a plain-English reply, never a stack trace', async () => {
   initCaptureWith(async () => { throw new Error('could not reach OBS at ws://x:4455'); });
-  const reply = await runClip();
-  assert.match(reply, /couldn't reach the recording PC/i);
-  assert.doesNotMatch(reply, /ws:\/\//, 'no internals in chat');
+  assert.match(await runClip(), /couldn't clip that one/i);
 });

--- a/test/rules/clip-command.test.js
+++ b/test/rules/clip-command.test.js
@@ -1,0 +1,108 @@
+// !clip mode selection. The default is LOCAL: !clip triggers the streamer's
+// OBS/Aitum capture and posts NOTHING to Twitch. These lock down which half of
+// the command fires for each CLIP_MODE — the failure that matters is a mode
+// quietly making a Twitch clip the streamer didn't ask for.
+//
+// The live mirror is `false` throughout (no RTDB here), which is exactly the
+// interesting case: the local buffer works offline, Twitch's Create Clip doesn't.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import clip, { resolveClipMode } from '../../src/commands/clip.js';
+import { initClipsWith } from '../../src/twitch/clips.js';
+import { initCaptureWith } from '../../src/integrations/capture.js';
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+const alice = { id: 'u1', displayName: 'Alice' };
+
+/** Run !clip and return what it said in chat. */
+async function runClip() {
+  let said = '';
+  await clip.run({ user: alice, reply: (t) => { said = t; }, logger: noopLogger });
+  return said;
+}
+
+afterEach(() => {
+  delete process.env.CLIP_MODE;
+  initClipsWith(null);
+  initCaptureWith(null);
+});
+
+test('CLIP_MODE parses the three modes and defaults to local', () => {
+  assert.equal(resolveClipMode(undefined), 'local', 'unset → local');
+  assert.equal(resolveClipMode(''), 'local');
+  assert.equal(resolveClipMode('  BOTH '), 'both', 'trimmed + case-insensitive');
+  assert.equal(resolveClipMode('twitch'), 'twitch');
+  assert.equal(resolveClipMode('nonsense'), 'local', 'a typo must not silently enable Twitch clips');
+});
+
+test('by default !clip captures locally and makes NO Twitch clip', async () => {
+  let clips = 0;
+  let captures = 0;
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(async () => { captures += 1; return { path: 'D:/rec/Replay.mkv' }; });
+
+  const reply = await runClip();
+  assert.equal(captures, 1);
+  assert.equal(clips, 0, 'the Twitch half must not fire in the default mode');
+  assert.match(reply, /local capture/i);
+  assert.doesNotMatch(reply, /clips\.twitch\.tv/);
+});
+
+test('local mode ignores the live gate — OBS records whether or not you are streaming', async () => {
+  let captures = 0;
+  initCaptureWith(async () => { captures += 1; return { path: 'D:/rec/Replay.mkv' }; });
+  const reply = await runClip(); // live === false
+  assert.equal(captures, 1, 'offline is fine: the replay buffer is local');
+  assert.doesNotMatch(reply, /only clip while the stream is live/i);
+});
+
+test('local mode never falls back to Twitch when no capture backend is configured', async () => {
+  let clips = 0;
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(null); // OBS not configured
+
+  const reply = await runClip();
+  assert.equal(clips, 0, 'silently posting a Twitch clip would defeat the mode');
+  assert.match(reply, /local clip capture isn't set up/i);
+});
+
+test("CLIP_MODE=twitch restores the old behaviour and doesn't touch OBS", async () => {
+  let captures = 0;
+  process.env.CLIP_MODE = 'twitch';
+  initClipsWith(async () => 'TwitchClipId');
+  initCaptureWith(async () => { captures += 1; return { path: 'x.mkv' }; });
+
+  const reply = await runClip(); // not live
+  assert.equal(captures, 0, 'no local capture in twitch mode');
+  assert.match(reply, /only clip while the stream is live/i);
+});
+
+test('CLIP_MODE=both while offline still saves locally instead of failing', async () => {
+  let clips = 0;
+  process.env.CLIP_MODE = 'both';
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(async () => ({ path: 'D:/rec/Replay.mkv' }));
+
+  const reply = await runClip(); // not live → Twitch half is impossible
+  assert.equal(clips, 0, 'Create Clip would be rejected offline — do not call it');
+  assert.match(reply, /local capture/i);
+});
+
+test('a cold replay buffer tells the viewer the next !clip will work', async () => {
+  initCaptureWith(async () => ({ path: null, started: true }));
+  assert.match(await runClip(), /next !clip/i);
+});
+
+test('a rate-limited capture tells the viewer when to retry', async () => {
+  initCaptureWith(async () => ({ path: 'a.mkv' }), { minIntervalMs: 60_000 });
+  await runClip();
+  const reply = await runClip(); // inside the channel-wide window
+  assert.match(reply, /try again in \d+s/i);
+});
+
+test('an unreachable OBS gets a plain-English reply, never a stack trace', async () => {
+  initCaptureWith(async () => { throw new Error('could not reach OBS at ws://x:4455'); });
+  const reply = await runClip();
+  assert.match(reply, /couldn't reach the recording PC/i);
+  assert.doesNotMatch(reply, /ws:\/\//, 'no internals in chat');
+});


### PR DESCRIPTION
`!clip` now triggers the streamer's OBS to save its **replay buffer** at full recording quality over the tailnet — and as of the last two commits that is what `!clip` does **by default**, instead of making a Twitch clip.

Twitch clips are capped at your *stream* resolution, so a Twitch clip can never be a 4K keepsake. The local recording is whatever the camera actually shot, which is the whole point of the command — posting a downscaled Twitch clip alongside it was the wrong default. This is also the instant counterpart to okra-clip-archiver's post-hoc re-cut: the replay buffer catches bot-triggered moments immediately, the archiver catches everything else (including viewer-made clips). The two workflows stay separate.

## ⚠️ Breaking: `!clip` changes behaviour on deploy

| `CLIP_MODE` | `!clip` does |
|---|---|
| `local` | **(default)** OBS/Aitum capture only — **nothing posted to Twitch** |
| `twitch` | Helix Create Clip only (the pre-merge behaviour) |
| `both` | each; the reply carries the Twitch link |

**faraday has no `OBS_WEBSOCKET_URL`**, so after this merges `!clip` there will reply *"clipping isn't set up right now"* until either an OBS is reachable or the Unraid template sets **`CLIP_MODE=twitch`**. The boot log says so explicitly (`!clip has nothing to do: CLIP_MODE=local but no capture backend is configured`) rather than leaving it to the first viewer to discover.

`local` mode deliberately **never falls back to Twitch** when capture is unconfigured — a silent fallback would defeat the mode.

## Design notes
- **No new dependency.** Node 22 ships a global `WebSocket` and obs-websocket v5 auth is two SHA-256 rounds, so `obs-websocket-js` would widen the supply chain of a 4-dependency bot for ~80 lines of protocol.
- **Connect per trigger**, not a held socket: clips are rare, the handshake is ~100ms, and there's no reconnect/backoff state to go stale while the streamer's PC sleeps. A single deadline bounds connect, identify, and every request.
- **Backend-agnostic facade** (`capture.js`) so Aitum's `:7777` rule API slots in later without touching the command. An unknown backend disables capture rather than guessing.
- Capture fires **first and in parallel** with any Helix call — the replay buffer holds the *last* N seconds, so earlier is better.
- **Channel-wide rate limit** (`CAPTURE_MIN_INTERVAL_MS`, default 60s), separate from `!clip`'s per-user cooldown: N viewers clipping in the same minute is free for Twitch but would write N × hundreds of MB locally.
- **The live gate now guards only the Twitch half.** OBS records with nothing streaming, so an offline `!clip` still saves locally; in `both` mode an offline clip drops the Twitch half rather than erroring.
- Mode is resolved and validated **at boot** alongside `TWITCH_SEND_MODE`, and surfaced in the health snapshot as `clipMode`. An unrecognised value falls back to `local` with a warning.

## Chat replies leak nothing about the rig
Viewers see only `🎬 clipped it!`, `🎬 just clipped that — try again in Ns.`, or `couldn't clip that one — try again in a moment.` No file path, no OBS, no second machine, not even that a local recording exists. A cold replay buffer folds into that last line (nothing was actually saved); the distinction reaches the operator via the `startedBuffer` log field. A regression test walks every branch against one pattern covering OBS, replay/buffer, recording, PC, quality, file extensions, drive letters, `ws://` URLs and bare IPs.

## Failure behaviour
Every capture failure **resolves rather than throws** — PC off, OBS closed, tailnet down all produce `{ ok: false, reason }`, which the command turns into the generic miss message. A failed attempt does **not** burn the rate-limit window, so the next `!clip` may retry immediately.

## Two bugs found against a real OBS (not by the unit tests)
1. **501 OutputNotRunning** — OBS brings outputs up *asynchronously*, so saving immediately after `StartReplayBuffer` fails. Now polls until `outputActive` and reports `started: true, path: null`.
2. **Stale path** — `GetLastReplayBufferReplay` keeps returning the *previous* file until the new one finalizes. Now reads the path *before* saving and polls until it changes; reports `null` rather than naming the wrong file.

Both have regression tests driven by a scripted fake OBS (`replayBufferSequence` is split out from the socket for exactly this).

## Tests
`test/rules/capture.test.js` (12) — config gating, rate limiting, unreachable-OBS-never-throws, auth derivation, and the two regressions above.
`test/rules/clip-command.test.js` (9) — mode routing, the live-gate split, the no-silent-Twitch-fallback guarantee, and the reply-leak guard.

**77 rules · 48 emulator · 28 e2e — all green.**

## Verified end to end against a real OBS
Live on `scasplte2` with OBS on the Windows side over the tailnet: `!clip` → `🎬 clipped it!`, **no Twitch clip**, and `C:/Users/Jimaa/Videos/Replay 2026-07-28 07-23-32.mp4` on disk with `startedBuffer=false`. Earlier runs confirmed 3 clips → 3 × ~44 MB 1080p60 captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
