### PR TITLE
Make muster roster last all season

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!bag` / `!inventory` | everyone | view unequipped loot |
 | `!equip <item>` | everyone | equip an owned item into its slot |
 | `!grab` / `!loot` | **subs** | roll for the active drop (independent rolls within the window) |
-| `!muster` | everyone* | sign up for this week's raid (during muster) / see status |
+| `!muster` | everyone* | sign up for this season's raid roster (during muster) / see status |
 | `!exp on\|off\|auto\|status` | mod | control the EXP gate (`on` bypasses live for testing) |
 | `!mute on\|off\|status` | mod | silence the bot's chat output when it gets noisy; it keeps listening, tracking EXP, and holding the lease — bare `!mute` toggles |
 | `!drop [item]` | mod | force a single loot drop |
@@ -79,8 +79,10 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 `!muster`) needs an active sub — same as `!create` and `!grab`. A lapsed sub keeps
 the hero they built and keeps earning EXP, but must re-sub to muster.
 
-Mustering writes a snapshot of your hero onto the roster. While the muster window
-is open, the bot re-snapshots signees from their live record on a timer
+Mustering writes a snapshot of your hero onto the season roster. When a new boss
+is scheduled in the same season, participating adventurers roll forward into that
+boss's muster roster; starting or rolling over a season clears the roster. While
+the muster window is open, the bot re-snapshots signees from their live record on a timer
 (`raid.rosterRefreshMs`), so leveling or gearing up after you muster keeps showing
 on the site without a re-`!muster`. At **roster lock** (15 min before raid night)
 every card is frozen from the live record — that's the loadout that fights.

--- a/src/commands/raid.js
+++ b/src/commands/raid.js
@@ -1,5 +1,5 @@
 // !muster — muster command (spec §5.8). During the signup phase it ENLISTS your
-// hero into this week's raid; otherwise it reports the current phase + your
+// hero for the season's raid roster; otherwise it reports the current phase + your
 // status and links to the site. Enlisting requires an ACTIVE sub (owner
 // decision: joining a season's raid is subscriber-only, same as !create) — a
 // lapsed sub keeps their hero and keeps earning EXP, but must re-sub to muster.
@@ -21,7 +21,7 @@ export default {
   names: ['muster'],
   mod: false,
   cooldownMs: 3_000,
-  help: '!muster — sign up for this week’s raid / see status',
+  help: '!muster — sign up for this season’s raid roster / see status',
   async run({ user, reply }) {
     const active = await getActiveRaid();
     if (!active || !active.boss) {

--- a/src/db/raid.js
+++ b/src/db/raid.js
@@ -84,11 +84,30 @@ export function computeTeam(signups) {
 
 /**
  * Stand up a raid week: write the boss, the config/raid pointer (signup phase +
- * schedule), and reset the raid node. The website's muster page lights up off
- * config/raid.
+ * schedule), and seed the raid node. Within a season, participation is
+ * season-long: a newly scheduled boss inherits the previous active roster.
+ * Starting/rolling over a season opens week 1 without carry-over.
  * @param {{ seasonId: string, weekId: string, boss: object, locksAt: number, startsAt: number }} args
  */
 export async function setupRaidWeek({ seasonId, weekId, boss, locksAt, startsAt }) {
+  const db = database();
+  const previous = getRaidPointer();
+  let signups = {};
+  if (previous?.seasonId === seasonId && previous?.weekId && previous.weekId !== weekId && weekId !== 'w1') {
+    const prevSnap = await db.ref(PATHS.signups(previous.seasonId, previous.weekId)).get();
+    signups = prevSnap.val() || {};
+
+    const refreshed = {};
+    await Promise.all(
+      Object.keys(signups).map(async (uid) => {
+        const playerSnap = await db.ref(PATHS.player(uid)).get();
+        const player = playerSnap.val();
+        refreshed[uid] = player ? buildSnapshot(player) : signups[uid];
+      }),
+    );
+    signups = refreshed;
+  }
+
   const baseHp = boss.baseHp ?? boss.hp ?? config.raid.defaultBossHp;
   const bossRecord = {
     name: boss.name,
@@ -102,12 +121,12 @@ export async function setupRaidWeek({ seasonId, weekId, boss, locksAt, startsAt 
     recommended: boss.recommended ?? null,
     status: 'signup',
   };
-  await database().ref().update({
+  await db.ref().update({
     [PATHS.boss(seasonId, weekId)]: bossRecord,
-    // Reset the raid node for muster. Do NOT seed a zeros `team` — the website
-    // computes team stats from `signups` until lock writes the real aggregate;
-    // a zeros object is truthy and would shadow that fallback (showing 0s).
-    [PATHS.raid(seasonId, weekId)]: { signups: {} },
+    // Do NOT seed a zeros `team` — the website computes team stats from
+    // `signups` until lock writes the real aggregate; a zeros object is truthy
+    // and would shadow that fallback (showing 0s).
+    [PATHS.raid(seasonId, weekId)]: { signups },
     [PATHS.configRaid()]: { seasonId, weekId, phase: 'signup', locksAt, startsAt, doneAt: null },
   });
   return { seasonId, weekId, boss: bossRecord };

--- a/test/roster-refresh.test.js
+++ b/test/roster-refresh.test.js
@@ -15,7 +15,9 @@ const runOrSkip = host ? test : test.skip;
 const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
 
 const SEASON = 's_rtest';
+const NEXT_SEASON = 's_rtest_next';
 const WEEK = 'w1';
+const NEXT_WEEK = 'w2';
 const UID = 'u_rtest';
 
 const makePlayer = (level) => ({
@@ -41,7 +43,10 @@ before(async () => {
 after(async () => {
   if (!host) return;
   await database().ref(PATHS.raid(SEASON, WEEK)).remove().catch(() => {});
+  await database().ref(PATHS.raid(SEASON, NEXT_WEEK)).remove().catch(() => {});
+  await database().ref(PATHS.raid(NEXT_SEASON, WEEK)).remove().catch(() => {});
   await database().ref(PATHS.bossesForSeason(SEASON)).remove().catch(() => {});
+  await database().ref(PATHS.bossesForSeason(NEXT_SEASON)).remove().catch(() => {});
   await database().ref(PATHS.player(UID)).remove().catch(() => {});
   await database().ref(PATHS.configRaid()).remove().catch(() => {});
   await closeFirebase();
@@ -77,4 +82,36 @@ runOrSkip('locked phase: the roster is frozen — no refresh', async () => {
   await db.ref(PATHS.player(UID)).update({ level: 9 });
   assert.equal(await refreshMusteredRoster(), 0, 'a locked roster must not be rewritten');
   assert.equal((await getSignup(SEASON, WEEK, UID)).level, 5, 'snapshot stays frozen at lock-time level');
+});
+
+runOrSkip('new boss in the same season inherits the mustered roster', async () => {
+  const db = database();
+  await db.ref(PATHS.player(UID)).set(makePlayer(7));
+  await setupRaidWeek({
+    seasonId: SEASON, weekId: WEEK,
+    boss: { name: 'First Boss', thresholds: { tank: 0, healer: 0, dps: 0 } },
+    locksAt: Date.now() + 3_600_000, startsAt: Date.now() + 7_200_000,
+  });
+  await waitForPointer((p) => p?.seasonId === SEASON && p?.weekId === WEEK && p?.phase === 'signup');
+  await enlist({ seasonId: SEASON, weekId: WEEK, userId: UID, player: makePlayer(7) });
+
+  await db.ref(PATHS.player(UID)).update({ level: 8 });
+  await setupRaidWeek({
+    seasonId: SEASON, weekId: NEXT_WEEK,
+    boss: { name: 'Next Boss', thresholds: { tank: 0, healer: 0, dps: 0 } },
+    locksAt: Date.now() + 10_800_000, startsAt: Date.now() + 14_400_000,
+  });
+
+  const carried = await getSignup(SEASON, NEXT_WEEK, UID);
+  assert.equal(carried.level, 8, 'carry-over uses a fresh player snapshot');
+});
+
+runOrSkip('new season week 1 starts with an empty muster roster', async () => {
+  await setupRaidWeek({
+    seasonId: NEXT_SEASON, weekId: WEEK,
+    boss: { name: 'Fresh Season Boss', thresholds: { tank: 0, healer: 0, dps: 0 } },
+    locksAt: Date.now() + 3_600_000, startsAt: Date.now() + 7_200_000,
+  });
+
+  assert.equal(await getSignup(NEXT_SEASON, WEEK, UID), null, 'season boundary clears participation');
 });


### PR DESCRIPTION
## Summary
- Carry same-season muster signups forward when scheduling a new boss
- Keep season start/rollover as the boundary that clears participation
- Update muster docs/help text and add emulator coverage

## Tests
- npm test
- npm run test:emulator
- git diff --check