### PR TITLE
ci: give Dependabot conventional commit titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot's default PR title is "Bump X from A to B", which the `pr-title` check
+# rejects — merges are squash-only, so that title would become a non-conventional
+# commit on main and release-please would ignore the bump entirely.
+#
+# `fix(deps)` is deliberate, not cosmetic: a dependency bump on this repo is almost
+# always a SECURITY fix, and `fix` cuts a patch release, which builds a new image.
+# Without that the fix sits on main and never reaches the running container.
+# Dev-only bumps use `chore` so they don't cut a release nobody needs.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps-dev)"
+    # One PR per ecosystem-wide bump run instead of one per package — the runtime
+    # deps here are a handful of twurple/firebase trees that move together.
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+
+  # The workflows pin actions by major tag; keep them current too.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
Every open Dependabot PR was failing `pr-title` while **passing `test`**:

```
Bump undici from 6.27.0 to 6.28.0      ✗ not a conventional commit
```

That is a gap I introduced with the `pr-title` check in #32 and did not account for. There was no `.github/dependabot.yml` at all, so Dependabot was running on GitHub defaults with no way to be told otherwise.

## The prefix choice is deliberate

Merges are squash-only, so the PR title becomes the commit on `main` and decides the release:

| Scope | Prefix | Why |
|---|---|---|
| production deps | **`fix(deps)`** | a bump here is almost always a **security** fix — `fix` cuts a patch release, which builds and publishes a new image |
| dev-only deps | `chore(deps-dev)` | no release for something the runtime never sees |
| workflow actions | `ci(deps)` | same |

The `fix` choice matters more than it looks: **anything that does not cut a release leaves the fix sitting on `main` while the running container keeps the vulnerable dependency.** There are 8 open alerts right now, 2 of them HIGH — all in transitive deps (`ip-address`, `undici`, `re2`, `fast-uri`).

Grouped by `dependency-type` so a bump run opens one PR per group rather than one per package; the production tree here is a handful of twurple/firebase deps that move together anyway.

## Two things to know

**This also enables version updates**, not just the security updates Dependabot was already opening on its own. `open-pull-requests-limit: 5` caps the volume, but expect more PRs than before. Say if you would rather have security-only.

**The three open PRs were retitled by hand** — Dependabot config only affects newly opened PRs, so #37/#38/#41 needed fixing directly. They are now `fix(deps): bump …` and should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)