### PR TITLE
feat: !fact <n> returns the fact numbered n on the /info/ page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 
 | Command | Who | Effect |
 |---|---|---|
-| `!fact` / `!facts` | everyone | a random fact · `!fact suggest <text>` submits one for approval |
+| `!fact` / `!facts` | everyone | a random fact, with its number · `!fact <#>` the one numbered `#` on [/info/](https://okrafans.com/info/) · `!fact suggest <text>` submits one for approval |
 | `!kennycommands` / `!kennybot` / `!kcommands` | everyone | the full command list, in chat |
 
 **Mod / operations**

--- a/src/commands/fact.js
+++ b/src/commands/fact.js
@@ -1,8 +1,18 @@
-// !fact — NIKKI FUN FACTS. Public: `!fact` shows a random approved fact;
-// `!fact suggest <text>` queues one for mod approval. Mod-only:
+// !fact — NIKKI FUN FACTS. Public: `!fact` shows a random approved fact, `!fact <n>`
+// shows the one numbered n on the /info/ page (see sortFacts in db/facts.js — the
+// page numbers its <ol> positionally and stores no number, so the bot has to derive
+// the identical ordering); `!fact suggest <text>` queues one for mod approval. Mod-only:
 // `!fact pending`, `!fact approve <#>`, `!fact reject <#>`. Mixed public/mod, so
 // it stays `mod:false` and gates the moderation subcommands on isMod inline.
-import { suggestFact, listPendingFacts, approveFact, rejectFact, randomApprovedFact, cleanFactText } from '../db/facts.js';
+import {
+  suggestFact,
+  listPendingFacts,
+  approveFact,
+  rejectFact,
+  randomApprovedFact,
+  factByNumber,
+  cleanFactText,
+} from '../db/facts.js';
 import { config } from '../config.js';
 
 // Per-user suggest throttle (single instance → in-memory is authoritative).
@@ -13,7 +23,7 @@ export default {
   names: ['fact', 'facts'],
   mod: false,
   cooldownMs: 3_000,
-  help: '!fact — a random Nikki fun fact · !fact suggest <text> — suggest one for approval',
+  help: '!fact — a random Nikki fun fact · !fact <#> — the one numbered # on /info/ · !fact suggest <text> — suggest one',
   async run({ user, args, reply }) {
     const sub = (args[0] || '').toLowerCase();
     const isMod = user.isMod || user.isBroadcaster;
@@ -61,11 +71,27 @@ export default {
       return;
     }
 
+    // ── public: a specific fact by its /info/ number ──
+    // Digits only, so this can never shadow a subcommand word.
+    if (/^\d+$/.test(sub)) {
+      const { fact, number, total } = await factByNumber(Number.parseInt(sub, 10));
+      if (!fact) {
+        reply(
+          total
+            ? `@${user.displayName} there ${total === 1 ? 'is only 1 fact' : `are only ${total} facts`} — try !fact 1-${total}  ·  ${config.siteUrl}/info/`
+            : `No facts yet — be the first! !fact suggest <your fact>  (${config.siteUrl}/info/)`,
+        );
+        return;
+      }
+      reply(`NIKKI FUN FACT #${number}: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}`);
+      return;
+    }
+
     // ── public: a random Nikki fun fact ──
     const fact = await randomApprovedFact();
     reply(
       fact
-        ? `NIKKI FUN FACT: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}  ·  suggest yours: !fact suggest <text>`
+        ? `NIKKI FUN FACT #${fact.number}: ${fact.text}${fact.by ? ` (— ${fact.by})` : ''}  ·  !fact <#> for a specific one  ·  suggest yours: !fact suggest <text>`
         : `No facts yet — be the first! !fact suggest <your fact>  (${config.siteUrl}/info/)`,
     );
   },

--- a/src/db/facts.js
+++ b/src/db/facts.js
@@ -100,10 +100,54 @@ export async function rejectFact(id) {
   return { ok: true, text: sub.text };
 }
 
-/** A random approved fact (for the bare `!fact` command), or null if none. */
-export async function randomApprovedFact() {
+/**
+ * The /info/ page's display order, mirrored EXACTLY: curated facts first in their
+ * seeded `order`, then viewer submissions newest-first.
+ *
+ * This is a duplicate of `sortFacts` in the website's `_includes/info.html`, and it
+ * has to stay one — `!fact <n>` promises the number a viewer can see on the page,
+ * and the page numbers its `<ol>` positionally, storing no number anywhere. If the
+ * two orderings drift, `!fact 3` starts quoting a different fact than the site
+ * shows, silently. Change one, change the other.
+ *
+ * Pure and exported so it can be unit-tested without a database.
+ */
+export function sortFacts(facts) {
+  return facts.slice().sort((a, b) => {
+    const ca = a.source === 'curated';
+    const cb = b.source === 'curated';
+    if (ca && cb) return (a.order || 0) - (b.order || 0);
+    if (ca !== cb) return ca ? -1 : 1;
+    return (b.at || 0) - (a.at || 0);
+  });
+}
+
+/** Every approved fact, in the same order the /info/ page numbers them. */
+export async function orderedFacts() {
   const snap = await database().ref(PATHS.facts()).get();
-  const facts = Object.values(snap.val() || {}).filter((f) => f && f.text);
+  return sortFacts(Object.values(snap.val() || {}).filter((f) => f && f.text));
+}
+
+/**
+ * The fact shown as **#n** on /info/ (1-based).
+ * @returns {Promise<{ fact: object|null, number?: number, total: number }>}
+ *   `fact` is null when n is out of range; `total` always lets the caller say
+ *   what the valid range is instead of guessing for the viewer.
+ */
+export async function factByNumber(n) {
+  const facts = await orderedFacts();
+  if (!Number.isInteger(n) || n < 1 || n > facts.length) return { fact: null, total: facts.length };
+  return { fact: facts[n - 1], number: n, total: facts.length };
+}
+
+/**
+ * A random approved fact — carrying the number it shows as on /info/, so the
+ * numbering is discoverable from chat without visiting the page.
+ * @returns {Promise<(object & { number: number, total: number })|null>}
+ */
+export async function randomApprovedFact() {
+  const facts = await orderedFacts();
   if (!facts.length) return null;
-  return facts[Math.floor(Math.random() * facts.length)];
+  const i = Math.floor(Math.random() * facts.length);
+  return { ...facts[i], number: i + 1, total: facts.length };
 }

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -12,7 +12,7 @@ import { ensureWallet } from '../../src/db/wallet.js';
 import { openMarket } from '../../src/db/market.js';
 import { setDrop } from '../../src/db/drops.js';
 import { setupRaidWeek, enlist } from '../../src/db/raid.js';
-import { seedCuratedFacts } from '../../src/db/facts.js';
+import { seedCuratedFacts, orderedFacts } from '../../src/db/facts.js';
 import { getRaidPointer, getConfig, setLive, setClipMode } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
@@ -220,11 +220,30 @@ export const SCENARIOS = [
     },
   },
   {
-    command: 'fact', title: 'returns a random fun fact',
+    command: 'fact', title: 'random fact, and a specific one by its /info/ number',
     run: async ({ bot, u, fx }) => {
       await fx.facts();
-      const reply = await bot.send(u('e2e_fact', { login: 'viewer' }), '!fact');
-      assert.match(reply, /FUN FACT/i);
+      const viewer = u('e2e_fact', { login: 'viewer' });
+
+      // Bare !fact — random, but it reports which number it is so the numbering
+      // is discoverable from chat.
+      const random = await bot.send(viewer, '!fact');
+      assert.match(random, /FUN FACT #\d+:/i);
+
+      // !fact <n> must return the fact the /info/ page shows at position n. The
+      // page numbers positionally, so assert against the same ordering the site
+      // uses rather than against a hardcoded string.
+      const ordered = await orderedFacts();
+      assert.ok(ordered.length >= 2, 'need at least two facts to test numbering');
+      const third = await bot.send(u('e2e_fact3', { login: 'v3' }), '!fact 2');
+      assert.match(third, /FUN FACT #2:/);
+      assert.ok(third.includes(ordered[1].text), 'must be the SAME fact the page numbers 2');
+
+      // Out of range says what the range is, rather than silently answering with
+      // some other fact — a typo must not look like a successful lookup.
+      const oor = await bot.send(u('e2e_fact4', { login: 'v4' }), `!fact ${ordered.length + 5}`);
+      assert.match(oor, new RegExp(`only ${ordered.length} facts`, 'i'));
+      assert.doesNotMatch(oor, /FUN FACT #/, 'must not fall back to a random fact');
     },
   },
   {

--- a/test/rules/fact-order.test.js
+++ b/test/rules/fact-order.test.js
@@ -1,0 +1,57 @@
+// Fact ordering. `!fact <n>` promises the number a viewer can SEE on the /info/
+// page — and the page numbers its <ol> positionally, storing no number anywhere.
+// So the bot has to reproduce the site's sort exactly. These tests pin that sort
+// against the website's own implementation (_includes/info.html sortFacts):
+//
+//   curated first, by `order` · then submissions, newest-first by `at`
+//
+// If these fail, `!fact 3` is quoting a different fact than the page displays.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sortFacts } from '../../src/db/facts.js';
+
+const curated = (order, text = `c${order}`) => ({ text, source: 'curated', order });
+const submitted = (at, text = `s${at}`, by = 'viewer') => ({ text, by, at });
+
+const texts = (facts) => sortFacts(facts).map((f) => f.text);
+
+test('curated facts come first, in their seeded order', () => {
+  assert.deepEqual(texts([curated(3), curated(1), curated(2)]), ['c1', 'c2', 'c3']);
+});
+
+test('submissions follow the curated block, newest first', () => {
+  const facts = [submitted(100), curated(2), submitted(300), curated(1), submitted(200)];
+  assert.deepEqual(texts(facts), ['c1', 'c2', 's300', 's200', 's100']);
+});
+
+test('a curated fact outranks a submission regardless of timestamps', () => {
+  // Curated facts carry no `at`, so a submission approved just now must not
+  // jump ahead of them.
+  const t = 1_900_000_000_000;
+  assert.deepEqual(texts([submitted(t), curated(1)]), ['c1', `s${t}`]);
+});
+
+test('the input array is never mutated — callers may hold the original', () => {
+  const input = [curated(2), curated(1)];
+  const copy = [...input];
+  sortFacts(input);
+  assert.deepEqual(input, copy);
+});
+
+test('missing order/at fields sort predictably instead of throwing', () => {
+  // Real data has gaps: approveFact writes no `order`, and older curated rows
+  // predate the field. Treat them as 0 rather than producing NaN comparisons.
+  const facts = [{ text: 'no-order', source: 'curated' }, curated(1), { text: 'no-at', by: 'x' }, submitted(50)];
+  const out = texts(facts);
+  assert.equal(out[0], 'no-order', 'order-less curated sorts as 0 → first');
+  assert.equal(out[1], 'c1');
+  assert.deepEqual(out.slice(2), ['s50', 'no-at'], 'at-less submission sorts as 0 → last');
+});
+
+test('numbering is 1-based and positional, matching the page <ol>', () => {
+  const ordered = sortFacts([submitted(200), curated(1), submitted(100), curated(2)]);
+  assert.equal(ordered.length, 4);
+  // What `!fact 2` must resolve to:
+  assert.equal(ordered[2 - 1].text, 'c2');
+  assert.equal(ordered[4 - 1].text, 's100');
+});


### PR DESCRIPTION
Viewers can see numbered facts on [okrafans.com/info/](https://okrafans.com/info/) but had no way to ask for one by number — bare `!fact` only ever returned a random one.

```
!fact       →  NIKKI FUN FACT #4: … · !fact <#> for a specific one · suggest yours: !fact suggest <text>
!fact 2     →  NIKKI FUN FACT #2: Ghost, her mini Pomeranian, is the actual star of the channel. 🐾
!fact 99    →  there are only 12 facts — try !fact 1-12 · https://okrafans.com/info/
```

## The catch: no number is stored anywhere

The page renders an `<ol>` and the **browser** numbers it positionally. So "fact 2" only means anything relative to the page's display order, and the bot has to derive the identical ordering:

```
curated first, by their seeded `order`  →  then submissions, newest-first by `at`
```

That's a verbatim copy of `sortFacts` in the website's `_includes/info.html`. If the two ever drift, **`!fact 3` starts quoting a different fact than the page shows — silently, with no error.** So it's exported as a pure function, documented as a deliberate duplicate, and **unit-tested with 6 cases** precisely so drift surfaces as a test failure rather than as a confused viewer.

## Details

- **Bare `!fact` now reports its number**, making the numbering discoverable from chat without visiting the site.
- **Out of range replies with the valid range** rather than falling back to a random fact — a typo'd number must not look like a successful lookup. The e2e asserts the reply contains no `FUN FACT #` at all in that case.
- The numeric branch matches `/^\d+$/` only, so it can never shadow the existing `suggest` / `pending` / `approve` / `reject` subcommands.
- **Missing `order`/`at` sort as 0** rather than producing `NaN` comparisons — `approveFact` writes no `order`, so real rows genuinely have those gaps. Tested.
- The e2e asserts `!fact 2` returns the same text as position 2 of the shared ordering rather than a hardcoded string, so it stays honest if the curated list changes.

## Worth knowing before this ships

**These numbers are positional, not durable ids.** Editing `CURATED_FACTS` renumbers everything after the edit, and each newly approved submission lands at the end of the curated block, pushing older submissions down. That matches what the page shows at any given moment — which is what was asked for — but "fact 7" in a clip title won't necessarily still be fact 7 next month.

If a stable identifier is wanted later, the fix is to give submissions an `order` at approval time and number by that instead — a bigger change touching both repos.

## Website

`_data/facts.yml` (the offline fallback) was checked and is **already in sync** — 12 facts, all texts identical to `CURATED_FACTS`. No change needed there.

**98 unit · 50 emulator · 29 e2e.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)