### PR TITLE
feat: vertical (9:16) capture on !clip, and a runtime-switchable clip mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,9 @@ FIREBASE_PROJECT_ID=okrafans
 # huge file apiece. Only the local save is gated; Twitch clips (clip mode twitch
 # or both) stay ungated because they cost nothing to make.
 # CAPTURE_MIN_INTERVAL_MS=60000
-# Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.
+# Capture backend: obs-websocket (default when a URL is set) | none.
+# There is no 'aitum' value: Aitum is reached through obs-websocket vendor requests
+# on the same connection (see CAPTURE_VERTICAL_OUTPUT below), not as a backend.
 # CAPTURE_BACKEND=obs-websocket
 #
 # Aitum Stream Suite vertical (9:16) capture — OPTIONAL, and saved ALONGSIDE the
@@ -79,11 +81,14 @@ FIREBASE_PROJECT_ID=okrafans
 # only. The vertical canvas is composed by the streamer for portrait, so this is a
 # natively-framed 9:16 clip rather than a crop of the landscape one.
 #
-# ⚠ Backtrack needs a RECORDING PATH set in the Vertical dock's config → General,
-# and its length should match the OBS replay-buffer length. Without a path the
-# plugin still answers "success" and writes NOTHING — so check for a real file the
-# first time you set this up. kennyBot logs `verticalRequested`, never "saved",
-# because the plugin gives us no way to confirm the write.
+# Configure the output in Aitum Stream Suite Settings → Output → (Backtrack)
+# Output Settings: recording path, Maximum Replay Time (match the OBS replay-buffer
+# length, or one !clip yields two files covering different spans) and Maximum Memory.
+#
+# ⚠ save_backtrack answers {"success": true} on ACCEPTANCE and the plugin gives no
+# way to read back the written path — so kennyBot logs `verticalRequested`, never
+# "saved". VERIFY THE FIRST SETUP FROM OBS'S OWN LOG ("Wrote replay buffer to '…'"),
+# not from the API's reply and not from a directory listing.
 # CAPTURE_VERTICAL_OUTPUT=Vertical Backtrack
 
 # ─── Runtime ───

--- a/.env.example
+++ b/.env.example
@@ -44,14 +44,18 @@ FIREBASE_PROJECT_ID=okrafans
 # FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000
 
 # ─── !clip behaviour — NOT an env var ───
-# What !clip does (local | twitch | both) is RUNTIME config, not environment:
-# it lives in RTDB at config/clipMode, seeded once from `clip.defaultMode` in
-# src/config.js, and mods change it live in chat:
+# WHICH of !clip's three outputs run is RUNTIME config, not environment. It lives
+# in RTDB at config/clipMode, seeded once from `clip.defaultMode` in src/config.js,
+# and mods change it live in chat:
 #
-#   !clipmode local|twitch|both|status
+#   !clipmode horizontal vertical twitch   (combine any of the three)
+#   !clipmode local | all | off | status
 #
 # Deliberately not duplicated here — an env var and a DB value that can disagree
 # is a trap. Same shape as the EXP gate (config.liveGate.defaultExpMode).
+#
+# NOTE the split: the mode decides WHETHER to save the vertical; the env var below
+# (CAPTURE_VERTICAL_OUTPUT) says WHAT that output is called. Both are required.
 
 # ─── Local capture (the default half of !clip) ───
 # Point this at the streamer's OBS (obs-websocket, built into OBS 28+ under

--- a/.env.example
+++ b/.env.example
@@ -43,20 +43,15 @@ FIREBASE_PROJECT_ID=okrafans
 # credentials are needed. Leave EMPTY in production.
 # FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000
 
-# ─── !clip behaviour ───
-# What !clip does. A Twitch clip is capped at your STREAM resolution, so it can
-# never be a 4K keepsake — hence the default is the LOCAL capture, not Twitch:
-#   local  — trigger the streamer's OBS/Aitum capture only; nothing is posted to
-#            Twitch. Needs OBS_WEBSOCKET_URL below, or !clip has nothing to do.
-#   twitch — Twitch clip only (Helix Create Clip; needs clips:edit + a live channel)
-#   both   — do each; the reply carries the Twitch link plus a local-capture note
-# An unrecognised value falls back to 'local' with a warning at boot.
+# ─── !clip behaviour — NOT an env var ───
+# What !clip does (local | twitch | both) is RUNTIME config, not environment:
+# it lives in RTDB at config/clipMode, seeded once from `clip.defaultMode` in
+# src/config.js, and mods change it live in chat:
 #
-# ⚠ This seeds the FIRST BOOT ONLY. After that `config/clipMode` in RTDB is
-# authoritative and mods change it live with `!clipmode local|twitch|both` — so
-# editing this var will NOT change a running deployment's behaviour, by design
-# (a mod's mid-stream switch must survive the next restart).
-# CLIP_MODE=local
+#   !clipmode local|twitch|both|status
+#
+# Deliberately not duplicated here — an env var and a DB value that can disagree
+# is a trap. Same shape as the EXP gate (config.liveGate.defaultExpMode).
 
 # ─── Local capture (the default half of !clip) ───
 # Point this at the streamer's OBS (obs-websocket, built into OBS 28+ under
@@ -72,7 +67,7 @@ FIREBASE_PROJECT_ID=okrafans
 # OBS_TIMEOUT_MS=8000
 # Channel-wide minimum gap between local captures (ms). !clip's own cooldown is
 # PER-USER, so without this a burst of viewers each firing !clip would write one
-# huge file apiece. Only the local save is gated; Twitch clips (CLIP_MODE=twitch
+# huge file apiece. Only the local save is gated; Twitch clips (clip mode twitch
 # or both) stay ungated because they cost nothing to make.
 # CAPTURE_MIN_INTERVAL_MS=60000
 # Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ FIREBASE_PROJECT_ID=okrafans
 #   twitch — Twitch clip only (Helix Create Clip; needs clips:edit + a live channel)
 #   both   — do each; the reply carries the Twitch link plus a local-capture note
 # An unrecognised value falls back to 'local' with a warning at boot.
+#
+# ⚠ This seeds the FIRST BOOT ONLY. After that `config/clipMode` in RTDB is
+# authoritative and mods change it live with `!clipmode local|twitch|both` — so
+# editing this var will NOT change a running deployment's behaviour, by design
+# (a mod's mid-stream switch must survive the next restart).
 # CLIP_MODE=local
 
 # ─── Local capture (the default half of !clip) ───

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,19 @@ FIREBASE_PROJECT_ID=okrafans
 # CAPTURE_MIN_INTERVAL_MS=60000
 # Capture backend: obs-websocket (default when a URL is set) | none. Aitum later.
 # CAPTURE_BACKEND=obs-websocket
+#
+# Aitum Stream Suite vertical (9:16) capture — OPTIONAL, and saved ALONGSIDE the
+# horizontal one on the same connection. Set it to the Backtrack output's name as
+# the plugin reports it (almost always "Vertical Backtrack"); unset = horizontal
+# only. The vertical canvas is composed by the streamer for portrait, so this is a
+# natively-framed 9:16 clip rather than a crop of the landscape one.
+#
+# ⚠ Backtrack needs a RECORDING PATH set in the Vertical dock's config → General,
+# and its length should match the OBS replay-buffer length. Without a path the
+# plugin still answers "success" and writes NOTHING — so check for a real file the
+# first time you set this up. kennyBot logs `verticalRequested`, never "saved",
+# because the plugin gives us no way to confirm the write.
+# CAPTURE_VERTICAL_OUTPUT=Vertical Backtrack
 
 # ─── Runtime ───
 # Stable id for the single-instance lease (defaults to hostname:pid if unset).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ about the capture rig · the capture rate limit is channel-wide, not per-user ·
 vertical (Aitum Backtrack) capture reports `requested`, **never** `saved` — the
 plugin answers `success` on acceptance and gives no way to confirm the write.
 
-The clip mode has **no env var**: it lives in RTDB (`config/clipMode`), seeded once
-from `clip.defaultMode` in `src/config.js`, and mods change it live via `!clipmode`.
+The clip mode is a **set of targets** — `horizontal` · `vertical` · `twitch`, combined
+freely (`local`/`all`/`off` are aliases) — with **no env var**: it lives in RTDB
+(`config/clipMode`), seeded once from `clip.defaultMode`, changed live via `!clipmode`.
+`CAPTURE_VERTICAL_OUTPUT` is separate and says only what the vertical output is *named*.
 
 When verifying a capture, **read OBS's own log** (`Wrote replay buffer to '…'`) —
 not the vendor API's return value, and not a filesystem listing (WSL serves stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,14 @@ The four that get forgotten most:
    processing stage. kennyBot never hands files to the archiver. The only thing it
    produces for it is the `!start` sync anchor, which is *data*, not a file handoff.
 
-Invariants (each has a test): `CLIP_MODE` defaults to `local` and never silently
+Invariants (each has a test): the clip mode defaults to `local` and never silently
 falls back to Twitch · capture failure never breaks chat · chat replies leak nothing
 about the capture rig · the capture rate limit is channel-wide, not per-user · the
 vertical (Aitum Backtrack) capture reports `requested`, **never** `saved` — the
 plugin answers `success` on acceptance and gives no way to confirm the write.
+
+`CLIP_MODE` seeds the first boot only; `config/clipMode` in RTDB then wins, changed
+live by mods via `!clipmode`. Editing the env var will not move a running deployment.
 
 When verifying a capture, **read OBS's own log** (`Wrote replay buffer to '…'`) —
 not the vendor API's return value, and not a filesystem listing (WSL serves stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ about the capture rig · the capture rate limit is channel-wide, not per-user ·
 vertical (Aitum Backtrack) capture reports `requested`, **never** `saved` — the
 plugin answers `success` on acceptance and gives no way to confirm the write.
 
-`CLIP_MODE` seeds the first boot only; `config/clipMode` in RTDB then wins, changed
-live by mods via `!clipmode`. Editing the env var will not move a running deployment.
+The clip mode has **no env var**: it lives in RTDB (`config/clipMode`), seeded once
+from `clip.defaultMode` in `src/config.js`, and mods change it live via `!clipmode`.
 
 When verifying a capture, **read OBS's own log** (`Wrote replay buffer to '…'`) —
 not the vendor API's return value, and not a filesystem listing (WSL serves stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,13 @@ The four that get forgotten most:
 
 Invariants (each has a test): `CLIP_MODE` defaults to `local` and never silently
 falls back to Twitch · capture failure never breaks chat · chat replies leak nothing
-about the capture rig · the capture rate limit is channel-wide, not per-user.
+about the capture rig · the capture rate limit is channel-wide, not per-user · the
+vertical (Aitum Backtrack) capture reports `requested`, **never** `saved` — the
+plugin answers `success` on acceptance and gives no way to confirm the write.
+
+When verifying a capture, **read OBS's own log** (`Wrote replay buffer to '…'`) —
+not the vendor API's return value, and not a filesystem listing (WSL serves stale
+metadata for `/mnt/c`, which has already caused one wrong diagnosis).
 
 ## Repo conventions
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ Recording settings.** Neither exceeds stream quality until those are raised.
 `!clipmode local|twitch|both|status` — mod-only, takes effect on the **next**
 `!clip`, and persists across restarts.
 
-This is deliberately a **runtime** setting rather than env-only. If the streamer's
-OBS dies mid-stream, `local` mode leaves `!clip` with nothing to do; recovering via
-SSH, an env-file edit and a container restart is not a route anyone takes mid-show.
-`CLIP_MODE` seeds the **first boot only** — after that RTDB (`config/clipMode`) is
-authoritative, so a mod's choice isn't silently reverted by the container's env.
+This is deliberately a **runtime** setting with **no environment variable**. If the
+streamer's OBS dies mid-stream, `local` mode leaves `!clip` with nothing to do;
+recovering via SSH, an env-file edit and a container restart is not a route anyone
+takes mid-show. The value lives in RTDB (`config/clipMode`), seeded once from
+`clip.defaultMode` in `src/config.js` — the same shape as the EXP gate. There is no
+second place that can disagree with it.
 
 `!clipmode status` reports the mode *and* whether each half can actually run, and a
 switch to a mode nothing is configured for warns immediately rather than leaving a
@@ -213,7 +214,6 @@ gitignored). Secrets arrive at runtime, never baked into the image.
 | `FIREBASE_DATABASE_EMULATOR_HOST` | *local only* — targets the emulator; leave empty in prod |
 | `TOKEN_STORE_DIR` | dir for the persisted refresh-token store (the `/data` volume) |
 | `TWITCH_SEND_MODE` | chat transport — `auto` (default, Helix + IRC fallback) · `helix` (Chat Bot badge) · `irc` |
-| `CLIP_MODE` | what `!clip` does — `local` (**default**: OBS/Aitum capture only, nothing posted to Twitch) · `twitch` · `both`. **Seeds the first boot only**; after that RTDB wins and mods change it with `!clipmode` |
 | `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` | the streamer's OBS (obs-websocket, over the tailnet) — required for the local capture |
 | `CAPTURE_VERTICAL_OUTPUT` | *optional* — Aitum Stream Suite Backtrack output name (e.g. `Vertical Backtrack`); also saves a natively-framed 9:16 clip. Unset = horizontal only |
 | `OBS_TIMEOUT_MS` / `CAPTURE_MIN_INTERVAL_MS` / `CAPTURE_BACKEND` | *optional* capture knobs — request deadline, channel-wide gap between local saves, backend |

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ gitignored). Secrets arrive at runtime, never baked into the image.
 | `TWITCH_SEND_MODE` | chat transport — `auto` (default, Helix + IRC fallback) · `helix` (Chat Bot badge) · `irc` |
 | `CLIP_MODE` | what `!clip` does — `local` (**default**: OBS/Aitum capture only, nothing posted to Twitch) · `twitch` · `both` |
 | `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` | the streamer's OBS (obs-websocket, over the tailnet) — required for the local capture |
