### PR TITLE
fix(deps): omnibus dependency and action bumps (closes 4 alerts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v5
         with:
           node-version: 22

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ghcr.io/nikkibreanne/kennybot

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,7 @@ jobs:
             type=raw,value=${{ inputs.version }}
             type=raw,value=latest
             type=sha
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ inputs.ref }}
       # docker-container driver — required to attach the SBOM/provenance attestations below.
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       packages: write # lets GITHUB_TOKEN push to GHCR — no PAT in CI
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       # docker-container driver — required to attach the SBOM/provenance attestations below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "firebase-admin": "^14.1.0"
       },
       "devDependencies": {
-        "firebase-tools": "^15.22.3"
+        "firebase-tools": "^15.25.1"
       },
       "engines": {
         "node": ">=20"
@@ -90,27 +90,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "^8.2.0"
-      }
-    },
-    "node_modules/@d-fischer/connection/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@d-fischer/deprecate": {
@@ -4544,9 +4523,9 @@
       "license": "MIT"
     },
     "node_modules/firebase-tools": {
-      "version": "15.22.3",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.22.3.tgz",
-      "integrity": "sha512-AsgQnlUMa/9kvGScHvJcizW1+jhZtQXA3aBfogMYDO8vepl74D3U5cRCCAhy5h+TFtbWdmLLIy6cEBzmnXXPwg==",
+      "version": "15.25.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.25.1.tgz",
+      "integrity": "sha512-TcKCgmlHducC3XrzS+FPgGXe2DlDl1Fh2GSN2Vkh71eGGvP7jE/JuEOFcE3osI0TBb1Os6MNTSsGL8mjdZ1IKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4612,11 +4591,12 @@
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.3",
         "triple-beam": "^1.3.0",
+        "undici": "^6.19.0",
         "universal-analytics": "^0.5.3",
         "update-notifier-cjs": "^5.1.6",
         "winston": "^3.0.0",
         "winston-transport": "^4.4.0",
-        "ws": "^7.5.10",
+        "ws": "^8.21.1",
         "yaml": "^2.8.3",
         "zod": "^4.0.0"
       },
@@ -4731,26 +4711,14 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/firebase-tools/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+    "node_modules/firebase-tools/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=18.17"
       }
     },
     "node_modules/fn.name": {
@@ -9638,6 +9606,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,7 +1568,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5798,9 +5797,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@twurple/chat": "^8.1.4",
         "@twurple/eventsub-ws": "^8.1.4",
         "dotenv": "^17.4.2",
-        "firebase-admin": "^14.1.0"
+        "firebase-admin": "^14.2.0"
       },
       "devDependencies": {
         "firebase-tools": "^15.22.3"
@@ -4350,15 +4350,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "node_modules/farmhash-modern": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
-      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -4515,15 +4506,14 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.1.0.tgz",
-      "integrity": "sha512-GdHh6vHWm9LVRt+3hINWczaA7fPwnN/l4xZdqzn+wNPYErrLI1x6u1mvAJM/5IGgYI9EqQgLt1EyBG8ok/hWCg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.2.0.tgz",
+      "integrity": "sha512-zfs5PdccEgjX479bbMmz95Rqc7ttQ4LV3qkGFlPiqOaOu/suBZc3fG52Qzn2hQjiSHkBM4NP2AZV5r2NvAt0TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.1.4",
         "@firebase/database-types": "^1.0.20",
-        "farmhash-modern": "^1.1.0",
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "firebase-admin": "^14.1.0"
   },
   "devDependencies": {
-    "firebase-tools": "^15.22.3"
+    "firebase-tools": "^15.25.1"
   },
   "overrides": {
     "uuid": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@twurple/chat": "^8.1.4",
     "@twurple/eventsub-ws": "^8.1.4",
     "dotenv": "^17.4.2",
-    "firebase-admin": "^14.1.0"
+    "firebase-admin": "^14.2.0"
   },
   "devDependencies": {
     "firebase-tools": "^15.22.3"


### PR DESCRIPTION
Rolls up the eight open Dependabot PRs into one reviewable change.

| | from → to | was |
|---|---|---|
| `firebase-admin` | 14.1.0 → 14.2.0 | #47 |
| `firebase-tools` | 15.22.3 → 15.25.1 | #48 |
| `ip-address` | 10.2.0 → 10.4.0 | #38 |
| `actions/checkout` | 5 → 7 | #44 |
| `actions/setup-node` | 5 → 7 | #46 |
| `docker/login-action` | 3 → 4 | #43 |
| `docker/build-push-action` | 6 → 7 | #45 |
| `docker/metadata-action` | 5 → 6 | #49 |

## #41 is deliberately excluded — it's superseded

`undici 6.27.0 → 6.28.0` is a no-op here. The `firebase-admin` bump already moves root `undici` to **8.10.0**, and the `firebase-tools` bump already brings the nested copy to **6.28.0**. That's exactly why #41 went `DIRTY`.

## Alert status — checked against each advisory's patched version, not assumed

| Alert | Patched at | Now | |
|---|---|---|---|
| `ip-address` **HIGH** ≤10.3.0 | 10.3.1 | 10.4.0 | ✅ closed |
| `ip-address` med ×2 | 10.2.1 / 10.2.2 | 10.4.0 | ✅ closed |
| `undici`, `re2` | — | — | ✅ no longer listed |
| `fast-uri` **HIGH** <4.1.2 | 4.1.2 | **4.1.1** | ❌ still open |
| `@hono/node-server` med <2.0.5 | 2.0.5 | **1.19.14** | ❌ still open |

**The two that remain have no Dependabot PR** because no parent has released anything that pulls them forward — every consumer of `fast-uri` pins ajv's `^3.0.1` line, and `@hono/node-server` would need a major bump inside a transitive tree. They can't be fixed by bumping; they need a parent release.

## Why that's tolerable

**Every package above is reachable only from `firebase-tools`, the single devDependency.** The Dockerfile builds with `npm ci --omit=dev`, so none of them — including both remaining HIGH/medium alerts — exist in the deployed image.

Verified by walking the production dependency graph from `package.json`'s `dependencies` (`@twurple/*`, `dotenv`, `firebase-admin`), not by assuming.

## ⚠️ The action bumps are all MAJOR versions

`checkout` and `setup-node` are exercised by `test` on every PR, so those are genuinely proven.

**The three `docker/*` bumps are not.** They only run in the `docker` job, which fires on release. If one has a breaking change, the first sign will be **a release that cuts a tag and then fails to publish an image** — the exact silent-failure shape this pipeline was designed around. Worth watching the next release rather than trusting green CI here.

`npm ci` is coherent from a clean `node_modules`; **98 unit · 50 emulator · 29 e2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