+| `CAPTURE_VERTICAL_OUTPUT` | *optional* — Aitum Stream Suite Backtrack output name (e.g. `Vertical Backtrack`); also saves a natively-framed 9:16 clip. Unset = horizontal only |
 | `OBS_TIMEOUT_MS` / `CAPTURE_MIN_INTERVAL_MS` / `CAPTURE_BACKEND` | *optional* capture knobs — request deadline, channel-wide gap between local saves, backend |
 | `INSTANCE_ID` / `LOG_LEVEL` / `HEARTBEAT_FILE` | optional runtime knobs |
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!equip <item>` | everyone | equip an owned item into its slot |
 | `!grab` / `!loot` | **subs** | roll for the active drop (independent rolls within the window) |
 | `!muster` | everyone* | sign up for this season's raid roster (during muster) / see status |
+| `!clip` | everyone | capture the last ~60s — local 9:16 + 16:9 by default, Twitch clip if the mode says so |
+| `!clipmode local\|twitch\|both\|status` | mod | change what `!clip` does, live — no redeploy (see below) |
 | `!exp on\|off\|auto\|status` | mod | control the EXP gate (`on` bypasses live for testing) |
 | `!mute on\|off\|status` | mod | silence the bot's chat output when it gets noisy; it keeps listening, tracking EXP, and holding the lease — bare `!mute` toggles |
 | `!drop [item]` | mod | force a single loot drop |
@@ -175,6 +177,21 @@ Two things that are commonly assumed and are false:
 Both ingest paths are bounded by the same ceiling: **the OBS canvas resolution and
 Recording settings.** Neither exceeds stream quality until those are raised.
 
+### Switching what `!clip` does, live
+
+`!clipmode local|twitch|both|status` — mod-only, takes effect on the **next**
+`!clip`, and persists across restarts.
+
+This is deliberately a **runtime** setting rather than env-only. If the streamer's
+OBS dies mid-stream, `local` mode leaves `!clip` with nothing to do; recovering via
+SSH, an env-file edit and a container restart is not a route anyone takes mid-show.
+`CLIP_MODE` seeds the **first boot only** — after that RTDB (`config/clipMode`) is
+authoritative, so a mod's choice isn't silently reverted by the container's env.
+
+`!clipmode status` reports the mode *and* whether each half can actually run, and a
+switch to a mode nothing is configured for warns immediately rather than leaving a
+viewer to discover it.
+
 The one point of contact is `!start` (`src/db/clipSync.js`), which writes a per-stream
 sync anchor to RTDB — *data the archiver reads*, not a file handoff, and it works
 whether or not local capture is configured.
@@ -196,7 +213,7 @@ gitignored). Secrets arrive at runtime, never baked into the image.
 | `FIREBASE_DATABASE_EMULATOR_HOST` | *local only* — targets the emulator; leave empty in prod |
 | `TOKEN_STORE_DIR` | dir for the persisted refresh-token store (the `/data` volume) |
 | `TWITCH_SEND_MODE` | chat transport — `auto` (default, Helix + IRC fallback) · `helix` (Chat Bot badge) · `irc` |
-| `CLIP_MODE` | what `!clip` does — `local` (**default**: OBS/Aitum capture only, nothing posted to Twitch) · `twitch` · `both` |
+| `CLIP_MODE` | what `!clip` does — `local` (**default**: OBS/Aitum capture only, nothing posted to Twitch) · `twitch` · `both`. **Seeds the first boot only**; after that RTDB wins and mods change it with `!clipmode` |
 | `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` | the streamer's OBS (obs-websocket, over the tailnet) — required for the local capture |
 | `CAPTURE_VERTICAL_OUTPUT` | *optional* — Aitum Stream Suite Backtrack output name (e.g. `Vertical Backtrack`); also saves a natively-framed 9:16 clip. Unset = horizontal only |
 | `OBS_TIMEOUT_MS` / `CAPTURE_MIN_INTERVAL_MS` / `CAPTURE_BACKEND` | *optional* capture knobs — request deadline, channel-wide gap between local saves, backend |

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!equip <item>` | everyone | equip an owned item into its slot |
 | `!grab` / `!loot` | **subs** | roll for the active drop (independent rolls within the window) |
 | `!muster` | everyone* | sign up for this season's raid roster (during muster) / see status |
-| `!clip` | everyone | capture the last ~60s — local 9:16 + 16:9 by default, Twitch clip if the mode says so |
-| `!clipmode local\|twitch\|both\|status` | mod | change what `!clip` does, live — no redeploy (see below) |
+| `!clip` | everyone | capture the last ~60s — 16:9 + 9:16 local files by default; Twitch clip only if the mode says so |
+| `!clipmode <targets>` | mod | pick which of `!clip`'s three outputs run — `horizontal` · `vertical` · `twitch`, combined freely (see below) |
 | `!exp on\|off\|auto\|status` | mod | control the EXP gate (`on` bypasses live for testing) |
 | `!mute on\|off\|status` | mod | silence the bot's chat output when it gets noisy; it keeps listening, tracking EXP, and holding the lease — bare `!mute` toggles |
 | `!drop [item]` | mod | force a single loot drop |
@@ -179,8 +179,36 @@ Recording settings.** Neither exceeds stream quality until those are raised.
 
 ### Switching what `!clip` does, live
 
-`!clipmode local|twitch|both|status` — mod-only, takes effect on the **next**
-`!clip`, and persists across restarts.
+`!clip` can produce **three independent outputs**, and the mode is the *set* of them
+you want — so every combination is one command, with no extra config values:
+
+| Target | What you get |
+|---|---|
+| `horizontal` | OBS's main replay buffer → **16:9** file on the streamer's PC |
+| `vertical` | Aitum's Backtrack output → **9:16** file, natively framed for portrait |
+| `twitch` | Helix Create Clip → a public **clip link** posted in chat |
+
+```
+!clipmode horizontal vertical         both local files, nothing on Twitch (default)
+!clipmode horizontal                  16:9 only
+!clipmode vertical twitch             9:16 file + a Twitch link
+!clipmode horizontal vertical twitch  everything
+!clipmode local                       alias for horizontal+vertical
+!clipmode all                         alias for all three
+!clipmode off                         !clip disabled
+!clipmode status                      what's set, and whether each part can run
+```
+
+Order doesn't matter and commas are optional — `vertical,horizontal` stores the same
+value as `horizontal vertical`. One unrecognised word rejects the whole line rather
+than silently applying part of it, because the symptom of a half-applied mode is a
+clip that quietly never gets made.
+
+`vertical` also needs `CAPTURE_VERTICAL_OUTPUT` set (that's the output's *name* —
+plumbing); the mode decides *whether* to save it. Both must hold, and `status` says
+which one is missing.
+
+Mod-only, takes effect on the **next** `!clip`, and persists across restarts.
 
 This is deliberately a **runtime** setting with **no environment variable**. If the
 streamer's OBS dies mid-stream, `local` mode leaves `!clip` with nothing to do;

--- a/database.rules.json
+++ b/database.rules.json
@@ -14,6 +14,7 @@
       ".write": false,
       "live": { ".read": true },
       "expMode": { ".read": true },
+      "clipMode": { ".read": true },
       "season": { ".read": true },
       "raid": { ".read": true },
       "lock": { ".read": true },

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -207,6 +207,25 @@ unless you're also changing the website.
 
 ---
 
+## `clip` — what `!clip` does
+
+| Key | Default | What it controls | Effect of changing it |
+|---|---|---|---|
+| `defaultMode` | `'local'` | The **seed default** for `!clip`: `local` (trigger the streamer's OBS/Aitum capture, post nothing to Twitch), `twitch` (Twitch clip only), `both`. Stored in RTDB on first boot; thereafter controlled by `!clipmode`. | Leave `local`. A Twitch clip is capped at your *stream* resolution, so it can never be the high-quality keepsake — that's the whole point of the local capture. (Change it live with `!clipmode`, not by editing this after first boot — see the seeding caveat.) |
+
+Same seeding rule as `defaultExpMode`: **editing this does nothing to an existing
+deployment**, because `config/clipMode` is already populated. Use `!clipmode` in chat.
+
+`!clipmode status` also reports whether each half can actually run — useful when
+`!clip` is telling viewers clipping isn't set up and you want to know which piece is
+missing.
+
+> Clip **length** is not configured here, or anywhere in kennyBot — it comes from
+> OBS's Replay Buffer and Aitum's Backtrack settings on the streamer's PC. See
+> [`clip-architecture.md`](clip-architecture.md).
+
+---
+
 ## `lock` — single-instance lease
 
 kennyBot must run as exactly one instance (two = double EXP/loot). A lease in

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -39,15 +39,16 @@ so a mod can change them **while the bot is running**. These are the
 | **EXP gate** — on / off / auto | `!exp on` · `!exp off` · `!exp auto` · `!exp status` | `config/expMode` |
 | **Chat output mute** — silence sends, keep listening | `!mute on` · `!mute off` · `!mute status` (bare `!mute` toggles) | `config/chatMuted` |
 | **Auto drop scheduler** — on/off + interval | `!drops on` · `!drops off` · `!drops every <min>` · `!drops status` | `config/dropScheduler` |
+| **Clip mode** — which of `!clip`'s outputs run | `!clipmode horizontal vertical twitch` · `!clipmode local\|all\|off` · `!clipmode status` | `config/clipMode` |
 | **Live status** (set automatically by Twitch) | _(no command — EventSub / Helix poll set it)_ | `config/live` |
 | **Active season** | `!season start <id>` · `!season rollover <id>` | `config/season/current` |
 | **Active raid / boss / phase** | `!boss set <name>` · `!boss next` · `!raidnight` | `config/raid`, `bosses/...` |
 
-**Important seeding caveat.** For the two settings that have *both* a `config.js`
-default *and* an RTDB home — the **EXP mode** (`liveGate.defaultExpMode`) and the
-**drop scheduler** (`loot.scheduler.enabled` / `intervalSec`) — the `config.js`
-value is only used to **seed RTDB the very first time** the bot connects to an
-empty database. After that first boot, the live value lives in RTDB and is
+**Important seeding caveat.** For the settings that have *both* a `config.js`
+default *and* an RTDB home — the **EXP mode** (`liveGate.defaultExpMode`), the
+**drop scheduler** (`loot.scheduler.enabled` / `intervalSec`) and the **clip mode**
+(`clip.defaultMode`) — the `config.js` value is only used to **seed RTDB the very
+first time** the bot connects to an empty database. After that first boot, the live value lives in RTDB and is
 controlled by the chat commands above. Editing those defaults in `config.js`
 later and restarting will **not** override what's already in RTDB. Use the chat
 commands to change them once the bot has run once.
@@ -211,7 +212,7 @@ unless you're also changing the website.
 
 | Key | Default | What it controls | Effect of changing it |
 |---|---|---|---|
-| `defaultMode` | `'local'` | The **seed default** for `!clip`: `local` (trigger the streamer's OBS/Aitum capture, post nothing to Twitch), `twitch` (Twitch clip only), `both`. Stored in RTDB on first boot; thereafter controlled by `!clipmode`. | Leave `local`. A Twitch clip is capped at your *stream* resolution, so it can never be the high-quality keepsake — that's the whole point of the local capture. (Change it live with `!clipmode`, not by editing this after first boot — see the seeding caveat.) |
+| `defaultMode` | `'horizontal,vertical'` | The **seed default** for `!clip`, as a set of targets: `horizontal` (16:9 local file), `vertical` (9:16 local file), `twitch` (public clip link) — any combination, plus the shorthands `local`, `all`, `off`. Stored in RTDB on first boot; thereafter controlled by `!clipmode`. | Leave it. A Twitch clip is capped at your *stream* resolution, so it can never be the high-quality keepsake — that's the whole point of the local capture. (Change it live with `!clipmode`, not by editing this after first boot — see the seeding caveat.) |
 
 Same seeding rule as `defaultExpMode`: **editing this does nothing to an existing
 deployment**, because `config/clipMode` is already populated. Use `!clipmode` in chat.

--- a/docs/clip-architecture.md
+++ b/docs/clip-architecture.md
@@ -101,6 +101,26 @@ encoder** on that output in the Aitum settings; miss any and it silently writes
 nothing. **OBS's own log is the source of truth** (`Wrote replay buffer to '…'`) —
 check it before believing either the API or a filesystem listing.
 
+### Clip length — set in OBS, not in kennyBot
+
+**kennyBot has no length setting.** It says "save"; it gets whatever is buffered.
+Length is entirely OBS-side, in **three independent places that must be aligned**:
+
+| What | Where | Note |
+|---|---|---|
+| Horizontal | OBS → Settings → Output → **Replay Buffer → Maximum Replay Time** | `RecRBTime` in the profile |
+| Vertical | Aitum settings → Outputs → Backtrack → **Maximum Replay Time** | plus **Maximum Memory**, a second cap |
+| Twitch clip | — | **not controllable.** Twitch decides (~30s) |
+
+If the two buffers disagree, one `!clip` yields a pair of files covering *different
+spans of time*, which makes them painful to cut together. Aitum's own docs say to
+match them.
+
+Both are also capped by **memory**: a buffer holds `min(time, size)`, so a generous
+Maximum Replay Time with a small Maximum Memory silently yields short clips. A
+vertical clip coming out shorter than the horizontal is normal if the Backtrack
+output was started later — the buffer simply hasn't filled yet.
+
 ### Why Ingest A currently carries the load
 
 Ingest B was the original plan for the archiver — re-cut any moment from a
@@ -113,7 +133,7 @@ above-stream quality, which makes Ingest A the primary path, not a convenience.
 ## What kennyBot does and does not do
 
 **Does:**
-- `!clip` → triggers the local capture and/or a Twitch clip, per `CLIP_MODE`
+- `!clip` → triggers the local capture and/or a Twitch clip, per the live clip mode
   (`src/commands/clip.js`)
 - Talks obs-websocket to save the replay buffer (`src/integrations/obsWebsocket.js`)
 - Rate-limits local captures channel-wide (`src/integrations/capture.js`)
@@ -135,20 +155,22 @@ configured.
 
 | Concern | Where |
 |---|---|
-| `!clip` command, `CLIP_MODE` routing | `src/commands/clip.js` |
+| `!clip` command, clip-mode routing | `src/commands/clip.js` |
+| `!clipmode` (mod, live switch) | `src/commands/mod/clipmode.js` |
 | Capture facade (backend-agnostic, rate limit) | `src/integrations/capture.js` |
 | obs-websocket v5 client + replay-buffer sequence | `src/integrations/obsWebsocket.js` |
 | Aitum vertical Backtrack (vendor requests) | `src/integrations/obsWebsocket.js` (`verticalBacktrackSequence`) |
 | Twitch clip creation (Helix) | `src/twitch/clips.js` |
 | `!start` sync anchor | `src/commands/start.js`, `src/db/clipSync.js` |
-| Config contract | `.env.example` (`CLIP_MODE`, `OBS_*`, `CAPTURE_*`) |
+| Clip mode (runtime) | RTDB `config/clipMode` · default `clip.defaultMode` in `src/config.js` |
+| Config contract | `.env.example` (`OBS_*`, `CAPTURE_*`) |
 | Vertical re-cut, job queue, uploads | okra-clip-archiver (**separate repo**) |
 
 ---
 
 ## Invariants — breaking these is a regression
 
-1. **`CLIP_MODE` defaults to `local`.** `!clip` does not create a Twitch clip unless
+1. **The clip mode defaults to `local`.** `!clip` does not create a Twitch clip unless
    explicitly asked. It must never silently fall back to Twitch when capture is
    unconfigured — that defeats the mode. (`test/rules/clip-command.test.js`)
 2. **Capture failure never breaks chat.** A PC that's off, OBS closed, or a dead
@@ -177,17 +199,19 @@ configured.
 |---|---|
 | `!clip` local capture (horizontal) | built, deployed, verified against a real OBS |
 | `!clip` vertical capture (Aitum Backtrack) | built, **verified end to end** — one `!clip` wrote a 1920×1080 and a 1080×1920 file one second apart |
-| `CLIP_MODE` default `local` | live on faraday (v0.8.0) |
+| clip mode default `local` | live on faraday (v0.8.0) |
 | Local capture on prod | **inert** — no `OBS_WEBSOCKET_URL` set; boot log warns |
 | Chat Bot badge on the prod channel | **falling back to IRC** — bot is not yet a moderator there |
 | Full-session recording (Ingest B) | not established |
 | okra-clip-archiver | processing half built; ingest source unsettled |
 
-**`CLIP_MODE` is runtime config, not env-only.** `CLIP_MODE` seeds the *first boot*;
-after that `config/clipMode` in RTDB is authoritative and mods change it from chat
-with `!clipmode local|twitch|both`. This exists because the streamer's OBS can die
-mid-stream, and recovering by SSH + env edit + container restart is not a route
-anyone takes mid-show. **The env var does not win it back on the next restart.**
+**The clip mode is runtime config with NO environment variable.** It lives in RTDB
+at `config/clipMode`, seeded once from `clip.defaultMode` in `src/config.js`, and
+mods change it from chat with `!clipmode local|twitch|both`. This exists because the
+streamer's OBS can die mid-stream, and recovering by SSH + env edit + container
+restart is not a route anyone takes mid-show. Deliberately **one** source of truth —
+an env var and a DB value that can disagree is a trap, and the EXP gate
+(`liveGate.defaultExpMode`) already establishes this shape.
 
 `CAPTURE_*` and `OBS_*` remain env-only — they describe the deployment's topology
 (which machine, which credentials), not an operational choice a mod should make.

--- a/docs/clip-architecture.md
+++ b/docs/clip-architecture.md
@@ -96,10 +96,15 @@ The vendor requests that matter:
 | `save_backtrack` | `{output: "Vertical Backtrack"}` |
 
 ⚠ **`save_backtrack` returning `{"success": true}` does not mean a file exists** —
-see invariant 5. Setting it up requires a **recording path, a length, and a video
-encoder** on that output in the Aitum settings; miss any and it silently writes
-nothing. **OBS's own log is the source of truth** (`Wrote replay buffer to '…'`) —
-check it before believing either the API or a filesystem listing.
+it reports acceptance, and the vendor API exposes no way to read back the written
+path (invariant 5). Configure the output in Aitum Stream Suite Settings → Output →
+(Backtrack) Output Settings: recording path, Maximum Replay Time, Maximum Memory.
+
+**OBS's own log is the source of truth** (`Wrote replay buffer to '…'`). During
+bring-up this was verified the hard way in the opposite direction: captures were
+landing correctly for over an hour while a WSL directory listing showed nothing —
+`/mnt/c` served stale metadata, and `ls -t` even reported a four-day-old file as the
+newest. Trust the log over the API's reply *and* over the filesystem.
 
 ### Clip length — set in OBS, not in kennyBot
 

--- a/docs/clip-architecture.md
+++ b/docs/clip-architecture.md
@@ -72,6 +72,35 @@ one file per !clip                      every moment, retrievable after the fact
 alignment reference* (see `!start` below). Per constraint 2 it can never improve
 quality, so it is never the video source.
 
+### Ingest A saves TWO files: horizontal and vertical
+
+Aitum Stream Suite adds a second **1080×1920 canvas** with its own replay buffer,
+**Backtrack**. The streamer composes that canvas for portrait — so its capture is a
+**natively framed 9:16 clip**, not a crop of the landscape one. That is strictly
+better than any after-the-fact crop, which can only guess where the subject was.
+
+Enabled with `CAPTURE_VERTICAL_OUTPUT` (the Backtrack output's name, normally
+`Vertical Backtrack`); unset means horizontal only. Both saves ride **one**
+obs-websocket connection: Stream Suite exposes its API as obs-websocket *vendor
+requests* under the vendor name `aitum-stream-suite`, so this needs no new
+transport, no new dependency, and **not Aitum Nexus** (Nexus is a separate
+automation product and is not on this path).
+
+The vendor requests that matter:
+
+| Request | Params |
+|---|---|
+| `get_canvas` · `get_outputs` · `version` | — |
+| `get_scenes` | `{canvas: "Vertical"}` (case-sensitive) |
+| `start_output` / `stop_output` | `{output: "Vertical Backtrack"}` |
+| `save_backtrack` | `{output: "Vertical Backtrack"}` |
+
+⚠ **`save_backtrack` returning `{"success": true}` does not mean a file exists** —
+see invariant 5. Setting it up requires a **recording path, a length, and a video
+encoder** on that output in the Aitum settings; miss any and it silently writes
+nothing. **OBS's own log is the source of truth** (`Wrote replay buffer to '…'`) —
+check it before believing either the API or a filesystem listing.
+
 ### Why Ingest A currently carries the load
 
 Ingest B was the original plan for the archiver — re-cut any moment from a
@@ -109,6 +138,7 @@ configured.
 | `!clip` command, `CLIP_MODE` routing | `src/commands/clip.js` |
 | Capture facade (backend-agnostic, rate limit) | `src/integrations/capture.js` |
 | obs-websocket v5 client + replay-buffer sequence | `src/integrations/obsWebsocket.js` |
+| Aitum vertical Backtrack (vendor requests) | `src/integrations/obsWebsocket.js` (`verticalBacktrackSequence`) |
 | Twitch clip creation (Helix) | `src/twitch/clips.js` |
 | `!start` sync anchor | `src/commands/start.js`, `src/db/clipSync.js` |
 | Config contract | `.env.example` (`CLIP_MODE`, `OBS_*`, `CAPTURE_*`) |
@@ -129,9 +159,14 @@ configured.
 4. **The local-capture rate limit is channel-wide**, deliberately separate from
    `!clip`'s per-user cooldown — N viewers clipping in a minute must not write N
    large files.
-5. **Aitum is a future second backend**, behind the same facade. It does not change
-   any of the above.
-6. **No real addresses, hostnames or credentials in the repo** — this is public. Use
+5. **The vertical capture reports `requested`, never `saved`.** Aitum answers
+   `{"success": true}` on *acceptance*, and exposes no way to read back the written
+   path — so acceptance must never be promoted to "a file exists". Verified the hard
+   way: a misconfigured output returned success for 90 minutes while writing nothing.
+   (`test/rules/capture.test.js` asserts the result carries neither `path` nor `saved`)
+6. **A vertical failure never costs the horizontal capture.** It runs after the
+   horizontal save and is caught separately.
+7. **No real addresses, hostnames or credentials in the repo** — this is public. Use
    placeholders (`ws://<obs-host>:4455`).
 
 ---
@@ -140,12 +175,16 @@ configured.
 
 | Thing | State |
 |---|---|
-| `!clip` local capture | built, deployed, verified against a real OBS |
+| `!clip` local capture (horizontal) | built, deployed, verified against a real OBS |
+| `!clip` vertical capture (Aitum Backtrack) | built, **verified end to end** — one `!clip` wrote a 1920×1080 and a 1080×1920 file one second apart |
 | `CLIP_MODE` default `local` | live on faraday (v0.8.0) |
 | Local capture on prod | **inert** — no `OBS_WEBSOCKET_URL` set; boot log warns |
 | Chat Bot badge on the prod channel | **falling back to IRC** — bot is not yet a moderator there |
 | Full-session recording (Ingest B) | not established |
 | okra-clip-archiver | processing half built; ingest source unsettled |
+
+`CLIP_MODE` and `CAPTURE_*` are **environment variables read once at boot**, not RTDB
+config — changing them needs a container restart, unlike the EXP gate or chat mute.
 
 ---
 

--- a/docs/clip-architecture.md
+++ b/docs/clip-architecture.md
@@ -183,8 +183,14 @@ configured.
 | Full-session recording (Ingest B) | not established |
 | okra-clip-archiver | processing half built; ingest source unsettled |
 
-`CLIP_MODE` and `CAPTURE_*` are **environment variables read once at boot**, not RTDB
-config — changing them needs a container restart, unlike the EXP gate or chat mute.
+**`CLIP_MODE` is runtime config, not env-only.** `CLIP_MODE` seeds the *first boot*;
+after that `config/clipMode` in RTDB is authoritative and mods change it from chat
+with `!clipmode local|twitch|both`. This exists because the streamer's OBS can die
+mid-stream, and recovering by SSH + env edit + container restart is not a route
+anyone takes mid-show. **The env var does not win it back on the next restart.**
+
+`CAPTURE_*` and `OBS_*` remain env-only — they describe the deployment's topology
+(which machine, which credentials), not an operational choice a mod should make.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,11 @@ function requireEnv() {
 
 async function touchHeartbeat() {
   try {
+    // clipMode is RUNTIME config — a mod can change it with `!clipmode` at any
+    // moment, so read it at write time. Capturing it once at boot would make the
+    // snapshot quietly lie about what the bot is doing, which is the one thing a
+    // health snapshot must never do.
+    health.clipMode = activeClipMode();
     await writeFile(HEARTBEAT_FILE, JSON.stringify({ ts: Date.now(), ...health }));
   } catch {
     /* best effort */
@@ -201,8 +206,7 @@ async function main() {
   // restores the Helix-clip-only behaviour; 'both' does each.
   // Lives in RTDB (`config/clipMode`), seeded once from config.clip.defaultMode and
   // changed live by mods with `!clipmode` — there is no env var to disagree with.
-  const clipMode = activeClipMode();
-  health.clipMode = clipMode;
+  const clipMode = activeClipMode(); // logged once; the snapshot re-reads it live
   logger.info('clip mode', { mode: clipMode, localCapture: captureReady() });
   if (clipMode === 'local' && !captureReady()) {
     logger.warn(

--- a/index.js
+++ b/index.js
@@ -18,9 +18,8 @@ import { buildAuth } from './src/twitch/auth.js';
 import { createSender } from './src/twitch/sender.js';
 import { initClips } from './src/twitch/clips.js';
 import { initCapture, captureReady } from './src/integrations/capture.js';
-// The !clip command owns CLIP_MODE; index.js only resolves it once at boot so a
-// typo is caught in the startup log rather than on the first viewer's !clip.
-import { resolveClipMode, activeClipMode } from './src/commands/clip.js';
+// Read once at boot purely to log what's in force; the live value is RTDB-backed.
+import { activeClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
@@ -200,21 +199,11 @@ async function main() {
   // capture and post NO Twitch clip — a Twitch clip is capped at the stream
   // resolution, so the local recording is the copy worth keeping. 'twitch'
   // restores the Helix-clip-only behaviour; 'both' does each.
-  const rawClipMode = (process.env.CLIP_MODE || '').toLowerCase();
-  const envClipMode = resolveClipMode(rawClipMode);
-  if (rawClipMode && rawClipMode !== envClipMode) {
-    logger.warn('unknown CLIP_MODE — using local', { value: process.env.CLIP_MODE });
-  }
-  // RTDB wins once seeded (a mod's `!clipmode` must outlive the container's env),
-  // so report what's ACTUALLY in force — otherwise the startup log contradicts the
-  // running behaviour and sends the next person to edit the wrong thing.
+  // Lives in RTDB (`config/clipMode`), seeded once from config.clip.defaultMode and
+  // changed live by mods with `!clipmode` — there is no env var to disagree with.
   const clipMode = activeClipMode();
   health.clipMode = clipMode;
-  logger.info('clip mode', {
-    mode: clipMode,
-    source: clipMode === envClipMode ? 'env/rtdb' : 'rtdb (overrides CLIP_MODE)',
-    localCapture: captureReady(),
-  });
+  logger.info('clip mode', { mode: clipMode, localCapture: captureReady() });
   if (clipMode === 'local' && !captureReady()) {
     logger.warn(
       '!clip has nothing to do: clip mode is local but no capture backend is configured — set OBS_WEBSOCKET_URL, or switch with `!clipmode twitch` in chat',

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ import { initClips } from './src/twitch/clips.js';
 import { initCapture, captureReady } from './src/integrations/capture.js';
 // The !clip command owns CLIP_MODE; index.js only resolves it once at boot so a
 // typo is caught in the startup log rather than on the first viewer's !clip.
-import { resolveClipMode } from './src/commands/clip.js';
+import { resolveClipMode, activeClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
 import { startEventSub } from './src/twitch/eventsub.js';
 import { advanceRaidPhases, refreshMusteredRoster } from './src/db/raid.js';
@@ -201,15 +201,23 @@ async function main() {
   // resolution, so the local recording is the copy worth keeping. 'twitch'
   // restores the Helix-clip-only behaviour; 'both' does each.
   const rawClipMode = (process.env.CLIP_MODE || '').toLowerCase();
-  const clipMode = resolveClipMode(rawClipMode);
-  if (rawClipMode && rawClipMode !== clipMode) {
+  const envClipMode = resolveClipMode(rawClipMode);
+  if (rawClipMode && rawClipMode !== envClipMode) {
     logger.warn('unknown CLIP_MODE — using local', { value: process.env.CLIP_MODE });
   }
+  // RTDB wins once seeded (a mod's `!clipmode` must outlive the container's env),
+  // so report what's ACTUALLY in force — otherwise the startup log contradicts the
+  // running behaviour and sends the next person to edit the wrong thing.
+  const clipMode = activeClipMode();
   health.clipMode = clipMode;
-  logger.info('clip mode', { mode: clipMode, localCapture: captureReady() });
+  logger.info('clip mode', {
+    mode: clipMode,
+    source: clipMode === envClipMode ? 'env/rtdb' : 'rtdb (overrides CLIP_MODE)',
+    localCapture: captureReady(),
+  });
   if (clipMode === 'local' && !captureReady()) {
     logger.warn(
-      '!clip has nothing to do: CLIP_MODE=local but no capture backend is configured — set OBS_WEBSOCKET_URL, or CLIP_MODE=twitch/both',
+      '!clip has nothing to do: clip mode is local but no capture backend is configured — set OBS_WEBSOCKET_URL, or switch with `!clipmode twitch` in chat',
     );
   }
 

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -48,7 +48,7 @@ export default {
   names: ['clip'],
   mod: false,
   cooldownMs: 60_000, // per-user: a viewer can clip at most once a minute
-  help: '!clip — clip the last ~30s of the stream',
+  help: '!clip — capture the last ~60s of the stream',
   async run({ user, reply, logger }) {
     const mode = activeClipMode();
     let twitch = mode !== 'local' && clipsReady();

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -1,6 +1,6 @@
 // !clip — grab the last ~30–60s of the stream.
 //
-// TWO independent halves, selected by CLIP_MODE:
+// TWO independent halves, selected by the live clip mode (`!clipmode`):
 //   local  (default) — tell the streamer's OBS/Aitum to save its replay buffer at
 //                      full recording quality. Nothing is posted to Twitch.
 //   twitch           — Helix Create Clip only (the original behaviour).
@@ -10,28 +10,22 @@
 // (≤1080p here) while the local recording is whatever the camera actually shot —
 // the high-quality copy is the point of the command.
 import { getConfig, parseClipMode, CLIP_MODES } from '../db/configStore.js';
+import { config as gameConfig } from '../config.js';
 import { createChannelClip, clipsReady } from '../twitch/clips.js';
 import { triggerCapture, captureReady } from '../integrations/capture.js';
 
 export { CLIP_MODES };
 
 /**
- * Resolve the mode from the ENV var, defaulting to 'local'. This is only the
- * first-boot seed and the fallback before the config mirror is warm — the live
- * value comes from RTDB (see activeClipMode).
- */
-export function resolveClipMode(raw = process.env.CLIP_MODE) {
-  return parseClipMode(raw);
-}
-
-/**
- * The mode in force right now. RTDB (`config/clipMode`, set by `!clipmode`) wins
- * over the environment, so a mod can switch to Twitch clips the moment the
- * streamer's OBS dies — without an SSH session, a file edit and a redeploy.
- * Falls back to env only while the mirror is cold (boot, or unit tests).
+ * The mode in force right now — RTDB `config/clipMode`, changed live by mods with
+ * `!clipmode`. There is no environment variable: one source of truth, seeded once
+ * from `config.clip.defaultMode`, exactly like the EXP gate.
+ *
+ * The fallback only covers the window before the config mirror is warm (early
+ * boot, and unit tests that run without a database).
  */
 export function activeClipMode() {
-  return getConfig().clipMode ?? resolveClipMode();
+  return getConfig().clipMode ?? parseClipMode(gameConfig.clip.defaultMode);
 }
 
 /**

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -1,18 +1,18 @@
 // !clip — grab the last ~30–60s of the stream.
 //
-// TWO independent halves, selected by the live clip mode (`!clipmode`):
-//   local  (default) — tell the streamer's OBS/Aitum to save its replay buffer at
-//                      full recording quality. Nothing is posted to Twitch.
-//   twitch           — Helix Create Clip only (the original behaviour).
-//   both             — do each; the reply carries the Twitch link plus a note.
+// THREE independent outputs, each switched on or off by the live clip mode
+// (`!clipmode`, stored in RTDB):
+//   horizontal — OBS's main replay buffer → 16:9 file at full recording quality
+//   vertical   — Aitum's Backtrack output → 9:16 file, framed for portrait
+//   twitch     — Helix Create Clip        → a public clip link in chat
 //
-// Local is the default because a Twitch clip is capped at the STREAM resolution
-// (≤1080p here) while the local recording is whatever the camera actually shot —
-// the high-quality copy is the point of the command.
-import { getConfig, parseClipMode, CLIP_MODES } from '../db/configStore.js';
+// The default is horizontal+vertical and no Twitch, because a Twitch clip is capped
+// at the STREAM resolution (≤1080p here) while the local recording is whatever the
+// camera actually shot — the high-quality copy is the point of the command.
+import { getConfig, parseClipMode, clipTargets, CLIP_MODES } from '../db/configStore.js';
 import { config as gameConfig } from '../config.js';
 import { createChannelClip, clipsReady } from '../twitch/clips.js';
-import { triggerCapture, captureReady } from '../integrations/capture.js';
+import { triggerCapture, captureReady, verticalReady } from '../integrations/capture.js';
 
 export { CLIP_MODES };
 
@@ -50,9 +50,11 @@ export default {
   cooldownMs: 60_000, // per-user: a viewer can clip at most once a minute
   help: '!clip — capture the last ~60s of the stream',
   async run({ user, reply, logger }) {
-    const mode = activeClipMode();
-    let twitch = mode !== 'local' && clipsReady();
-    const local = mode !== 'twitch' && captureReady();
+    const want = clipTargets(activeClipMode());
+    let twitch = want.twitch && clipsReady();
+    // Vertical needs a configured output NAME (env) as well as being asked for.
+    const vertical = want.vertical && verticalReady();
+    const local = (want.horizontal || vertical) && captureReady();
 
     // One wording for every unconfigured mode — which half is missing is an
     // operator concern (the boot log spells it out), not a thing to tell chat.
@@ -74,7 +76,9 @@ export default {
     // Fire the local capture FIRST and in parallel: the replay buffer holds the
     // last N seconds, so the sooner it's told to save, the less the moment has
     // aged out of it. Its failure never affects the Twitch clip.
-    const capture = local ? triggerCapture(logger) : null;
+    const capture = local
+      ? triggerCapture(logger, Date.now(), { horizontal: want.horizontal, vertical })
+      : null;
 
     if (!twitch) {
       reply(`@${user.displayName} ${localOnlyReply(await capture)}`);

--- a/src/commands/clip.js
+++ b/src/commands/clip.js
@@ -9,19 +9,29 @@
 // Local is the default because a Twitch clip is capped at the STREAM resolution
 // (≤1080p here) while the local recording is whatever the camera actually shot —
 // the high-quality copy is the point of the command.
-import { getConfig } from '../db/configStore.js';
+import { getConfig, parseClipMode, CLIP_MODES } from '../db/configStore.js';
 import { createChannelClip, clipsReady } from '../twitch/clips.js';
 import { triggerCapture, captureReady } from '../integrations/capture.js';
 
-export const CLIP_MODES = ['local', 'twitch', 'both'];
+export { CLIP_MODES };
 
 /**
- * Resolve CLIP_MODE, defaulting to 'local'. An unrecognised value falls back to
- * the default rather than failing boot — index.js warns about it once at startup.
+ * Resolve the mode from the ENV var, defaulting to 'local'. This is only the
+ * first-boot seed and the fallback before the config mirror is warm — the live
+ * value comes from RTDB (see activeClipMode).
  */
 export function resolveClipMode(raw = process.env.CLIP_MODE) {
-  const v = String(raw ?? '').trim().toLowerCase();
-  return CLIP_MODES.includes(v) ? v : 'local';
+  return parseClipMode(raw);
+}
+
+/**
+ * The mode in force right now. RTDB (`config/clipMode`, set by `!clipmode`) wins
+ * over the environment, so a mod can switch to Twitch clips the moment the
+ * streamer's OBS dies — without an SSH session, a file edit and a redeploy.
+ * Falls back to env only while the mirror is cold (boot, or unit tests).
+ */
+export function activeClipMode() {
+  return getConfig().clipMode ?? resolveClipMode();
 }
 
 /**
@@ -46,7 +56,7 @@ export default {
   cooldownMs: 60_000, // per-user: a viewer can clip at most once a minute
   help: '!clip — clip the last ~30s of the stream',
   async run({ user, reply, logger }) {
-    const mode = resolveClipMode();
+    const mode = activeClipMode();
     let twitch = mode !== 'local' && clipsReady();
     const local = mode !== 'twitch' && captureReady();
 

--- a/src/commands/mod/clipmode.js
+++ b/src/commands/mod/clipmode.js
@@ -1,57 +1,73 @@
-// !clipmode local|twitch|both|status (mod) — change what !clip does, live.
+// !clipmode (mod) — choose which of !clip's three outputs are produced, live.
 //
-// Exists because the failure is operational, not a game setting: the streamer's
-// OBS can go down mid-stream, and until it's back `!clip` in `local` mode can do
-// nothing. Recovering by SSHing into the host, editing an env file and restarting
-// the container is not a recovery path anyone will take at 2am, so this is
-// reachable from chat like the EXP gate and the chat mute.
+//   !clipmode horizontal vertical      both local files, nothing on Twitch
+//   !clipmode horizontal               16:9 only
+//   !clipmode twitch                   Twitch clip only
+//   !clipmode horizontal vertical twitch
+//   !clipmode local | all | off        shorthands
 //
-// RTDB is the only source (seeded once from config.clip.defaultMode), so there is
-// no environment variable that could disagree or revert this on the next restart.
-import { setClipMode, getConfig, CLIP_MODES } from '../../db/configStore.js';
-import { captureReady } from '../../integrations/capture.js';
+// A SET rather than fixed presets, so every combination is reachable without
+// multiplying config values — and so "just horizontal" and "horizontal + twitch",
+// which the old local|twitch|both presets could not express, are just typing.
+//
+// Exists as a chat command because the failure is operational: the streamer's OBS
+// can go down mid-stream, and until it's back a local-only mode leaves !clip with
+// nothing to do. SSHing in to edit an env file is not a 2am recovery path.
+//
+// RTDB is the only source (seeded once from config.clip.defaultMode), so nothing
+// reverts this on the next restart.
+import { setClipMode, getConfig, clipTargets, readClipTargets, CLIP_TARGETS } from '../../db/configStore.js';
+import { captureReady, verticalReady } from '../../integrations/capture.js';
 import { clipsReady } from '../../twitch/clips.js';
 
-/** What each half of !clip could actually do right now. */
-function readiness(mode) {
-  const local = mode !== 'twitch' && captureReady();
-  const twitch = mode !== 'local' && clipsReady();
-  return { local, twitch, dead: !local && !twitch };
+const USAGE = `Usage: !clipmode ${CLIP_TARGETS.join(' | ')} (combine freely) · local | all | off · status`;
+
+/**
+ * Per-target: asked for, and able to run? The second half is what makes `status`
+ * worth typing — "horizontal,vertical" looks fine right up until you learn the
+ * vertical output was never named.
+ */
+function report(mode) {
+  const want = clipTargets(mode);
+  if (want.none) return { line: 'off — !clip is disabled', dead: false };
+  const bits = [];
+  if (want.horizontal) bits.push(`horizontal ${captureReady() ? '✓' : '✗ no OBS configured'}`);
+  if (want.vertical) {
+    bits.push(`vertical ${captureReady() && verticalReady() ? '✓' : '✗ no vertical output configured'}`);
+  }
+  if (want.twitch) bits.push(`twitch ${clipsReady() ? '✓' : '✗ not configured'}`);
+  const dead =
+    !(want.horizontal && captureReady()) &&
+    !(want.vertical && captureReady() && verticalReady()) &&
+    !(want.twitch && clipsReady());
+  return { line: bits.join(' · '), dead };
 }
 
 export default {
   names: ['clipmode'],
   mod: true,
   cooldownMs: 0,
-  help: '!clipmode local|twitch|both|status — mod-only control of what !clip does',
+  help: '!clipmode horizontal|vertical|twitch (combine) | local | all | off | status — mod-only',
   async run({ args, reply }) {
-    const sub = (args[0] || 'status').toLowerCase();
+    const input = args.join(' ').trim();
     const current = getConfig().clipMode ?? 'local';
 
-    if (sub === 'status') {
-      const r = readiness(current);
-      const parts = [
-        `capture ${captureReady() ? 'ready' : 'not configured'}`,
-        `twitch ${clipsReady() ? 'ready' : 'not configured'}`,
-      ];
-      reply(`!clip mode: ${current} · ${parts.join(' · ')}${r.dead ? ' — ⚠ !clip can do nothing' : ''}`);
+    if (!input || input.toLowerCase() === 'status') {
+      const { line, dead } = report(current);
+      reply(`!clip mode: ${current} · ${line}${dead ? ' — ⚠ !clip can do nothing' : ''}`);
       return;
     }
 
-    if (!CLIP_MODES.includes(sub)) {
-      reply(`Usage: !clipmode ${CLIP_MODES.join(' | ')} | status`);
+    // All-or-nothing: a typo'd token must not quietly produce a mode that does
+    // less than asked, because the symptom is a clip that silently isn't made.
+    if (readClipTargets(input) === null) {
+      reply(USAGE);
       return;
     }
 
-    await setClipMode(sub);
-
-    // Warn immediately if the mode just set can't actually produce anything —
-    // better a mod finds out here than a viewer finds out by being told clipping
-    // isn't set up.
-    const r = readiness(sub);
-    const warn = r.dead
-      ? ' — ⚠ nothing is configured for that mode, !clip will tell viewers clipping is unavailable'
-      : '';
-    reply(`!clip mode set to ${sub}${warn}`);
+    const saved = await setClipMode(input);
+    const { line, dead } = report(saved);
+    const warn = dead ? ' — ⚠ nothing is configured for that, !clip will tell viewers it is unavailable' : '';
+    reply(`!clip mode set to ${saved} · ${line}${warn}`);
   },
 };

--- a/src/commands/mod/clipmode.js
+++ b/src/commands/mod/clipmode.js
@@ -6,8 +6,8 @@
 // the container is not a recovery path anyone will take at 2am, so this is
 // reachable from chat like the EXP gate and the chat mute.
 //
-// RTDB is authoritative once set, so this is NOT undone by the container's
-// CLIP_MODE on the next restart.
+// RTDB is the only source (seeded once from config.clip.defaultMode), so there is
+// no environment variable that could disagree or revert this on the next restart.
 import { setClipMode, getConfig, CLIP_MODES } from '../../db/configStore.js';
 import { captureReady } from '../../integrations/capture.js';
 import { clipsReady } from '../../twitch/clips.js';

--- a/src/commands/mod/clipmode.js
+++ b/src/commands/mod/clipmode.js
@@ -1,0 +1,57 @@
+// !clipmode local|twitch|both|status (mod) — change what !clip does, live.
+//
+// Exists because the failure is operational, not a game setting: the streamer's
+// OBS can go down mid-stream, and until it's back `!clip` in `local` mode can do
+// nothing. Recovering by SSHing into the host, editing an env file and restarting
+// the container is not a recovery path anyone will take at 2am, so this is
+// reachable from chat like the EXP gate and the chat mute.
+//
+// RTDB is authoritative once set, so this is NOT undone by the container's
+// CLIP_MODE on the next restart.
+import { setClipMode, getConfig, CLIP_MODES } from '../../db/configStore.js';
+import { captureReady } from '../../integrations/capture.js';
+import { clipsReady } from '../../twitch/clips.js';
+
+/** What each half of !clip could actually do right now. */
+function readiness(mode) {
+  const local = mode !== 'twitch' && captureReady();
+  const twitch = mode !== 'local' && clipsReady();
+  return { local, twitch, dead: !local && !twitch };
+}
+
+export default {
+  names: ['clipmode'],
+  mod: true,
+  cooldownMs: 0,
+  help: '!clipmode local|twitch|both|status — mod-only control of what !clip does',
+  async run({ args, reply }) {
+    const sub = (args[0] || 'status').toLowerCase();
+    const current = getConfig().clipMode ?? 'local';
+
+    if (sub === 'status') {
+      const r = readiness(current);
+      const parts = [
+        `capture ${captureReady() ? 'ready' : 'not configured'}`,
+        `twitch ${clipsReady() ? 'ready' : 'not configured'}`,
+      ];
+      reply(`!clip mode: ${current} · ${parts.join(' · ')}${r.dead ? ' — ⚠ !clip can do nothing' : ''}`);
+      return;
+    }
+
+    if (!CLIP_MODES.includes(sub)) {
+      reply(`Usage: !clipmode ${CLIP_MODES.join(' | ')} | status`);
+      return;
+    }
+
+    await setClipMode(sub);
+
+    // Warn immediately if the mode just set can't actually produce anything —
+    // better a mod finds out here than a viewer finds out by being told clipping
+    // isn't set up.
+    const r = readiness(sub);
+    const warn = r.dead
+      ? ' — ⚠ nothing is configured for that mode, !clip will tell viewers clipping is unavailable'
+      : '';
+    reply(`!clip mode set to ${sub}${warn}`);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -22,6 +22,7 @@ import start from './start.js';
 import market from './mod/market.js';
 import todo from './mod/todo.js';
 import exp from './mod/exp.js';
+import clipmode from './mod/clipmode.js';
 import mute from './mod/mute.js';
 import drop from './mod/drop.js';
 import drops from './mod/drops.js';
@@ -29,7 +30,7 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, mute, drop, drops, boss, raidnight, season, market, todo];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/config.js
+++ b/src/config.js
@@ -152,14 +152,18 @@ export const config = {
 
   // ── !clip ────────────────────────────────────────────────────────────────
   clip: {
-    // What !clip does on a BRAND-NEW database: local | twitch | both.
-    // 'local' = trigger the streamer's OBS/Aitum capture, post nothing to Twitch
-    // (a Twitch clip is capped at stream resolution, so it can't be the keepsake).
+    // Which of !clip's three outputs are produced on a BRAND-NEW database. Any
+    // combination of: horizontal (16:9 local file) · vertical (9:16 local file) ·
+    // twitch (public clip link). 'local', 'all' and 'off' are shorthands.
     //
-    // This seeds config/clipMode once. After that RTDB is the ONLY source and
-    // mods change it live with `!clipmode` — same as defaultExpMode above.
-    // Editing this value does not move an existing deployment.
-    defaultMode: 'local',
+    // Default is the two local files and NO Twitch clip: a Twitch clip is capped
+    // at your stream resolution, so it can never be the high-quality keepsake —
+    // which is the entire point of the command.
+    //
+    // This seeds config/clipMode once. After that RTDB is the ONLY source and mods
+    // change it live with `!clipmode` — same as defaultExpMode above. Editing this
+    // value does not move an existing deployment.
+    defaultMode: 'horizontal,vertical',
   },
 
   // ── Single-instance lease (IMPLEMENTATION §E/§J) ─────────────────────────

--- a/src/config.js
+++ b/src/config.js
@@ -150,6 +150,18 @@ export const config = {
     defaultExpMode: 'auto', // on | off | auto  (auto = follow live status)
   },
 
+  // ── !clip ────────────────────────────────────────────────────────────────
+  clip: {
+    // What !clip does on a BRAND-NEW database: local | twitch | both.
+    // 'local' = trigger the streamer's OBS/Aitum capture, post nothing to Twitch
+    // (a Twitch clip is capped at stream resolution, so it can't be the keepsake).
+    //
+    // This seeds config/clipMode once. After that RTDB is the ONLY source and
+    // mods change it live with `!clipmode` — same as defaultExpMode above.
+    // Editing this value does not move an existing deployment.
+    defaultMode: 'local',
+  },
+
   // ── Single-instance lease (IMPLEMENTATION §E/§J) ─────────────────────────
   lock: {
     heartbeatMs: 15_000,

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -14,6 +14,11 @@ const mirror = {
   // connected — listening, granting EXP, processing drops, holding the lease —
   // but sends nothing to chat. Persisted so a restart keeps the mods' choice.
   chatMuted: false,
+  // What !clip does: 'local' | 'twitch' | 'both'. Seeded from CLIP_MODE at first
+  // boot, then RTDB is authoritative so a mod can flip it from chat — the
+  // streamer's OBS can die mid-stream, and re-deploying the container to get
+  // Twitch clips back is not an acceptable recovery path.
+  clipMode: null, // null until the mirror is warm; readers fall back to env
   season: null,
   raid: null, // config/raid: { seasonId, weekId, phase, locksAt, startsAt }
   dropScheduler: { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec },
@@ -34,10 +39,14 @@ export async function startConfigMirror(logger = console) {
   await db.ref(PATHS.configExpMode()).transaction((v) => (v == null ? gameConfig.liveGate.defaultExpMode : v));
   await db.ref(PATHS.configLive()).transaction((v) => (v == null ? false : v));
   await db.ref(PATHS.configChatMuted()).transaction((v) => (v == null ? false : v));
+  // CLIP_MODE seeds the FIRST boot only; after that RTDB wins, so a mod's `!clipmode`
+  // is not silently undone by whatever the container's env still says.
+  await db.ref(PATHS.configClipMode()).transaction((v) => (v == null ? parseClipMode(process.env.CLIP_MODE) : v));
 
   const liveRef = db.ref(PATHS.configLive());
   const expRef = db.ref(PATHS.configExpMode());
   const mutedRef = db.ref(PATHS.configChatMuted());
+  const clipRef = db.ref(PATHS.configClipMode());
   const seasonRef = db.ref(PATHS.seasonCurrent());
   const raidRef = db.ref(PATHS.configRaid());
   const dropRef = db.ref(PATHS.configDropScheduler());
@@ -48,26 +57,36 @@ export async function startConfigMirror(logger = console) {
   liveRef.on('value', (s) => { mirror.live = Boolean(s.val()); });
   expRef.on('value', (s) => { mirror.expMode = s.val() || gameConfig.liveGate.defaultExpMode; });
   mutedRef.on('value', (s) => { mirror.chatMuted = Boolean(s.val()); });
+  clipRef.on('value', (s) => { mirror.clipMode = parseClipMode(s.val()); });
   seasonRef.on('value', (s) => { mirror.season = s.val(); });
   raidRef.on('value', (s) => { mirror.raid = s.val(); });
   dropRef.on('value', (s) => { if (s.val()) mirror.dropScheduler = s.val(); });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, mutedSnap, seasonSnap, raidSnap, dropSnap] = await Promise.all([
-    liveRef.get(), expRef.get(), mutedRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
+  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap] = await Promise.all([
+    liveRef.get(), expRef.get(), mutedRef.get(), clipRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
   mirror.chatMuted = Boolean(mutedSnap.val());
+  mirror.clipMode = parseClipMode(clipSnap.val());
   mirror.season = seasonSnap.val();
   mirror.raid = raidSnap.val();
   if (dropSnap.val()) mirror.dropScheduler = dropSnap.val();
-  logger.info?.('config mirror warm', { live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted });
+  logger.info?.('config mirror warm', {
+    live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, clipMode: mirror.clipMode,
+  });
 }
 
 /** Current in-memory config view (hot path). */
 export function getConfig() {
-  return { live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, season: mirror.season };
+  return {
+    live: mirror.live,
+    expMode: mirror.expMode,
+    chatMuted: mirror.chatMuted,
+    clipMode: mirror.clipMode,
+    season: mirror.season,
+  };
 }
 
 /** True when a mod has muted the bot's outbound chat (`!mute`). Hot-path read. */
@@ -119,6 +138,44 @@ export async function setLive(value, source = 'unknown', logger = console) {
 }
 
 /** Set the EXP gate override mode (on|off|auto). */
+/**
+ * Test seam: prime the in-memory mirror without RTDB. Unit tests run with no
+ * database, so the mirror is otherwise stuck at its cold defaults and any
+ * "live config wins" behaviour is untestable offline.
+ * @param {Partial<typeof mirror>} patch
+ */
+export function primeConfigForTest(patch) {
+  Object.assign(mirror, patch);
+}
+
+/** What `!clip` may do. `local` = OBS/Aitum capture only, no Twitch clip. */
+export const CLIP_MODES = ['local', 'twitch', 'both'];
+
+/**
+ * Parse a clip mode from any source (env, RTDB, chat). Anything unrecognised —
+ * including null/undefined — becomes 'local', because the failure that matters is
+ * a typo quietly turning Twitch clipping back on.
+ *
+ * Lives here rather than in commands/clip.js so configStore can validate and seed
+ * without importing the command that imports it.
+ */
+export function parseClipMode(raw) {
+  const v = String(raw ?? '').trim().toLowerCase();
+  return CLIP_MODES.includes(v) ? v : 'local';
+}
+
+/**
+ * Change what `!clip` does, live (`!clipmode`). Updates the mirror synchronously
+ * so the very next `!clip` obeys it without waiting for the RTDB round-trip, then
+ * persists so the choice survives a restart — and outlives the container's env.
+ */
+export async function setClipMode(mode) {
+  if (!CLIP_MODES.includes(mode)) throw new Error(`invalid clipMode: ${mode}`);
+  mirror.clipMode = mode;
+  await database().ref(PATHS.configClipMode()).set(mode);
+  return mode;
+}
+
 export async function setExpMode(mode) {
   if (!['on', 'off', 'auto'].includes(mode)) throw new Error(`invalid expMode: ${mode}`);
   await database().ref(PATHS.configExpMode()).set(mode);

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -14,11 +14,11 @@ const mirror = {
   // connected — listening, granting EXP, processing drops, holding the lease —
   // but sends nothing to chat. Persisted so a restart keeps the mods' choice.
   chatMuted: false,
-  // What !clip does: 'local' | 'twitch' | 'both'. Seeded from CLIP_MODE at first
-  // boot, then RTDB is authoritative so a mod can flip it from chat — the
-  // streamer's OBS can die mid-stream, and re-deploying the container to get
-  // Twitch clips back is not an acceptable recovery path.
-  clipMode: null, // null until the mirror is warm; readers fall back to env
+  // What !clip does: 'local' | 'twitch' | 'both'. Seeded once from
+  // config.clip.defaultMode; RTDB is then the only source, so a mod can flip it
+  // from chat — the streamer's OBS can die mid-stream, and re-deploying the
+  // container to get Twitch clips back is not an acceptable recovery path.
+  clipMode: null, // null until the mirror is warm; readers fall back to the config default
   season: null,
   raid: null, // config/raid: { seasonId, weekId, phase, locksAt, startsAt }
   dropScheduler: { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec },
@@ -39,9 +39,10 @@ export async function startConfigMirror(logger = console) {
   await db.ref(PATHS.configExpMode()).transaction((v) => (v == null ? gameConfig.liveGate.defaultExpMode : v));
   await db.ref(PATHS.configLive()).transaction((v) => (v == null ? false : v));
   await db.ref(PATHS.configChatMuted()).transaction((v) => (v == null ? false : v));
-  // CLIP_MODE seeds the FIRST boot only; after that RTDB wins, so a mod's `!clipmode`
-  // is not silently undone by whatever the container's env still says.
-  await db.ref(PATHS.configClipMode()).transaction((v) => (v == null ? parseClipMode(process.env.CLIP_MODE) : v));
+  // Seeded once from config.js, exactly like expMode above — never clobbered, so a
+  // mod's `!clipmode` survives every restart. There is deliberately no env var:
+  // one source of truth beats two that can disagree.
+  await db.ref(PATHS.configClipMode()).transaction((v) => (v == null ? parseClipMode(gameConfig.clip.defaultMode) : v));
 
   const liveRef = db.ref(PATHS.configLive());
   const expRef = db.ref(PATHS.configExpMode());
@@ -137,7 +138,6 @@ export async function setLive(value, source = 'unknown', logger = console) {
   return true;
 }
 
-/** Set the EXP gate override mode (on|off|auto). */
 /**
  * Test seam: prime the in-memory mirror without RTDB. Unit tests run with no
  * database, so the mirror is otherwise stuck at its cold defaults and any
@@ -152,22 +152,22 @@ export function primeConfigForTest(patch) {
 export const CLIP_MODES = ['local', 'twitch', 'both'];
 
 /**
- * Parse a clip mode from any source (env, RTDB, chat). Anything unrecognised —
- * including null/undefined — becomes 'local', because the failure that matters is
- * a typo quietly turning Twitch clipping back on.
+ * Parse a clip mode from any source (RTDB, chat, config). Anything unrecognised —
+ * including null/undefined — falls back to the configured default, because the
+ * failure that matters is a typo quietly turning Twitch clipping back on.
  *
  * Lives here rather than in commands/clip.js so configStore can validate and seed
  * without importing the command that imports it.
  */
 export function parseClipMode(raw) {
   const v = String(raw ?? '').trim().toLowerCase();
-  return CLIP_MODES.includes(v) ? v : 'local';
+  return CLIP_MODES.includes(v) ? v : gameConfig.clip.defaultMode;
 }
 
 /**
  * Change what `!clip` does, live (`!clipmode`). Updates the mirror synchronously
  * so the very next `!clip` obeys it without waiting for the RTDB round-trip, then
- * persists so the choice survives a restart — and outlives the container's env.
+ * persists so the choice survives every restart.
  */
 export async function setClipMode(mode) {
   if (!CLIP_MODES.includes(mode)) throw new Error(`invalid clipMode: ${mode}`);
@@ -176,6 +176,7 @@ export async function setClipMode(mode) {
   return mode;
 }
 
+/** Set the EXP gate override mode (on|off|auto). */
 export async function setExpMode(mode) {
   if (!['on', 'off', 'auto'].includes(mode)) throw new Error(`invalid expMode: ${mode}`);
   await database().ref(PATHS.configExpMode()).set(mode);

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -148,8 +148,30 @@ export function primeConfigForTest(patch) {
   Object.assign(mirror, patch);
 }
 
-/** What `!clip` may do. `local` = OBS/Aitum capture only, no Twitch clip. */
-export const CLIP_MODES = ['local', 'twitch', 'both'];
+/**
+ * The three things `!clip` can independently produce. The mode is a SET of these,
+ * not a fixed preset, so every combination is expressible with one config value:
+ *   horizontal — OBS's main replay buffer  → 16:9 file on the streamer's PC
+ *   vertical   — Aitum's Backtrack output  → 9:16 file, natively framed
+ *   twitch     — Helix Create Clip         → a public clip link in chat
+ */
+export const CLIP_TARGETS = ['horizontal', 'vertical', 'twitch'];
+
+/**
+ * Shorthands, kept so existing values and muscle memory keep working. `local`
+ * predates the vertical canvas and has always meant "the local capture", which is
+ * now explicitly both local files.
+ */
+export const CLIP_MODE_ALIASES = {
+  local: ['horizontal', 'vertical'],
+  both: ['horizontal', 'vertical', 'twitch'],
+  all: ['horizontal', 'vertical', 'twitch'],
+  off: [],
+  none: [],
+};
+
+/** Legal single words for `!clipmode`, for usage messages. */
+export const CLIP_MODES = [...CLIP_TARGETS, ...Object.keys(CLIP_MODE_ALIASES)];
 
 /**
  * Parse a clip mode from any source (RTDB, chat, config). Anything unrecognised —
@@ -160,8 +182,50 @@ export const CLIP_MODES = ['local', 'twitch', 'both'];
  * without importing the command that imports it.
  */
 export function parseClipMode(raw) {
-  const v = String(raw ?? '').trim().toLowerCase();
-  return CLIP_MODES.includes(v) ? v : gameConfig.clip.defaultMode;
+  const targets = readClipTargets(raw);
+  if (targets === null) return parseClipMode(gameConfig.clip.defaultMode);
+  // 'off' is a real, storable choice — an empty string would round-trip back to
+  // the default on the next read, silently re-enabling clipping a mod turned off.
+  return targets.length ? targets.join(',') : 'off';
+}
+
+/**
+ * Parse a mode into its target list, or `null` if ANY token is unrecognised.
+ *
+ * All-or-nothing on purpose: silently dropping a bad token would leave a mode that
+ * looks accepted but does less than asked, and the failure that matters here is a
+ * clip quietly not being made. Callers decide what to do with `null` — RTDB reads
+ * fall back to the default, `!clipmode` shows usage.
+ *
+ * Accepts commas or spaces, any order, aliases mixed in: `local twitch`,
+ * `horizontal,vertical`, `all`.
+ *
+ * @returns {string[]|null} canonical targets in CLIP_TARGETS order, deduped
+ */
+export function readClipTargets(raw) {
+  const words = String(raw ?? '').toLowerCase().split(/[\s,]+/).filter(Boolean);
+  if (!words.length) return null;
+  const set = new Set();
+  for (const w of words) {
+    if (CLIP_TARGETS.includes(w)) set.add(w);
+    else if (w in CLIP_MODE_ALIASES) CLIP_MODE_ALIASES[w].forEach((t) => set.add(t));
+    else return null;
+  }
+  return CLIP_TARGETS.filter((t) => set.has(t)); // canonical order, so 'a,b' === 'b,a'
+}
+
+/**
+ * The stored mode as booleans, for callers that just want to know what to do.
+ * @returns {{ horizontal: boolean, vertical: boolean, twitch: boolean, none: boolean }}
+ */
+export function clipTargets(mode) {
+  const list = readClipTargets(mode) ?? readClipTargets(gameConfig.clip.defaultMode) ?? [];
+  return {
+    horizontal: list.includes('horizontal'),
+    vertical: list.includes('vertical'),
+    twitch: list.includes('twitch'),
+    none: list.length === 0,
+  };
 }
 
 /**
@@ -170,10 +234,13 @@ export function parseClipMode(raw) {
  * persists so the choice survives every restart.
  */
 export async function setClipMode(mode) {
-  if (!CLIP_MODES.includes(mode)) throw new Error(`invalid clipMode: ${mode}`);
-  mirror.clipMode = mode;
-  await database().ref(PATHS.configClipMode()).set(mode);
-  return mode;
+  if (readClipTargets(mode) === null) throw new Error(`invalid clipMode: ${mode}`);
+  // Store the CANONICAL form, so 'local', 'vertical horizontal' and
+  // 'horizontal,vertical' all persist identically and comparisons are trivial.
+  const canonical = parseClipMode(mode);
+  mirror.clipMode = canonical;
+  await database().ref(PATHS.configClipMode()).set(canonical);
+  return canonical;
 }
 
 /** Set the EXP gate override mode (on|off|auto). */

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -82,6 +82,7 @@ export const PATHS = {
   configLive: () => 'config/live',
   configExpMode: () => 'config/expMode',
   configChatMuted: () => 'config/chatMuted',
+  configClipMode: () => 'config/clipMode',
   seasonCurrent: () => 'config/season/current',
   configRaid: () => 'config/raid',
   configDropScheduler: () => 'config/dropScheduler',

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -13,8 +13,12 @@
 // kennyBot does for the archiver is the `!start` sync anchor (src/db/clipSync.js).
 //
 // Backend-agnostic on purpose: obs-websocket today (free, password-authed, built
-// into OBS 28+), Aitum's :7777 rule API later. Commands call `triggerCapture()`
-// and never learn which one is configured.
+// into OBS 28+). Commands call `triggerCapture()` and never learn what is behind it.
+//
+// NOTE: Aitum is ALREADY integrated — but through obs-websocket VENDOR REQUESTS on
+// this same connection, not as a separate backend and not via Aitum Nexus's :7777
+// API (Nexus is a different product and is not on this path). CAPTURE_BACKEND has
+// no 'aitum' value by design; see obsWebsocket.js verticalBacktrackSequence.
 //
 // EVERY failure here is non-fatal and RESOLVES rather than throwing. The
 // streamer's PC may be off, OBS may be closed, the tailnet may be down — the
@@ -34,7 +38,8 @@ let cfg = null;
 let lastAt = 0;
 
 /**
- * @param {{ backend?: string, url?: string, password?: string, timeoutMs?: number }} [opts]
+ * @param {{ backend?: string, url?: string, password?: string, timeoutMs?: number,
+ *          minIntervalMs?: number, verticalOutput?: string }} [opts]
  * @param {any} [logger]
  */
 export function initCapture(opts = {}, logger = console) {
@@ -89,7 +94,14 @@ export function captureReady() {
 
 /**
  * Fire the local capture. Never throws.
- * @returns {Promise<{ ok: boolean, path?: string|null, started?: boolean, reason?: string }>}
+ *
+ * `vertical` is present only when a vertical output is configured. Note it reports
+ * `requested`, NOT `saved` — Aitum answers success on acceptance and gives us no way
+ * to confirm a file was written.
+ *
+ * @returns {Promise<{ ok: boolean, path?: string|null, started?: boolean, reason?: string,
+ *   retryInMs?: number,
+ *   vertical?: { ok: boolean, requested?: boolean, started?: boolean, reason?: string } }>}
  */
 export async function triggerCapture(logger = console, now = Date.now()) {
   if (!cfg) return { ok: false, reason: 'not configured' };

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -4,7 +4,7 @@
 // A Twitch clip is capped at the STREAM resolution, so it can never be a 4K
 // keepsake. This fires a capture at full recording quality on the streamer's
 // machine (reached over their private network) — the default half of `!clip`
-// (CLIP_MODE).
+// (see the live clip mode / `!clipmode`).
 //
 // This is a SELF-CONTAINED workflow: the file it saves is the finished artefact.
 // It is NOT an input to okra-clip-archiver, which is an unrelated tool that

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -63,9 +63,17 @@ export function initCapture(opts = {}, logger = console) {
     password: opts.password ?? process.env.OBS_WEBSOCKET_PASSWORD ?? '',
     timeoutMs: opts.timeoutMs ?? Number(process.env.OBS_TIMEOUT_MS || 8000),
     minIntervalMs: opts.minIntervalMs ?? Number(process.env.CAPTURE_MIN_INTERVAL_MS || 60_000),
+    // Aitum Stream Suite's vertical (9:16) Backtrack output, saved alongside the
+    // horizontal replay buffer on the same connection. Unset = horizontal only.
+    verticalOutput: opts.verticalOutput ?? process.env.CAPTURE_VERTICAL_OUTPUT ?? '',
   };
   lastAt = 0;
-  logger.info?.('local capture ready', { backend, url, minIntervalMs: cfg.minIntervalMs });
+  logger.info?.('local capture ready', {
+    backend,
+    url,
+    minIntervalMs: cfg.minIntervalMs,
+    vertical: cfg.verticalOutput || 'disabled',
+  });
 }
 
 /** Test seam: inject a fake trigger. Pass `null` to disable capture. */
@@ -97,8 +105,28 @@ export async function triggerCapture(logger = console, now = Date.now()) {
 
   try {
     const res = cfg.backend === 'test' ? await cfg.trigger() : await saveReplayBuffer(cfg);
-    logger.info?.('local capture saved', { path: res?.path ?? null, startedBuffer: Boolean(res?.started) });
-    return { ok: true, path: res?.path ?? null, started: Boolean(res?.started) };
+    // `vertical.requested` is NOT proof of a file — Aitum answers success on
+    // acceptance and writes nothing when its output has no recording path. Logged
+    // as what it is so a silent misconfiguration is visible in `docker logs`.
+    logger.info?.('local capture saved', {
+      path: res?.path ?? null,
+      startedBuffer: Boolean(res?.started),
+      ...(res?.vertical
+        ? {
+            verticalRequested: Boolean(res.vertical.requested),
+            verticalStartedBuffer: Boolean(res.vertical.started),
+            ...(res.vertical.ok ? {} : { verticalError: res.vertical.reason }),
+          }
+        : {}),
+    });
+    // `vertical` is present only when a vertical output is configured, so callers
+    // (and tests) that predate it see exactly the shape they always did.
+    return {
+      ok: true,
+      path: res?.path ?? null,
+      started: Boolean(res?.started),
+      ...(res?.vertical ? { vertical: res.vertical } : {}),
+    };
   } catch (err) {
     // A failed attempt shouldn't burn the rate-limit window — let the next !clip
     // retry immediately (the PC may have just come back).

--- a/src/integrations/capture.js
+++ b/src/integrations/capture.js
@@ -81,15 +81,31 @@ export function initCapture(opts = {}, logger = console) {
   });
 }
 
-/** Test seam: inject a fake trigger. Pass `null` to disable capture. */
-export function initCaptureWith(fn, { minIntervalMs = 0 } = {}) {
-  cfg = fn ? { backend: 'test', trigger: fn, minIntervalMs } : null;
+/**
+ * Test seam: inject a fake trigger. Pass `null` to disable capture.
+ *
+ * The fake stands in for a FULLY configured backend, vertical output included —
+ * otherwise vertical-only modes resolve to "not configured" in tests for a reason
+ * that has nothing to do with the behaviour under test. Pass `verticalOutput: ''`
+ * to model a rig with no vertical output configured.
+ */
+export function initCaptureWith(fn, { minIntervalMs = 0, verticalOutput = 'test-vertical' } = {}) {
+  cfg = fn ? { backend: 'test', trigger: fn, minIntervalMs, verticalOutput } : null;
   lastAt = 0;
 }
 
 /** True when a capture backend is configured. */
 export function captureReady() {
   return cfg !== null;
+}
+
+/**
+ * True when the vertical (Aitum Backtrack) output has a name configured. Separate
+ * from captureReady: the clip mode decides WHETHER to save vertical, this decides
+ * whether we know WHAT to save. Both must hold.
+ */
+export function verticalReady() {
+  return Boolean(cfg?.verticalOutput);
 }
 
 /**
@@ -103,8 +119,13 @@ export function captureReady() {
  *   retryInMs?: number,
  *   vertical?: { ok: boolean, requested?: boolean, started?: boolean, reason?: string } }>}
  */
-export async function triggerCapture(logger = console, now = Date.now()) {
+export async function triggerCapture(logger = console, now = Date.now(), targets = {}) {
   if (!cfg) return { ok: false, reason: 'not configured' };
+  const { horizontal = true, vertical = true } = targets;
+  // Vertical also needs its output NAME (env). Asking for vertical-only without one
+  // configured is a no-op, not a silent horizontal capture.
+  const verticalOutput = vertical ? cfg.verticalOutput : '';
+  if (!horizontal && !verticalOutput) return { ok: false, reason: 'not configured' };
 
   const since = now - lastAt;
   if (cfg.minIntervalMs && lastAt && since < cfg.minIntervalMs) {
@@ -116,7 +137,9 @@ export async function triggerCapture(logger = console, now = Date.now()) {
   lastAt = now;
 
   try {
-    const res = cfg.backend === 'test' ? await cfg.trigger() : await saveReplayBuffer(cfg);
+    const res = cfg.backend === 'test'
+      ? await cfg.trigger({ horizontal, vertical: Boolean(verticalOutput) })
+      : await saveReplayBuffer({ ...cfg, horizontal, verticalOutput });
     // `vertical.requested` is NOT proof of a file — Aitum answers success on
     // acceptance and writes nothing when its output has no recording path. Logged
     // as what it is so a silent misconfiguration is visible in `docker logs`.

--- a/src/integrations/obsWebsocket.js
+++ b/src/integrations/obsWebsocket.js
@@ -135,8 +135,68 @@ export async function withObs({ url, password = '', timeoutMs = 8000 }, fn) {
  *
  * @returns {Promise<{ path: string|null, started: boolean }>}
  */
-export async function saveReplayBuffer({ url, password, timeoutMs }) {
-  return withObs({ url, password, timeoutMs }, (request) => replayBufferSequence(request));
+export async function saveReplayBuffer({ url, password, timeoutMs, verticalOutput = '' }) {
+  return withObs({ url, password, timeoutMs }, async (request) => {
+    const horizontal = await replayBufferSequence(request);
+    if (!verticalOutput) return horizontal;
+    // Vertical rides the SAME connection — one handshake, one deadline. It is
+    // strictly best-effort: a missing plugin or a misconfigured output must not
+    // cost us the horizontal capture we already have.
+    const vertical = await verticalBacktrackSequence(request, verticalOutput)
+      .catch((err) => ({ ok: false, reason: String(err?.message || err) }));
+    return { ...horizontal, vertical };
+  });
+}
+
+/** obs-websocket vendor name registered by the Aitum Stream Suite plugin. */
+export const AITUM_VENDOR = 'aitum-stream-suite';
+
+/**
+ * Save the vertical canvas's "Backtrack" — Aitum's replay buffer for its second
+ * (9:16) canvas, which carries the natively-framed portrait layout rather than a
+ * crop of the landscape one.
+ *
+ * IMPORTANT: `save_backtrack` answers `{success: true}` as soon as it ACCEPTS the
+ * request. Verified against a real Stream Suite 1.2.1: with a full buffer it
+ * returns success and writes NO FILE when the output has no recording path
+ * configured. The vendor API exposes no way to read that path back, so we cannot
+ * confirm a write. This returns `requested`, never `saved`, precisely so callers
+ * can't mistake acceptance for a file on disk.
+ *
+ * @param {(type: string, data?: object) => Promise<any>} request
+ * @param {string} outputName e.g. "Vertical Backtrack" (see the `get_outputs` vendor request)
+ * @param {(ms: number) => Promise<void>} [sleep] injectable for tests
+ * @returns {Promise<{ ok: boolean, requested: boolean, started: boolean, reason?: string }>}
+ */
+export async function verticalBacktrackSequence(request, outputName, sleep = (ms) => new Promise((r) => setTimeout(r, ms))) {
+  const vendor = (requestType, requestData = {}) =>
+    request('CallVendorRequest', { vendorName: AITUM_VENDOR, requestType, requestData })
+      .then((r) => r?.responseData ?? r);
+
+  const find = async () => {
+    const { outputs = [] } = (await vendor('get_outputs')) || {};
+    return outputs.find((o) => o.name === outputName) || null;
+  };
+
+  const output = await find();
+  if (!output) throw new Error(`no Aitum output named "${outputName}"`);
+
+  if (!output.active) {
+    // Same lesson as the main replay buffer: outputs come up asynchronously, and
+    // a buffer that just started holds nothing worth saving. Start it and let the
+    // NEXT clip have content.
+    await vendor('start_output', { output: outputName });
+    for (const wait of [150, 250, 500, 1000]) {
+      await sleep(wait);
+      const s = await find();
+      if (s?.active) break;
+    }
+    return { ok: true, requested: false, started: true };
+  }
+
+  const res = await vendor('save_backtrack', { output: outputName });
+  if (res && res.success === false) throw new Error(res.error || `save_backtrack refused for "${outputName}"`);
+  return { ok: true, requested: true, started: false };
 }
 
 /**

--- a/src/integrations/obsWebsocket.js
+++ b/src/integrations/obsWebsocket.js
@@ -135,16 +135,23 @@ export async function withObs({ url, password = '', timeoutMs = 8000 }, fn) {
  *
  * @returns {Promise<{ path: string|null, started: boolean }>}
  */
-export async function saveReplayBuffer({ url, password, timeoutMs, verticalOutput = '' }) {
+export async function saveReplayBuffer({ url, password, timeoutMs, horizontal = true, verticalOutput = '' }) {
+  if (!horizontal && !verticalOutput) throw new Error('nothing requested: neither horizontal nor vertical');
   return withObs({ url, password, timeoutMs }, async (request) => {
-    const horizontal = await replayBufferSequence(request);
-    if (!verticalOutput) return horizontal;
-    // Vertical rides the SAME connection — one handshake, one deadline. It is
-    // strictly best-effort: a missing plugin or a misconfigured output must not
-    // cost us the horizontal capture we already have.
+    // `skipped` distinguishes "not asked for" from "asked for, produced no path" —
+    // otherwise a vertical-only save looks exactly like a failed horizontal one.
+    const h = horizontal
+      ? await replayBufferSequence(request)
+      : { path: null, started: false, skipped: true };
+    if (!verticalOutput) return h;
+    // Vertical rides the SAME connection — one handshake, one deadline.
     const vertical = await verticalBacktrackSequence(request, verticalOutput)
       .catch((err) => ({ ok: false, reason: String(err?.message || err) }));
-    return { ...horizontal, vertical };
+    // When horizontal ran, vertical is strictly best-effort: a misconfigured
+    // vertical output must never cost us the capture we already have. When it did
+    // NOT run, vertical is the whole job, so its failure is the call's failure.
+    if (!horizontal && !vertical.ok) throw new Error(vertical.reason || 'vertical capture failed');
+    return { ...h, vertical };
   });
 }
 

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -109,12 +109,22 @@ export const SCENARIOS = [
         // Not live → the twitch half is impossible, and local is switched off.
         assert.match(await bot.send(viewer, '!clip'), /only clip while the stream is live/i);
 
+        // Aliases expand to the canonical target list on the way in.
         await bot.send(mod, '!clipmode local');
-        assert.equal(getConfig().clipMode, 'local');
+        assert.equal(getConfig().clipMode, 'horizontal,vertical');
 
-        assert.match(await bot.send(mod, '!clipmode nonsense'), /Usage: !clipmode/);
-        assert.equal(getConfig().clipMode, 'local', 'a bad value changes nothing');
+        // The combinations the old local|twitch|both presets could not express.
+        await bot.send(mod, '!clipmode horizontal');
+        assert.equal(getConfig().clipMode, 'horizontal');
+        await bot.send(mod, '!clipmode vertical twitch');
+        assert.equal(getConfig().clipMode, 'vertical,twitch', 'order-normalised');
+
+        // All-or-nothing: one bad token must reject the whole line, not part of it.
+        assert.match(await bot.send(mod, '!clipmode horizontal nonsense'), /Usage: !clipmode/);
+        assert.equal(getConfig().clipMode, 'vertical,twitch', 'a bad value changes nothing');
       } finally {
+        // Scenarios share one emulator DB — leave the mode as the next one expects.
+        await setClipMode('local');
         initCaptureWith(null);
       }
     },

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -13,7 +13,7 @@ import { openMarket } from '../../src/db/market.js';
 import { setDrop } from '../../src/db/drops.js';
 import { setupRaidWeek, enlist } from '../../src/db/raid.js';
 import { seedCuratedFacts } from '../../src/db/facts.js';
-import { getRaidPointer, getConfig, setLive } from '../../src/db/configStore.js';
+import { getRaidPointer, getConfig, setLive, setClipMode } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 import { defaultBoss } from '../../src/content/bosses.js';
@@ -77,15 +77,46 @@ export const SCENARIOS = [
         assert.match(local, /clipped it/i);
         assert.doesNotMatch(local, /clips\.twitch\.tv/, 'the default must not make a Twitch clip');
 
-        // CLIP_MODE=both puts the Twitch clip back alongside it (needs live).
-        process.env.CLIP_MODE = 'both';
+        // 'both' puts the Twitch clip back alongside it (needs live). Set the LIVE
+        // value rather than the env var — RTDB deliberately overrides the
+        // environment, so setting CLIP_MODE here would (correctly) be ignored.
+        await setClipMode('both');
         await setLive(true, 'test');
         await until(() => getConfig().live === true); // mirror is async
         assert.match(await bot.send(bob, '!clip'), /clips\.twitch\.tv\/TestClipId123/);
       } finally {
-        delete process.env.CLIP_MODE;
+        await setClipMode('local'); // reset shared config for later scenarios
         initCaptureWith(null);
         await setLive(false, 'test'); // reset shared live state for later scenarios
+      }
+    },
+  },
+  {
+    command: 'clipmode', title: 'a mod switches what !clip does, and it persists',
+    run: async ({ bot, u }) => {
+      const mod = u('e2e_clipmode', { login: 'nikki', name: 'Nikki', mod: true });
+      const viewer = u('e2e_clipmode_v', { login: 'carl', name: 'Carl' });
+      initCaptureWith(async () => ({ path: 'D:/rec/Replay.mkv' }));
+      try {
+        assert.match(await bot.send(mod, '!clipmode status'), /!clip mode: \w+/);
+
+        // Switching to twitch must take effect for the very next !clip, without
+        // waiting on an RTDB round-trip — that's why setClipMode writes the mirror first.
+        await bot.send(mod, '!clipmode twitch');
+        assert.equal(getConfig().clipMode, 'twitch', 'mirror updated synchronously');
+        const snap = await database().ref('config/clipMode').get();
+        assert.equal(snap.val(), 'twitch', 'and persisted, so it survives a restart');
+
+        // Not live → the twitch half is impossible, and local is switched off.
+        assert.match(await bot.send(viewer, '!clip'), /only clip while the stream is live/i);
+
+        await bot.send(mod, '!clipmode local');
+        assert.equal(getConfig().clipMode, 'local');
+
+        assert.match(await bot.send(mod, '!clipmode nonsense'), /Usage: !clipmode/);
+        assert.equal(getConfig().clipMode, 'local', 'a bad value changes nothing');
+      } finally {
+        initCaptureWith(null);
       }
     },
   },

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -70,16 +70,15 @@ export const SCENARIOS = [
       initClipsWith(async () => 'TestClipId123'); // fake Helix Create Clip
       initCaptureWith(async () => ({ path: 'D:/rec/Replay.mkv' })); // fake OBS
       try {
-        // Default CLIP_MODE=local: the streamer's OBS saves the moment at full
+        // Default mode is local: the streamer's OBS saves the moment at full
         // recording quality and nothing is posted to Twitch.
         // The reply is a bare confirmation — chat learns nothing about the rig.
         const local = await bot.send(alice, '!clip');
         assert.match(local, /clipped it/i);
         assert.doesNotMatch(local, /clips\.twitch\.tv/, 'the default must not make a Twitch clip');
 
-        // 'both' puts the Twitch clip back alongside it (needs live). Set the LIVE
-        // value rather than the env var — RTDB deliberately overrides the
-        // environment, so setting CLIP_MODE here would (correctly) be ignored.
+        // 'both' puts the Twitch clip back alongside it (needs live). The mode is
+        // RTDB-only — there is no env var — so switch it the way a mod does.
         await setClipMode('both');
         await setLive(true, 'test');
         await until(() => getConfig().live === true); // mirror is async

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -4,7 +4,13 @@
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { initCapture, initCaptureWith, captureReady, triggerCapture } from '../../src/integrations/capture.js';
-import { deriveAuth, websocketAvailable, replayBufferSequence } from '../../src/integrations/obsWebsocket.js';
+import {
+  deriveAuth,
+  websocketAvailable,
+  replayBufferSequence,
+  verticalBacktrackSequence,
+  AITUM_VENDOR,
+} from '../../src/integrations/obsWebsocket.js';
 
 const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
 
@@ -157,4 +163,80 @@ test('warm buffer: a path that never changes is reported as null, not stale', as
   const res = await replayBufferSequence(obs.request, noSleep);
   assert.equal(res.path, null, 'better no path than the wrong one');
   assert.ok(obs.calls.includes('SaveReplayBuffer'), 'the save still happened');
+});
+
+
+// ── Aitum vertical Backtrack ────────────────────────────────────────────────
+// The 9:16 canvas has its own replay buffer ("Backtrack"), reached through
+// obs-websocket vendor requests on the SAME connection as the horizontal save.
+
+/** A fake Aitum Stream Suite vendor endpoint. */
+function fakeAitum({ outputs, saveResult = { success: true } } = {}) {
+  const calls = [];
+  const state = new Map(outputs.map((o) => [o.name, o.active]));
+  return {
+    calls,
+    request: async (type, data) => {
+      if (type !== 'CallVendorRequest') throw new Error(`unexpected ${type}`);
+      const { vendorName, requestType, requestData } = data;
+      assert.equal(vendorName, AITUM_VENDOR, 'must address the Stream Suite vendor');
+      calls.push(requestType);
+      switch (requestType) {
+        case 'get_outputs':
+          return { responseData: { success: true, outputs: [...state].map(([name, active]) => ({ name, active, type: 'backtrack' })) } };
+        case 'start_output':
+          state.set(requestData.output, true); // flips on the next poll
+          return { responseData: { success: true } };
+        case 'save_backtrack':
+          return { responseData: saveResult };
+        default:
+          throw new Error(`unexpected vendor request ${requestType}`);
+      }
+    },
+  };
+}
+
+test('vertical: an inactive Backtrack is started and NOT treated as a save', async () => {
+  const aitum = fakeAitum({ outputs: [{ name: 'Vertical Backtrack', active: false }] });
+  const res = await verticalBacktrackSequence(aitum.request, 'Vertical Backtrack', noSleep);
+  assert.deepEqual(res, { ok: true, requested: false, started: true });
+  assert.ok(!aitum.calls.includes('save_backtrack'), 'nothing buffered yet — saving would be a lie');
+});
+
+test('vertical: an active Backtrack is saved', async () => {
+  const aitum = fakeAitum({ outputs: [{ name: 'Vertical Backtrack', active: true }] });
+  const res = await verticalBacktrackSequence(aitum.request, 'Vertical Backtrack', noSleep);
+  assert.deepEqual(res, { ok: true, requested: true, started: false });
+  assert.ok(aitum.calls.includes('save_backtrack'));
+});
+
+// Found against a real Stream Suite 1.2.1: with a 15-minute-full buffer,
+// save_backtrack answered {success:true} and wrote NO file, because the output
+// had no recording path. The vendor API can't read that path back, so we must
+// never promote acceptance to "saved".
+test('vertical: success means REQUESTED, never a file on disk', async () => {
+  const aitum = fakeAitum({ outputs: [{ name: 'Vertical Backtrack', active: true }] });
+  const res = await verticalBacktrackSequence(aitum.request, 'Vertical Backtrack', noSleep);
+  assert.equal(res.requested, true);
+  assert.ok(!('path' in res), 'no path field — we cannot know it, so we must not imply it');
+  assert.ok(!('saved' in res), 'must not claim a save it cannot verify');
+});
+
+test('vertical: an explicit failure from the plugin is surfaced', async () => {
+  const aitum = fakeAitum({
+    outputs: [{ name: 'Vertical Backtrack', active: true }],
+    saveResult: { success: false, error: "'output' not set" },
+  });
+  await assert.rejects(
+    () => verticalBacktrackSequence(aitum.request, 'Vertical Backtrack', noSleep),
+    /output' not set/,
+  );
+});
+
+test('vertical: a missing output names itself rather than failing vaguely', async () => {
+  const aitum = fakeAitum({ outputs: [{ name: 'Vertical Stream', active: true }] });
+  await assert.rejects(
+    () => verticalBacktrackSequence(aitum.request, 'Vertical Backtrack', noSleep),
+    /no Aitum output named "Vertical Backtrack"/,
+  );
 });

--- a/test/rules/capture.test.js
+++ b/test/rules/capture.test.js
@@ -23,7 +23,9 @@ test('capture is disabled when no OBS url is configured', () => {
 
 test('an unknown backend disables capture rather than guessing', () => {
   initCapture({ backend: 'aitum', url: 'ws://x:4455' }, noopLogger);
-  assert.equal(captureReady(), false, 'aitum is not implemented yet — must not silently use obs');
+  // Aitum IS supported — but via obs-websocket vendor requests on the obs-websocket
+  // backend, not as a backend name. An unknown name must disable capture, never guess.
+  assert.equal(captureReady(), false, 'an unrecognised backend must not silently use obs');
 });
 
 test('a valid obs-websocket config enables capture', () => {

--- a/test/rules/clip-command.test.js
+++ b/test/rules/clip-command.test.js
@@ -1,13 +1,13 @@
 // !clip mode selection. The default is LOCAL: !clip triggers the streamer's
 // OBS/Aitum capture and posts NOTHING to Twitch. These lock down which half of
-// the command fires for each CLIP_MODE — the failure that matters is a mode
+// the command fires for each clip mode — the failure that matters is a mode
 // quietly making a Twitch clip the streamer didn't ask for.
 //
 // The live mirror is `false` throughout (no RTDB here), which is exactly the
 // interesting case: the local buffer works offline, Twitch's Create Clip doesn't.
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import clip, { resolveClipMode, activeClipMode } from '../../src/commands/clip.js';
+import clip, { activeClipMode } from '../../src/commands/clip.js';
 import { parseClipMode, CLIP_MODES, primeConfigForTest } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
@@ -23,51 +23,41 @@ async function runClip() {
 }
 
 afterEach(() => {
-  delete process.env.CLIP_MODE;
   primeConfigForTest({ clipMode: null }); // back to a cold mirror
   initClipsWith(null);
   initCaptureWith(null);
 });
 
-test('CLIP_MODE parses the three modes and defaults to local', () => {
-  assert.equal(resolveClipMode(undefined), 'local', 'unset → local');
-  assert.equal(resolveClipMode(''), 'local');
-  assert.equal(resolveClipMode('  BOTH '), 'both', 'trimmed + case-insensitive');
-  assert.equal(resolveClipMode('twitch'), 'twitch');
-  assert.equal(resolveClipMode('nonsense'), 'local', 'a typo must not silently enable Twitch clips');
-  // Same guarantees wherever the value comes from — env, RTDB, or chat.
+test('a clip mode parses from any source and defaults to local', () => {
   assert.deepEqual(CLIP_MODES, ['local', 'twitch', 'both']);
-  assert.equal(parseClipMode(null), 'local', 'a wiped RTDB value must not enable Twitch');
+  assert.equal(parseClipMode('  BOTH '), 'both', 'trimmed + case-insensitive');
+  assert.equal(parseClipMode('twitch'), 'twitch');
+  // Every bad-input path lands on the safe default. The failure that matters is a
+  // typo — or a wiped RTDB value — quietly turning Twitch clipping back on.
+  for (const bad of [undefined, null, '', 'nonsense', 42, {}]) {
+    assert.equal(parseClipMode(bad), 'local', `${JSON.stringify(bad)} must not enable Twitch`);
+  }
 });
 
-// The whole point of making this dynamic: a mod flips it from chat when the
-// streamer's OBS dies, and the container's env must not quietly win it back.
-test('the live RTDB value overrides the environment', () => {
-  process.env.CLIP_MODE = 'twitch';
-  assert.equal(resolveClipMode(), 'twitch', 'env alone says twitch');
-  primeConfigForTest({ clipMode: 'local' }); // a mod ran `!clipmode local`
-  assert.equal(activeClipMode(), 'local', 'the live value wins');
-});
-
-test('activeClipMode falls back to env only while the mirror is cold', () => {
-  // clipMode is null until startConfigMirror lands its first snapshot — true in
-  // unit tests, and true for the window during boot before the mirror is warm.
-  process.env.CLIP_MODE = 'both';
-  primeConfigForTest({ clipMode: null });
-  assert.equal(activeClipMode(), 'both', 'cold mirror → env');
-});
-
-test('!clip obeys the live mode, not the environment', async () => {
-  let clips = 0;
+// The point of making this runtime config: a mod flips it from chat the moment the
+// streamer's OBS dies, without an SSH session and a redeploy.
+test('the live RTDB value is what !clip obeys', async () => {
   let captures = 0;
-  process.env.CLIP_MODE = 'local'; // env says local…
-  primeConfigForTest({ clipMode: 'twitch' }); // …but a mod switched to twitch
-  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  primeConfigForTest({ clipMode: 'twitch' }); // a mod ran `!clipmode twitch`
+  assert.equal(activeClipMode(), 'twitch');
+  initClipsWith(async () => 'TwitchClipId');
   initCaptureWith(async () => { captures += 1; return { path: 'x.mkv' }; });
 
   const reply = await runClip(); // not live, so the twitch half is gated
   assert.equal(captures, 0, 'local capture must not fire — the live mode is twitch');
   assert.match(reply, /only clip while the stream is live/i);
+});
+
+test('a cold mirror falls back to the configured default, never to Twitch', () => {
+  // clipMode is null until startConfigMirror lands its first snapshot — true in
+  // unit tests, and true for the window during boot before the mirror is warm.
+  primeConfigForTest({ clipMode: null });
+  assert.equal(activeClipMode(), 'local');
 });
 
 test('by default !clip captures locally and makes NO Twitch clip', async () => {
@@ -120,9 +110,9 @@ test('local mode never falls back to Twitch when no capture backend is configure
   assert.match(reply, /clipping isn't set up/i);
 });
 
-test("CLIP_MODE=twitch restores the old behaviour and doesn't touch OBS", async () => {
+test("mode 'twitch' restores the old behaviour and doesn't touch OBS", async () => {
   let captures = 0;
-  process.env.CLIP_MODE = 'twitch';
+  primeConfigForTest({ clipMode: 'twitch' });
   initClipsWith(async () => 'TwitchClipId');
   initCaptureWith(async () => { captures += 1; return { path: 'x.mkv' }; });
 
@@ -131,9 +121,9 @@ test("CLIP_MODE=twitch restores the old behaviour and doesn't touch OBS", async 
   assert.match(reply, /only clip while the stream is live/i);
 });
 
-test('CLIP_MODE=both while offline still saves locally instead of failing', async () => {
+test("mode 'both' while offline still saves locally instead of failing", async () => {
   let clips = 0;
-  process.env.CLIP_MODE = 'both';
+  primeConfigForTest({ clipMode: 'both' });
   initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
   initCaptureWith(async () => ({ path: 'D:/rec/Replay.mkv' }));
 

--- a/test/rules/clip-command.test.js
+++ b/test/rules/clip-command.test.js
@@ -8,7 +8,7 @@
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import clip, { activeClipMode } from '../../src/commands/clip.js';
-import { parseClipMode, CLIP_MODES, primeConfigForTest } from '../../src/db/configStore.js';
+import { parseClipMode, readClipTargets, clipTargets, primeConfigForTest } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 
@@ -28,15 +28,44 @@ afterEach(() => {
   initCaptureWith(null);
 });
 
-test('a clip mode parses from any source and defaults to local', () => {
-  assert.deepEqual(CLIP_MODES, ['local', 'twitch', 'both']);
-  assert.equal(parseClipMode('  BOTH '), 'both', 'trimmed + case-insensitive');
+test('the mode is a SET of targets, in any order, with aliases', () => {
+  // Canonical form, so 'a b' and 'b,a' are the same stored value.
+  assert.equal(parseClipMode('horizontal vertical'), 'horizontal,vertical');
+  assert.equal(parseClipMode('vertical,horizontal'), 'horizontal,vertical', 'order-independent');
+  assert.equal(parseClipMode('HORIZONTAL'), 'horizontal', 'case-insensitive');
+  assert.equal(parseClipMode('horizontal twitch'), 'horizontal,twitch');
   assert.equal(parseClipMode('twitch'), 'twitch');
-  // Every bad-input path lands on the safe default. The failure that matters is a
-  // typo — or a wiped RTDB value — quietly turning Twitch clipping back on.
+  assert.equal(parseClipMode('vertical'), 'vertical');
+  // Shorthands, kept so old stored values and muscle memory keep working.
+  assert.equal(parseClipMode('local'), 'horizontal,vertical');
+  assert.equal(parseClipMode('both'), 'horizontal,vertical,twitch');
+  assert.equal(parseClipMode('all'), 'horizontal,vertical,twitch');
+  assert.equal(parseClipMode('local twitch'), 'horizontal,vertical,twitch', 'alias + target mixes');
+});
+
+test("'off' is storable and does not decay back to the default", () => {
+  // An empty target list must not round-trip through '' — that would read back as
+  // "unrecognised" and silently re-enable clipping a mod had turned off.
+  assert.equal(parseClipMode('off'), 'off');
+  assert.equal(parseClipMode(parseClipMode('off')), 'off', 'stable across a re-read');
+  assert.equal(clipTargets('off').none, true);
+});
+
+test('a mode is all-or-nothing — one bad token rejects the whole thing', () => {
+  // Dropping the bad token would leave a mode that looks accepted but does less
+  // than asked, and the symptom is a clip that silently is not made.
+  assert.equal(readClipTargets('horizontal nonsense'), null);
+  assert.equal(readClipTargets('nonsense'), null);
+  // Bad input from RTDB still lands on the safe default, never on Twitch.
   for (const bad of [undefined, null, '', 'nonsense', 42, {}]) {
-    assert.equal(parseClipMode(bad), 'local', `${JSON.stringify(bad)} must not enable Twitch`);
+    assert.equal(parseClipMode(bad), 'horizontal,vertical', `${JSON.stringify(bad)} must not enable Twitch`);
   }
+});
+
+test('clipTargets turns a mode into what to actually do', () => {
+  assert.deepEqual(clipTargets('horizontal'), { horizontal: true, vertical: false, twitch: false, none: false });
+  assert.deepEqual(clipTargets('vertical,twitch'), { horizontal: false, vertical: true, twitch: true, none: false });
+  assert.deepEqual(clipTargets('all'), { horizontal: true, vertical: true, twitch: true, none: false });
 });
 
 // The point of making this runtime config: a mod flips it from chat the moment the
@@ -57,7 +86,7 @@ test('a cold mirror falls back to the configured default, never to Twitch', () =
   // clipMode is null until startConfigMirror lands its first snapshot — true in
   // unit tests, and true for the window during boot before the mirror is warm.
   primeConfigForTest({ clipMode: null });
-  assert.equal(activeClipMode(), 'local');
+  assert.equal(activeClipMode(), 'horizontal,vertical');
 });
 
 test('by default !clip captures locally and makes NO Twitch clip', async () => {
@@ -130,6 +159,54 @@ test("mode 'both' while offline still saves locally instead of failing", async (
   const reply = await runClip(); // not live → Twitch half is impossible
   assert.equal(clips, 0, 'Create Clip would be rejected offline — do not call it');
   assert.match(reply, /clipped it/i);
+});
+
+// The combinations the old local|twitch|both presets could NOT express. Each
+// asserts what the capture layer was actually asked for, not just the reply text.
+test('horizontal-only does not ask for the vertical save', async () => {
+  let asked = null;
+  primeConfigForTest({ clipMode: 'horizontal' });
+  initCaptureWith(async (t) => { asked = t; return { path: 'h.mkv' }; });
+  assert.match(await runClip(), /clipped it/i);
+  assert.deepEqual(asked, { horizontal: true, vertical: false });
+});
+
+test('vertical-only does not ask for the horizontal save', async () => {
+  let asked = null;
+  primeConfigForTest({ clipMode: 'vertical' });
+  initCaptureWith(async (t) => { asked = t; return { path: null, vertical: { ok: true, requested: true } }; });
+  assert.match(await runClip(), /clipped it/i);
+  assert.deepEqual(asked, { horizontal: false, vertical: true });
+});
+
+test('horizontal + twitch captures locally without the vertical file', async () => {
+  let asked = null;
+  let clips = 0;
+  primeConfigForTest({ clipMode: 'horizontal,twitch' });
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(async (t) => { asked = t; return { path: 'h.mkv' }; });
+  await runClip(); // offline → twitch half drops, local still runs
+  assert.deepEqual(asked, { horizontal: true, vertical: false });
+  assert.equal(clips, 0, 'Create Clip is impossible offline — do not call it');
+});
+
+test('asking for vertical with no vertical output configured is a no-op, not a horizontal capture', async () => {
+  let captures = 0;
+  primeConfigForTest({ clipMode: 'vertical' });
+  initCaptureWith(async () => { captures += 1; return { path: 'h.mkv' }; }, { verticalOutput: '' });
+  assert.match(await runClip(), /clipping isn't set up/i);
+  assert.equal(captures, 0, 'must not silently save the horizontal instead');
+});
+
+test("'off' disables !clip entirely without touching either backend", async () => {
+  let captures = 0;
+  let clips = 0;
+  primeConfigForTest({ clipMode: 'off' });
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(async () => { captures += 1; return { path: 'x.mkv' }; });
+  assert.match(await runClip(), /clipping isn't set up/i);
+  assert.equal(captures, 0);
+  assert.equal(clips, 0);
 });
 
 test('a cold replay buffer reads as an ordinary miss, not a status report', async () => {

--- a/test/rules/clip-command.test.js
+++ b/test/rules/clip-command.test.js
@@ -7,7 +7,8 @@
 // interesting case: the local buffer works offline, Twitch's Create Clip doesn't.
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import clip, { resolveClipMode } from '../../src/commands/clip.js';
+import clip, { resolveClipMode, activeClipMode } from '../../src/commands/clip.js';
+import { parseClipMode, CLIP_MODES, primeConfigForTest } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 
@@ -23,6 +24,7 @@ async function runClip() {
 
 afterEach(() => {
   delete process.env.CLIP_MODE;
+  primeConfigForTest({ clipMode: null }); // back to a cold mirror
   initClipsWith(null);
   initCaptureWith(null);
 });
@@ -33,6 +35,39 @@ test('CLIP_MODE parses the three modes and defaults to local', () => {
   assert.equal(resolveClipMode('  BOTH '), 'both', 'trimmed + case-insensitive');
   assert.equal(resolveClipMode('twitch'), 'twitch');
   assert.equal(resolveClipMode('nonsense'), 'local', 'a typo must not silently enable Twitch clips');
+  // Same guarantees wherever the value comes from — env, RTDB, or chat.
+  assert.deepEqual(CLIP_MODES, ['local', 'twitch', 'both']);
+  assert.equal(parseClipMode(null), 'local', 'a wiped RTDB value must not enable Twitch');
+});
+
+// The whole point of making this dynamic: a mod flips it from chat when the
+// streamer's OBS dies, and the container's env must not quietly win it back.
+test('the live RTDB value overrides the environment', () => {
+  process.env.CLIP_MODE = 'twitch';
+  assert.equal(resolveClipMode(), 'twitch', 'env alone says twitch');
+  primeConfigForTest({ clipMode: 'local' }); // a mod ran `!clipmode local`
+  assert.equal(activeClipMode(), 'local', 'the live value wins');
+});
+
+test('activeClipMode falls back to env only while the mirror is cold', () => {
+  // clipMode is null until startConfigMirror lands its first snapshot — true in
+  // unit tests, and true for the window during boot before the mirror is warm.
+  process.env.CLIP_MODE = 'both';
+  primeConfigForTest({ clipMode: null });
+  assert.equal(activeClipMode(), 'both', 'cold mirror → env');
+});
+
+test('!clip obeys the live mode, not the environment', async () => {
+  let clips = 0;
+  let captures = 0;
+  process.env.CLIP_MODE = 'local'; // env says local…
+  primeConfigForTest({ clipMode: 'twitch' }); // …but a mod switched to twitch
+  initClipsWith(async () => { clips += 1; return 'TwitchClipId'; });
+  initCaptureWith(async () => { captures += 1; return { path: 'x.mkv' }; });
+
+  const reply = await runClip(); // not live, so the twitch half is gated
+  assert.equal(captures, 0, 'local capture must not fire — the live mode is twitch');
+  assert.match(reply, /only clip while the stream is live/i);
 });
 
 test('by default !clip captures locally and makes NO Twitch clip', async () => {


### PR DESCRIPTION
Four commits. The PR title covers the release-note-worthy part; the rest is below.

## 1. Vertical capture — `!clip` saves both formats

Aitum Stream Suite adds a second **1080×1920 canvas** with its own replay buffer, **Backtrack**. The streamer composes that canvas for portrait, so its capture is a **natively framed 9:16 clip** — not a crop of the landscape one, which is all an after-the-fact crop can produce.

`CAPTURE_VERTICAL_OUTPUT=Vertical Backtrack` enables it; unset = horizontal only. Both saves ride **one** obs-websocket connection — Stream Suite exposes its API as obs-websocket *vendor requests* (`aitum-stream-suite`), so no new transport, no new dependency, and **not Aitum Nexus**.

**It reports `requested`, never `saved`.** `save_backtrack` answers `{"success": true}` on *acceptance*, and the vendor API cannot read back the written path. A test asserts the result carries neither a `path` nor a `saved` field.

**Verified end to end through the real command:** one `!clip` in chat produced `Replay …15-22-46.mp4` (1920×1080, 60s) and `…15-22-47 Vertical Backtrack.mp4` (1080×1920, 52s) one second apart, while the vertical canvas was being broadcast. A frame extracted from the vertical file shows the composed two-box layout.

## 2. `!clipmode` — the clip mode is now runtime config

```
!clipmode local|twitch|both|status    (mod)
```

Operational, not game balance: if the streamer's OBS dies mid-stream, `local` leaves `!clip` with nothing to do, and recovering via SSH + env edit + container restart is not a route anyone takes mid-show.

`status` reports the mode **and** whether each half can actually run; switching to a mode nothing is configured for warns immediately, rather than leaving a viewer to discover it.

## 3. `CLIP_MODE` env var removed entirely

An env var *and* a DB value that can disagree is a trap. `config/clipMode` is now seeded once from `clip.defaultMode` in `src/config.js` and authoritative thereafter — exactly the shape `liveGate.defaultExpMode` already established for the EXP gate, which never had an env var either.

The existing `!clip` e2e caught this correctly: it had been setting `process.env.CLIP_MODE`, which RTDB now rightly ignores.

## 4. Audit fixes

- **`health.clipMode` went stale.** Captured once at boot, so the heartbeat reported a mode no longer in force the moment a mod switched it. Now read at write time. A health snapshot that lies is worse than one that omits.
- **An unverified causal claim removed.** The docs asserted Backtrack "writes nothing without a recording path". Never verified — files were landing from the first test; the reason none were found was WSL serving stale `/mnt/c` metadata (`ls -t` reported a four-day-old file as newest). Docs now state only what was observed, and that **OBS's own log is the source of truth** over both the API and the filesystem.
- Stale comments that would misdirect: `capture.js` claimed Aitum would arrive "via :7777 later" (it's already integrated, and Nexus isn't needed); a test's rationale said Aitum "is not implemented yet".
- Stale JSDoc on `initCapture` / `triggerCapture`; `!clip` help said "~30s" (it's ~60s, and viewers see that string).
- `docs/CONFIG.md` claims to document every knob and omitted `clip.defaultMode`.

## Docs

`docs/clip-architecture.md` gains the vendor-request table, the Aitum setup path, and **where clip length actually lives** — three independent OBS-side settings that must be aligned, none of them in kennyBot.

**84 unit · 50 emulator · 29 e2e.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)