### PR TITLE
feat: !timer — a mod-set stream countdown with heads-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 |---|---|---|
 | `!exp on\|off\|auto\|status` | mod | control the EXP gate (`on` bypasses live for testing) |
 | `!mute on\|off\|status` | mod | silence the bot's chat output when it gets noisy; it keeps listening, tracking EXP, and holding the lease — bare `!mute` toggles |
+| `!timer <dur> [label]` | mod | set the stream countdown — `10` (minutes), `90s`, `1h30m`, `5:30`; the words after it are the label |
+| `!timer +5` / `!timer -2m` | mod | add/remove time without restarting the countdown (bare number = minutes) |
+| `!timer pause\|resume\|stop` | mod | freeze / un-freeze / dismiss it |
+| `!timer` | everyone | how long is left. One timer at a time (a new one replaces it); the bot posts heads-ups at 5 min + 1 min, then calls time. Stored as a deadline in `config/timer`, so a restart resumes it |
 | `!drop [itemId]` | mod | force a single loot drop |
 | `!drops on\|off\|every <min>\|status` | mod | auto chat-drop scheduler (rarity-weighted, while live) |
 | `!boss set <name>` / `!boss next` | mod | custom boss / advance to the next scripted season boss |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -40,6 +40,7 @@ so a mod can change them **while the bot is running**. These are the
 | **Chat output mute** — silence sends, keep listening | `!mute on` · `!mute off` · `!mute status` (bare `!mute` toggles) | `config/chatMuted` |
 | **Auto drop scheduler** — on/off + interval | `!drops on` · `!drops off` · `!drops every <min>` · `!drops status` | `config/dropScheduler` |
 | **Clip mode** — which of `!clip`'s outputs run | `!clipmode horizontal vertical twitch` · `!clipmode local\|all\|off` · `!clipmode status` | `config/clipMode` |
+| **Stream timer** — the one mod countdown | `!timer 10m [label]` · `!timer +5` · `!timer -2m` · `!timer pause` / `resume` · `!timer stop` | `config/timer` |
 | **Live status** (set automatically by Twitch) | _(no command — EventSub / Helix poll set it)_ | `config/live` |
 | **Active season** | `!season start <id>` · `!season rollover <id>` | `config/season/current` |
 | **Active raid / boss / phase** | `!boss set <name>` · `!boss next` · `!raidnight` | `config/raid`, `bosses/...` |
@@ -224,6 +225,28 @@ missing.
 > Clip **length** is not configured here, or anywhere in kennyBot — it comes from
 > OBS's Replay Buffer and Aitum's Backtrack settings on the streamer's PC. See
 > [`clip-architecture.md`](clip-architecture.md).
+
+---
+
+## `timer` — the mod stream countdown (`!timer`)
+
+The chat-set countdown for breaks and intermissions ("brb 10", "starting in 5").
+It isn't part of the game: no EXP, no credits, no live gate — a mod can set one
+before going live. There is only ever **one** timer; setting another replaces it.
+
+The countdown is stored as an absolute deadline in RTDB (`config/timer`), so a
+bot restart resumes the same timer instead of losing it. What a restart *does*
+reset is which heads-up marks have already been announced — deliberately, so a
+restart can't make the bot repeat a "1 minute left" it already posted.
+
+| Key | Default | What it controls | Effect of changing it |
+|---|---|---|---|
+| `minMs` | `5000` (5 s) | Shortest timer that can be set. | Below a few seconds a timer is just chat noise. Rarely worth changing. |
+| `maxMs` | `43200000` (12 h) | Longest timer that can be set, and the ceiling `!timer +X` can push one to. | The guard against a typo (`!timer 999`) camping a countdown for weeks. |
+| `warnAtMs` | `[300000, 60000]` (5 min, 1 min) | The heads-up announcements, fired as the clock **crosses** each mark. | Add marks for a chattier countdown (e.g. `[600000, 300000, 60000]`), or set `[]` for a silent timer that only speaks when it's up. A mark is skipped unless the timer had **1.5×** that long left when it was set or last adjusted, so a 5-minute timer never opens with "5 minutes left". |
+| `graceMs` | `120000` (2 min) | How overdue an expired timer may be and still get its "time's up" announced. Past this it's cleared silently. | This only matters when the bot was down at the moment a timer expired. Raise it if you'd rather hear a late call than none; lower it to keep the bot from ever announcing stale news. |
+| `tickMs` | `1000` (1 s) | Countdown resolution. Each tick reads memory only — RTDB is touched just when the timer actually fires. | Higher = a "time's up" that can land that much late. Little reason to change. |
+| `maxLabelLen` | `60` | Longest timer label; longer ones are clipped with `…`. | Keeps a pasted paragraph out of every heads-up line. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ import { seedCatalog } from './src/db/catalog.js';
 import { createMessageHandler } from './src/events/chat.js';
 import { attachTwitchEvents } from './src/events/twitchEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
+import { startTimerScheduler } from './src/events/timerScheduler.js';
 import { processDrops } from './src/db/drops.js';
 
 // Running version, read from the bundled package.json (in the image at /app).
@@ -274,6 +275,10 @@ async function main() {
 
   // Auto chat-drop scheduler (mod-toggled via !drops; fires only while live).
   shutdownHooks.push(startDropScheduler({ send, logger }));
+
+  // Mod timer countdown (`!timer`): heads-up marks + "time's up". Resumes any
+  // timer that was running before a restart from its stored deadline.
+  shutdownHooks.push(startTimerScheduler({ send, logger }));
 
   // ── Live gate: Helix poll (always) + EventSub (when broadcaster auth fits) ──
   const setLiveBound = (live, source) => {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node --watch index.js",
     "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",

--- a/src/commands/mod/timer.js
+++ b/src/commands/mod/timer.js
@@ -1,0 +1,126 @@
+// !timer — the stream countdown ("brb 10", "raid starts in 5m"). ONE timer at a
+// time: setting a new one replaces whatever was running, so there is never a
+// list to address in chat. kennyBot announces the heads-up marks and calls
+// "time's up" itself (src/events/timerScheduler.js).
+//
+// Mixed public/mod (like !fact and !market): it stays `mod:false` so ANYONE can
+// ask how long is left, and every control is gated on isMod inline — a non-mod
+// trying one is ignored, exactly as the dispatcher would.
+//   Public:  !timer                       — how long is left
+//   Mod:     !timer <duration> [label]    — set/replace  (10 · 90s · 45m · 1h30m · 5:30)
+//            !timer +5 | !timer -90s      — add/remove time (bare number = minutes)
+//            !timer pause | resume        — freeze / un-freeze the countdown
+//            !timer stop                  — dismiss it
+import {
+  getTimer, startTimer, addTime, pauseTimer, resumeTimer, clearTimer,
+  takeDuration, parseAdjustment, formatDuration, remainingMs, cleanLabel,
+} from '../../db/timer.js';
+import { config } from '../../config.js';
+
+const SET = ['set', 'start', 'go', 'new'];
+const STOP = ['stop', 'dismiss', 'cancel', 'clear', 'off', 'end', 'done'];
+const PAUSE = ['pause', 'hold', 'freeze'];
+const RESUME = ['resume', 'unpause', 'unfreeze', 'continue'];
+const ADD = ['add', 'plus', 'extend'];
+const SUB = ['sub', 'subtract', 'minus', 'less'];
+
+const USAGE = 'Usage: !timer <10 | 90s | 1h30m> [label] · !timer +5 · !timer -2m · !timer pause | resume | stop';
+
+/** `Break: 4m 12s` / `4m 12s` — the countdown with its label, when it has one. */
+function withLabel(timer, remaining) {
+  const left = formatDuration(remaining);
+  return timer?.label ? `${timer.label}: ${left}` : left;
+}
+
+export default {
+  names: ['timer', 'countdown'],
+  mod: false, // mixed: public status, mod controls (gated inline)
+  cooldownMs: 2_000,
+  help: '!timer — time left on the stream timer · mods: !timer <10m> [label] | +5 | pause | stop',
+  async run({ user, args, reply }) {
+    const isMod = user.isMod || user.isBroadcaster;
+    const sub = (args[0] || '').toLowerCase();
+    const cur = getTimer();
+    const now = Date.now();
+
+    // ── status (public, and the bare-command default) ──
+    if (!sub || sub === 'status' || sub === 'left' || sub === 'time') {
+      if (!cur) {
+        reply(isMod ? 'No timer running. Set one: !timer 10m [label]' : 'No timer running right now.');
+        return;
+      }
+      const left = remainingMs(cur, now);
+      reply(cur.paused
+        ? `⏸️ ${withLabel(cur, left)} left — paused.${isMod ? ' (!timer resume)' : ''}`
+        : `⏳ ${withLabel(cur, left)} left.`);
+      return;
+    }
+
+    if (!isMod) return; // every control below is a mod control — ignore quietly
+
+    // ── +5 / -90s (and the `add` / `subtract` spellings) ──
+    let delta = parseAdjustment(args);
+    if (delta == null && (ADD.includes(sub) || SUB.includes(sub))) {
+      const taken = takeDuration(args.slice(1));
+      if (!taken?.ms) { reply(`Usage: !timer ${SUB.includes(sub) ? '-' : '+'}<minutes>  (e.g. !timer ${SUB.includes(sub) ? '-2' : '+5'})`); return; }
+      delta = SUB.includes(sub) ? -taken.ms : taken.ms;
+    }
+    if (delta != null) {
+      const res = await addTime(delta, now);
+      if (!res.ok) {
+        reply(res.reason === 'none'
+          ? 'No timer running — set one first: !timer 10m [label]'
+          : `That would push it past the ${formatDuration(config.timer.maxMs)} limit.`);
+        return;
+      }
+      const sign = delta > 0 ? '+' : '−';
+      if (res.ended) {
+        // Ran the clock out. A running timer is now due, so the countdown tick
+        // calls "time's up" a moment from now — don't say it twice here.
+        reply(res.timer ? `⏱️ ${sign}${formatDuration(Math.abs(delta))} — that runs it out.` : '⏹️ Timer wound down to zero — cleared.');
+        return;
+      }
+      reply(`⏱️ ${sign}${formatDuration(Math.abs(delta))} — ${withLabel(res.timer, res.remaining)}${res.timer.paused ? ' (paused)' : ' left'}.`);
+      return;
+    }
+
+    // ── stop / pause / resume ──
+    if (STOP.includes(sub)) {
+      const res = await clearTimer(now);
+      reply(res.ok
+        ? `⏹️ Timer dismissed${res.timer.label ? ` — “${res.timer.label}”` : ''} (${formatDuration(res.remaining)} was left).`
+        : 'No timer running.');
+      return;
+    }
+    if (PAUSE.includes(sub)) {
+      const res = await pauseTimer(now);
+      if (!res.ok) { reply(res.reason === 'none' ? 'No timer running.' : `⏸️ Already paused — ${formatDuration(res.remaining)} left. (!timer resume)`); return; }
+      reply(`⏸️ Paused — ${withLabel(res.timer, res.remaining)} on the clock. !timer resume to start it again.`);
+      return;
+    }
+    // A bare `!timer start` / `!timer go` on a paused clock means resume — it's
+    // the natural thing to type, and there's no duration for it to mean instead.
+    if (RESUME.includes(sub) || (SET.includes(sub) && args.length === 1 && cur?.paused)) {
+      const res = await resumeTimer(now);
+      if (!res.ok) { reply(res.reason === 'none' ? 'No timer running — set one: !timer 10m [label]' : `⏳ Already running — ${formatDuration(res.remaining)} left.`); return; }
+      reply(`▶️ Resumed — ${withLabel(res.timer, res.remaining)} left.`);
+      return;
+    }
+
+    // ── set: `!timer 10m Break` or the explicit `!timer set 10m Break` ──
+    const words = SET.includes(sub) ? args.slice(1) : args;
+    const taken = takeDuration(words);
+    if (!taken?.ms) { reply(USAGE); return; }
+
+    const label = cleanLabel(taken.rest.join(' '));
+    const res = await startTimer({ durationMs: taken.ms, label, by: user.displayName, now });
+    if (!res.ok) {
+      reply(res.reason === 'too-short'
+        ? `That's too short — ${formatDuration(config.timer.minMs)} is the minimum.`
+        : `That's too long — ${formatDuration(config.timer.maxMs)} is the maximum.`);
+      return;
+    }
+    const replaced = res.replaced ? ` (replaced the ${formatDuration(remainingMs(res.replaced, now))} one)` : '';
+    reply(`⏳ Timer set — ${withLabel(res.timer, taken.ms)}${replaced}. I'll call it when it's up.`);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -29,8 +29,9 @@ import drops from './mod/drops.js';
 import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
+import timer from './mod/timer.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/config.js
+++ b/src/config.js
@@ -144,6 +144,25 @@ export const config = {
     },
   },
 
+  // ── Mod stream timer (`!timer`) ──────────────────────────────────────────
+  // One shared countdown a mod can set from chat ("brb 10", "raid starts in
+  // 5m"). Not a game system — it announces heads-ups and a "time's up" line and
+  // owns no state beyond config/timer, so a restart resumes it from `endsAt`.
+  timer: {
+    minMs: 5_000, // shortest settable timer (a 1s timer is just noise)
+    maxMs: 12 * 60 * 60 * 1000, // longest — a typo like "!timer 999" can't camp forever
+    // Heads-up announcements, fired as the clock CROSSES each mark (longest
+    // first). A mark is skipped unless the timer had at least 1.5× that long
+    // left when it was set/adjusted, so a 5-minute timer doesn't immediately
+    // shout "5 minutes left".
+    warnAtMs: [5 * 60 * 1000, 60 * 1000],
+    // If the bot was down when a timer expired, announcing "time's up" minutes
+    // late is worse than silence: past this much overdue it's cleared quietly.
+    graceMs: 2 * 60 * 1000,
+    tickMs: 1_000, // countdown resolution (in-memory read; hits RTDB only on fire)
+    maxLabelLen: 60,
+  },
+
   // ── Live gate (spec §5.1) ────────────────────────────────────────────────
   liveGate: {
     pollIntervalMs: 45_000, // Helix poll fallback cadence (30–60s)

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -6,7 +6,7 @@
 import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
 import { config as gameConfig } from '../config.js';
 
-/** @type {{ live: boolean, expMode: string, chatMuted: boolean, season: any, raid: any, dropScheduler: any }} */
+/** @type {{ live: boolean, expMode: string, chatMuted: boolean, season: any, raid: any, dropScheduler: any, timer: any }} */
 const mirror = {
   live: false,
   expMode: gameConfig.liveGate.defaultExpMode,
@@ -22,6 +22,9 @@ const mirror = {
   season: null,
   raid: null, // config/raid: { seasonId, weekId, phase, locksAt, startsAt }
   dropScheduler: { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec },
+  // config/timer: the one mod-set countdown, or null. Read once a second by the
+  // timer scheduler, so it belongs in the mirror rather than an RTDB read loop.
+  timer: null,
 };
 
 let started = false;
@@ -51,6 +54,7 @@ export async function startConfigMirror(logger = console) {
   const seasonRef = db.ref(PATHS.seasonCurrent());
   const raidRef = db.ref(PATHS.configRaid());
   const dropRef = db.ref(PATHS.configDropScheduler());
+  const timerRef = db.ref(PATHS.configTimer());
 
   // Seed drop-scheduler defaults once (never clobber a mod's settings).
   await dropRef.transaction((v) => (v == null ? { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec } : v));
@@ -62,10 +66,12 @@ export async function startConfigMirror(logger = console) {
   seasonRef.on('value', (s) => { mirror.season = s.val(); });
   raidRef.on('value', (s) => { mirror.raid = s.val(); });
   dropRef.on('value', (s) => { if (s.val()) mirror.dropScheduler = s.val(); });
+  timerRef.on('value', (s) => { mirror.timer = s.val() || null; });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap] = await Promise.all([
+  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap] = await Promise.all([
     liveRef.get(), expRef.get(), mutedRef.get(), clipRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
+    timerRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
@@ -74,6 +80,7 @@ export async function startConfigMirror(logger = console) {
   mirror.season = seasonSnap.val();
   mirror.raid = raidSnap.val();
   if (dropSnap.val()) mirror.dropScheduler = dropSnap.val();
+  mirror.timer = timerSnap.val() || null;
   logger.info?.('config mirror warm', {
     live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, clipMode: mirror.clipMode,
   });
@@ -114,6 +121,23 @@ export function getDropScheduler() {
 export async function setDropScheduler(patch) {
   await database().ref(PATHS.configDropScheduler()).update(patch);
   return { ...mirror.dropScheduler, ...patch };
+}
+
+/** The active mod timer record (`!timer`), or null. See src/db/timer.js. */
+export function getTimer() {
+  return mirror.timer;
+}
+
+/**
+ * Replace (or clear, with null) the mod timer. Updates the mirror synchronously
+ * so a follow-up `!timer +5` — or the countdown tick a moment later — sees the
+ * new state without waiting for the RTDB listener to echo it back.
+ */
+export async function setTimerState(timer) {
+  mirror.timer = timer || null;
+  const ref = database().ref(PATHS.configTimer());
+  await (timer ? ref.set(timer) : ref.remove());
+  return mirror.timer;
 }
 
 /**

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -86,6 +86,10 @@ export const PATHS = {
   seasonCurrent: () => 'config/season/current',
   configRaid: () => 'config/raid',
   configDropScheduler: () => 'config/dropScheduler',
+  // MOD TIMER (`!timer`): the single shared countdown. Stored (not just held in
+  // memory) so a restart resumes it from `endsAt` instead of losing it — the
+  // same "never a timer a restart could lose" rule the raid phases follow.
+  configTimer: () => 'config/timer',
   configLock: () => 'config/lock',
   // OKRA FACTS (/info/): approved facts are client-read-only; the submission
   // queue + counter are admin-only.

--- a/src/db/timer.js
+++ b/src/db/timer.js
@@ -1,0 +1,209 @@
+// MOD TIMER (`!timer`) — ONE shared countdown a mod can set from chat ("brb 10",
+// "raid starts in 5m"). Deliberately singular: a second `!timer 5m` replaces the
+// first rather than growing a list nobody can address in chat.
+//
+// The record lives at config/timer and stores an ABSOLUTE `endsAt`, never a
+// live setTimeout, so a restart resumes the same countdown instead of losing it
+// (the rule the raid phases follow — IMPLEMENTATION §H.5). A paused timer drops
+// `endsAt` and keeps a frozen `remainingMs`, which is restart-proof for free.
+//
+// Duration parsing/formatting below is PURE (no clock, no db) so it can be
+// unit-tested offline — see test/rules/timer.test.js.
+
+import { getTimer, setTimerState } from './configStore.js';
+import { config } from '../config.js';
+
+export { getTimer };
+
+const UNIT_MS = {
+  h: 3_600_000, hr: 3_600_000, hrs: 3_600_000, hour: 3_600_000, hours: 3_600_000,
+  m: 60_000, min: 60_000, mins: 60_000, minute: 60_000, minutes: 60_000,
+  s: 1_000, sec: 1_000, secs: 1_000, second: 1_000, seconds: 1_000,
+};
+
+// Longest-first alternation so `1min` reads as "min", never "m" + leftovers.
+const UNITS = Object.keys(UNIT_MS).sort((a, b) => b.length - a.length).join('|');
+const NUMBER = /^\d+(?:\.\d+)?$/;
+const CLOCK = /^\d{1,3}(?::\d{2}){1,2}$/; // mm:ss or hh:mm:ss
+const UNIT_RUN = new RegExp(`^(?:\\d+(?:\\.\\d+)?(?:${UNITS}))+$`);
+const UNIT_PART = new RegExp(`(\\d+(?:\\.\\d+)?)(${UNITS})`, 'g');
+
+/**
+ * Parse ONE duration token to milliseconds, or null if it isn't one.
+ * Accepts `10` (a bare number = MINUTES, the common chat case), `90s`, `45m`,
+ * `2h`, run-ons like `1h30m`, and clock form `5:30` / `1:05:00`.
+ */
+export function parseDurationToken(token) {
+  const t = String(token || '').trim().toLowerCase();
+  if (!t) return null;
+
+  if (CLOCK.test(t)) {
+    const parts = t.split(':').map(Number);
+    const [h, m, s] = parts.length === 3 ? parts : [0, parts[0], parts[1]];
+    if (m > 59 || s > 59) return null; // 5:75 is a typo, not 6:15
+    return ((h * 60 + m) * 60 + s) * 1000;
+  }
+  if (NUMBER.test(t)) return Math.round(parseFloat(t) * 60_000); // bare = minutes
+  if (!UNIT_RUN.test(t)) return null; // reject "5x", "soon", "10m!" — no partial credit
+
+  let ms = 0;
+  for (const [, n, unit] of t.matchAll(UNIT_PART)) ms += parseFloat(n) * UNIT_MS[unit];
+  return Math.round(ms);
+}
+
+/**
+ * Take the leading duration off a token list, returning the total and the tokens
+ * left over (the label). Consumes as many duration tokens as lead — so both
+ * `1h30m Break` and `1h 30m Break` work — and also the spaced `10 min break`
+ * form, where a bare number is followed by a lone unit word.
+ * @returns {{ ms: number, rest: string[] } | null} null when it doesn't start with a duration
+ */
+export function takeDuration(tokens) {
+  const list = Array.isArray(tokens) ? tokens : String(tokens || '').split(/\s+/);
+  let ms = 0;
+  let i = 0;
+  while (i < list.length) {
+    const tok = String(list[i] || '').toLowerCase();
+    const nextUnit = UNIT_MS[String(list[i + 1] || '').toLowerCase()];
+    if (NUMBER.test(tok) && nextUnit) { // "10 min" — number and unit split apart
+      ms += Math.round(parseFloat(tok) * nextUnit);
+      i += 2;
+      continue;
+    }
+    const one = parseDurationToken(tok);
+    if (one == null) break;
+    ms += one;
+    i += 1;
+  }
+  return i ? { ms, rest: list.slice(i) } : null;
+}
+
+/**
+ * Parse a SIGNED adjustment like `+5`, `-90s`, `+1h30m` (bare number = minutes).
+ * @returns {number | null} signed ms, or null if it isn't an adjustment
+ */
+export function parseAdjustment(tokens) {
+  const list = Array.isArray(tokens) ? tokens : String(tokens || '').split(/\s+/);
+  const first = String(list[0] || '');
+  const sign = first.startsWith('-') ? -1 : first.startsWith('+') ? 1 : 0;
+  if (!sign) return null;
+  const taken = takeDuration([first.slice(1), ...list.slice(1)]);
+  if (!taken || !taken.ms) return null;
+  return sign * taken.ms;
+}
+
+/** Human countdown: `1h 05m`, `4m 12s`, `45s`. Rounds to the nearest second. */
+export function formatDuration(ms) {
+  const total = Math.max(0, Math.round(Number(ms) / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h) return m ? `${h}h ${String(m).padStart(2, '0')}m` : `${h}h`;
+  if (m) return s ? `${m}m ${String(s).padStart(2, '0')}s` : `${m}m`;
+  return `${s}s`;
+}
+
+/** Milliseconds left on a timer record (0 when expired/absent; frozen when paused). */
+export function remainingMs(timer, now = Date.now()) {
+  if (!timer) return 0;
+  if (timer.paused) return Math.max(0, timer.remainingMs || 0);
+  return Math.max(0, (timer.endsAt || 0) - now);
+}
+
+/** Trim + clamp a label; empty becomes null (an unlabeled timer is fine). */
+export function cleanLabel(raw) {
+  const text = String(raw || '').replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  return text.length > config.timer.maxLabelLen
+    ? `${text.slice(0, config.timer.maxLabelLen - 1)}…`
+    : text;
+}
+
+/** Build the stored record. `durationMs` is the span as of this set/adjust — the
+ *  heads-up marks use it to skip warnings the timer was never long enough for. */
+function record({ durationMs, label, by, setAt, now }) {
+  return {
+    setAt,
+    label: label || null,
+    by: by || null,
+    durationMs,
+    endsAt: now + durationMs,
+    paused: false,
+    remainingMs: null,
+  };
+}
+
+/**
+ * Start (or replace) the timer.
+ * @returns {Promise<{ok:true,timer:object,replaced:object|null}|{ok:false,reason:'too-short'|'too-long'}>}
+ */
+export async function startTimer({ durationMs, label, by, now = Date.now() }) {
+  const ms = Math.round(Number(durationMs) || 0);
+  if (ms < config.timer.minMs) return { ok: false, reason: 'too-short' };
+  if (ms > config.timer.maxMs) return { ok: false, reason: 'too-long' };
+  const replaced = getTimer();
+  const timer = record({ durationMs: ms, label: cleanLabel(label), by, setAt: now, now });
+  await setTimerState(timer);
+  return { ok: true, timer, replaced: replaced || null };
+}
+
+/**
+ * Add (or subtract) time on the running/paused timer, keeping its identity so
+ * the countdown isn't "restarted". Going to zero or below ENDS it: a running
+ * timer is left due immediately (the scheduler announces it like any expiry), a
+ * paused one is cleared outright since nothing is ticking to notice.
+ * @returns {Promise<{ok:true,timer:object|null,remaining:number,ended:boolean}|{ok:false,reason:'none'|'too-long'}>}
+ */
+export async function addTime(deltaMs, now = Date.now()) {
+  const cur = getTimer();
+  if (!cur) return { ok: false, reason: 'none' };
+
+  const next = remainingMs(cur, now) + Math.round(Number(deltaMs) || 0);
+  if (next > config.timer.maxMs) return { ok: false, reason: 'too-long' };
+
+  if (next <= 0) {
+    if (cur.paused) { // nothing is counting down to fire it — clear it here
+      await setTimerState(null);
+      return { ok: true, timer: null, remaining: 0, ended: true };
+    }
+    const timer = { ...cur, endsAt: now, remainingMs: null, durationMs: 0 };
+    await setTimerState(timer);
+    return { ok: true, timer, remaining: 0, ended: true };
+  }
+
+  const timer = cur.paused
+    ? { ...cur, remainingMs: next, durationMs: next }
+    : { ...cur, endsAt: now + next, durationMs: next };
+  await setTimerState(timer);
+  return { ok: true, timer, remaining: next, ended: false };
+}
+
+/** Freeze the countdown where it stands. */
+export async function pauseTimer(now = Date.now()) {
+  const cur = getTimer();
+  if (!cur) return { ok: false, reason: 'none' };
+  if (cur.paused) return { ok: false, reason: 'already', remaining: remainingMs(cur, now) };
+  const remaining = remainingMs(cur, now);
+  const timer = { ...cur, paused: true, remainingMs: remaining, endsAt: null };
+  await setTimerState(timer);
+  return { ok: true, timer, remaining };
+}
+
+/** Un-freeze: the frozen remainder becomes a fresh deadline. */
+export async function resumeTimer(now = Date.now()) {
+  const cur = getTimer();
+  if (!cur) return { ok: false, reason: 'none' };
+  if (!cur.paused) return { ok: false, reason: 'already', remaining: remainingMs(cur, now) };
+  const remaining = Math.max(0, cur.remainingMs || 0);
+  const timer = { ...cur, paused: false, endsAt: now + remaining, remainingMs: null };
+  await setTimerState(timer);
+  return { ok: true, timer, remaining };
+}
+
+/** Dismiss the timer. Returns what was cleared (for the ack), or ok:false. */
+export async function clearTimer(now = Date.now()) {
+  const cur = getTimer();
+  if (!cur) return { ok: false, reason: 'none' };
+  await setTimerState(null);
+  return { ok: true, timer: cur, remaining: remainingMs(cur, now) };
+}

--- a/src/events/timerScheduler.js
+++ b/src/events/timerScheduler.js
@@ -1,0 +1,78 @@
+// Mod-timer countdown (`!timer`). Ticks once a second against the in-memory
+// config mirror — no RTDB traffic until something actually fires — and does two
+// things: announce the heads-up marks as the clock CROSSES them, and call
+// "time's up" when it runs out (clearing config/timer so the state is gone once
+// it's been announced).
+//
+// "Crossing" is tracked in memory rather than persisted: the first tick that
+// sees a given timer only records where it stands, so a bot restart mid-timer
+// resumes the countdown WITHOUT re-announcing marks it already passed. What a
+// restart must not lose is the deadline itself, and that lives in RTDB.
+//
+// Not gated on live status: a mod setting a pre-stream countdown is the point.
+import { getTimer } from '../db/configStore.js';
+import { clearTimer, remainingMs, formatDuration } from '../db/timer.js';
+import { config } from '../config.js';
+
+/**
+ * @param {{ send: { say: (t: string) => Promise<void> }, logger: any }} deps
+ *   `send` is the mute-aware wrapper — a muted bot stays quiet, and the timer
+ *   still expires and clears on schedule.
+ * @returns {() => void} stop function
+ */
+export function startTimerScheduler({ send, logger }) {
+  // Marks are checked longest-first so a single slow tick can only fire the
+  // nearest one that matters, not a burst of "5 minutes… 1 minute" together.
+  const marks = [...config.timer.warnAtMs].sort((a, b) => b - a);
+  let seen = { id: null, remaining: Infinity };
+  let busy = false;
+
+  async function tick() {
+    if (busy) return; // an expiry write is in flight — don't double-fire it
+    const timer = getTimer();
+    if (!timer) { seen = { id: null, remaining: Infinity }; return; }
+
+    // A paused timer neither counts down nor warns; remember where it froze so
+    // resuming doesn't look like a crossing.
+    if (timer.paused) { seen = { id: timer.setAt, remaining: remainingMs(timer) }; return; }
+
+    const remaining = remainingMs(timer);
+    if (seen.id !== timer.setAt) seen = { id: timer.setAt, remaining }; // first sight: no back-warning
+
+    if (remaining <= 0) {
+      busy = true;
+      const overdue = Date.now() - (timer.endsAt || 0);
+      try {
+        await clearTimer();
+        seen = { id: null, remaining: Infinity };
+        if (overdue <= config.timer.graceMs) {
+          send.say(`⏰ Time's up${timer.label ? ` — ${timer.label}` : ''}!`);
+          logger.info?.('timer fired', { label: timer.label || null, by: timer.by || null });
+        } else {
+          // Expired while the bot was down; shouting about it now is just noise.
+          logger.info?.('stale timer cleared without announcing', { label: timer.label || null, overdueMs: overdue });
+        }
+      } catch (err) {
+        logger.error?.('timer expiry failed', { err: String(err) });
+      } finally {
+        busy = false;
+      }
+      return;
+    }
+
+    for (const mark of marks) {
+      // Skip a mark the timer was never comfortably longer than — a 5-minute
+      // timer shouldn't open with "5 minutes left".
+      if (timer.durationMs < mark * 1.5) continue;
+      if (remaining <= mark && seen.remaining > mark) {
+        send.say(`⏳ ${timer.label ? `${timer.label}: ` : ''}${formatDuration(mark)} left.`);
+        break;
+      }
+    }
+    seen.remaining = remaining;
+  }
+
+  const interval = setInterval(() => { tick().catch(() => {}); }, config.timer.tickMs);
+  interval.unref?.();
+  return () => clearInterval(interval);
+}

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -372,6 +372,30 @@ export const SCENARIOS = [
     },
   },
   {
+    command: 'timer', title: 'mod sets/extends the stream timer; anyone can read it',
+    run: async ({ bot, u }) => {
+      const mod = u('e2e_timer', { login: 'mod', name: 'Mod', mod: true });
+      const viewer = u('e2e_timer_v', { login: 'viewer', name: 'Viewer' });
+      try {
+        assert.match(await bot.send(mod, '!timer 10m Coffee break'), /Timer set — Coffee break: 10m/i);
+        assert.match(await bot.send(mod, '!timer +5'), /\+5m/, 'extends without restarting');
+        // A viewer can ask how long is left…
+        const status = await bot.send(viewer, '!timer');
+        assert.match(status, /Coffee break: 1[45]m/, '~15m left');
+        // …but cannot touch the clock: no reply, and the timer is untouched.
+        assert.equal(await bot.send(viewer, '!timer stop'), '', 'a non-mod control is ignored');
+        assert.ok((await database().ref('config/timer').get()).exists(), 'still running');
+
+        assert.match(await bot.send(mod, '!timer pause'), /Paused/i);
+        assert.match(await bot.send(mod, '!timer resume'), /Resumed/i);
+        assert.match(await bot.send(mod, '!timer stop'), /dismissed/i);
+        assert.equal((await database().ref('config/timer').get()).exists(), false, 'cleared from RTDB');
+      } finally {
+        await bot.send(mod, '!timer stop'); // never leak a timer into the next scenario
+      }
+    },
+  },
+  {
     command: 'season', title: 'mod starts a new season',
     run: async ({ bot, u }) => {
       const reply = await bot.send(u('e2e_season', { login: 'mod', name: 'Mod', mod: true }), '!season start t2');

--- a/test/rules/timer.test.js
+++ b/test/rules/timer.test.js
@@ -1,0 +1,92 @@
+// !timer parsing/formatting — the pure half of src/db/timer.js (no clock, no
+// RTDB). The failures that matter here are silent misreadings: `!timer 10`
+// meaning ten seconds instead of ten minutes, `5:75` becoming a real duration,
+// or a stray word being swallowed as time instead of kept as the label.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseDurationToken, takeDuration, parseAdjustment, formatDuration, remainingMs, cleanLabel,
+} from '../../src/db/timer.js';
+import { config } from '../../src/config.js';
+
+const MIN = 60_000;
+
+test('a bare number is MINUTES — the thing a mod types most', () => {
+  assert.equal(parseDurationToken('10'), 10 * MIN);
+  assert.equal(parseDurationToken('1'), MIN);
+  assert.equal(parseDurationToken('2.5'), 2.5 * MIN);
+});
+
+test('unit forms parse, including run-ons and the long spellings', () => {
+  assert.equal(parseDurationToken('90s'), 90_000);
+  assert.equal(parseDurationToken('45m'), 45 * MIN);
+  assert.equal(parseDurationToken('2h'), 2 * 60 * MIN);
+  assert.equal(parseDurationToken('1h30m'), 90 * MIN);
+  assert.equal(parseDurationToken('30sec'), 30_000);
+  assert.equal(parseDurationToken('5mins'), 5 * MIN);
+  assert.equal(parseDurationToken('2hours'), 120 * MIN);
+  assert.equal(parseDurationToken('1minute'), MIN, 'long spellings must not read as "1m" + junk');
+});
+
+test('clock form parses; an impossible clock is rejected, not rounded', () => {
+  assert.equal(parseDurationToken('5:30'), 5 * MIN + 30_000);
+  assert.equal(parseDurationToken('1:05:00'), 65 * MIN);
+  assert.equal(parseDurationToken('5:75'), null, '75 seconds is a typo, not 6:15');
+});
+
+test('non-durations are rejected outright — no partial credit', () => {
+  for (const bad of ['', '   ', 'soon', '5x', '10m!', 'break', 'm', '-5']) {
+    assert.equal(parseDurationToken(bad), null, `${JSON.stringify(bad)} must not parse`);
+  }
+});
+
+test('takeDuration consumes the leading time and keeps the rest as the label', () => {
+  assert.deepEqual(takeDuration(['10m', 'Coffee', 'break']), { ms: 10 * MIN, rest: ['Coffee', 'break'] });
+  assert.deepEqual(takeDuration(['1h', '30m', 'BRB']), { ms: 90 * MIN, rest: ['BRB'] }, 'split run-on');
+  assert.deepEqual(takeDuration(['10', 'min', 'break']), { ms: 10 * MIN, rest: ['break'] }, 'spaced unit word');
+  assert.deepEqual(takeDuration(['10']), { ms: 10 * MIN, rest: [] });
+  assert.equal(takeDuration(['break', '10m']), null, 'must START with a duration');
+  assert.equal(takeDuration([]), null);
+});
+
+test('a label word that looks time-ish stays a label', () => {
+  // "minute" alone carries no number — swallowing it would eat the label.
+  assert.deepEqual(takeDuration(['5', 'minute', 'warning']), { ms: 5 * MIN, rest: ['warning'] });
+});
+
+test('adjustments are signed; an unsigned or empty one is not an adjustment', () => {
+  assert.equal(parseAdjustment(['+5']), 5 * MIN);
+  assert.equal(parseAdjustment(['-2m']), -2 * MIN);
+  assert.equal(parseAdjustment(['-90s']), -90_000);
+  assert.equal(parseAdjustment(['+1h30m']), 90 * MIN);
+  assert.equal(parseAdjustment(['5']), null, 'unsigned is a SET, not an adjust');
+  assert.equal(parseAdjustment(['+']), null);
+  assert.equal(parseAdjustment(['+soon']), null);
+});
+
+test('formatDuration reads like a countdown', () => {
+  assert.equal(formatDuration(45_000), '45s');
+  assert.equal(formatDuration(4 * MIN + 12_000), '4m 12s');
+  assert.equal(formatDuration(5 * MIN), '5m');
+  assert.equal(formatDuration(65 * MIN), '1h 05m');
+  assert.equal(formatDuration(2 * 60 * MIN), '2h');
+  assert.equal(formatDuration(-1), '0s', 'an expired timer never reads negative');
+  assert.equal(formatDuration(config.timer.maxMs), '12h');
+});
+
+test('remainingMs: running counts down, paused is frozen, missing is zero', () => {
+  const now = 1_000_000;
+  assert.equal(remainingMs({ endsAt: now + 30_000 }, now), 30_000);
+  assert.equal(remainingMs({ endsAt: now - 5_000 }, now), 0, 'never negative');
+  assert.equal(remainingMs({ paused: true, remainingMs: 42_000, endsAt: null }, now), 42_000, 'a paused clock ignores wall time');
+  assert.equal(remainingMs(null, now), 0);
+});
+
+test('labels are collapsed, trimmed, clipped, and empty means none', () => {
+  assert.equal(cleanLabel('  Coffee   break '), 'Coffee break');
+  assert.equal(cleanLabel('   '), null);
+  assert.equal(cleanLabel(undefined), null);
+  const long = cleanLabel('x'.repeat(200));
+  assert.equal(long.length, config.timer.maxLabelLen);
+  assert.ok(long.endsWith('…'));
+});

--- a/test/timer.test.js
+++ b/test/timer.test.js
@@ -1,0 +1,188 @@
+// MOD TIMER (`!timer`) — the stateful half: the config/timer record's lifecycle
+// (set → adjust → pause → resume → clear) and the countdown scheduler that
+// announces it. The pure parsing/formatting half is covered offline in
+// test/rules/timer.test.js. Skipped without the emulator host.
+//
+// The scheduler tests shrink `config.timer` (tick + marks) so a crossing can be
+// observed in milliseconds instead of minutes; the original is restored after.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { setTimerState, getTimer } from '../src/db/configStore.js';
+import { startTimer, addTime, pauseTimer, resumeTimer, clearTimer, remainingMs } from '../src/db/timer.js';
+import { startTimerScheduler } from '../src/events/timerScheduler.js';
+import { config } from '../src/config.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+const silentLogger = { info() {}, warn() {}, error() {}, debug() {} };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Clear through the store (not a raw ref.remove()) so the in-memory mirror the
+// timer functions read stays in step with RTDB.
+async function wipe() { await setTimerState(null); }
+
+/**
+ * Run the scheduler over a pre-planted record and collect what it said.
+ *
+ * The deadline is stamped AFTER the record is written and the scheduler is
+ * running, so RTDB write latency can't eat into the window the test is timing.
+ * Without that, a slow write under load shifts every deadline earlier relative
+ * to the observation window and the expiry gatecrashes a heads-up test — which
+ * is exactly how this suite went flaky once. Every timing below is also given
+ * margin far larger than a tick, so nothing here rides on a millisecond.
+ *
+ * @param {(startedAt:number) => object|null} plant builds the record from the
+ *   instant observation actually begins
+ */
+async function withScheduler(plant, { forMs = 400, marks, tickMs = 25 } = {}) {
+  const said = [];
+  const originalMarks = config.timer.warnAtMs;
+  const originalTick = config.timer.tickMs;
+  if (marks) config.timer.warnAtMs = marks;
+  config.timer.tickMs = tickMs;
+  const stop = startTimerScheduler({ send: { say: (t) => { said.push(t); } }, logger: silentLogger });
+  try {
+    await setTimerState(plant(Date.now())); // deadline stamped as late as possible
+    await sleep(forMs);
+  } finally {
+    stop();
+    config.timer.warnAtMs = originalMarks;
+    config.timer.tickMs = originalTick;
+  }
+  return said;
+}
+
+/**
+ * Just the heads-up lines. The three mark tests below are about WHICH heads-ups
+ * fire, never about whether the timer also ran out — and it can, because a
+ * `sleep(n)` on a busy event loop is a floor, not a ceiling: an overrun that
+ * carries the window past the deadline is what made these flaky. Filtering makes
+ * them depend on the scheduler's logic instead of on the host's timing. Expiry
+ * has its own tests, which can't be polluted in return (a short timer's marks are
+ * skipped by the 1.5x guard — a rule, not a race).
+ */
+const headsUps = (said) => said.filter((line) => line.endsWith('left.'));
+
+/** A running record `ms` from expiry, as if it had been set for `span`. */
+function running(ms, { span = ms, label = null } = {}) {
+  return (from) => ({
+    setAt: from - 1, label, by: 'Mod', durationMs: span, endsAt: from + ms, paused: false, remainingMs: null,
+  });
+}
+
+before(async () => { if (host) initFirebase(); });
+after(async () => { if (host) { await wipe(); await closeFirebase(); } });
+beforeEach(async () => { if (host) await wipe(); });
+
+runOrSkip('timer: set stores an absolute deadline and reports the replaced one', async () => {
+  const first = await startTimer({ durationMs: 10 * 60_000, label: '  Coffee   break ', by: 'Mod' });
+  assert.equal(first.ok, true);
+  assert.equal(first.replaced, null, 'nothing to replace');
+  assert.equal(first.timer.label, 'Coffee break', 'label cleaned');
+  assert.equal(first.timer.paused, false);
+  assert.ok(first.timer.endsAt > Date.now(), 'stores a deadline, not a duration countdown');
+
+  const second = await startTimer({ durationMs: 60_000, by: 'Mod' });
+  assert.equal(second.replaced?.label, 'Coffee break', 'setting a new one replaces the old (only ever one)');
+  assert.equal(second.timer.label, null, 'a label is optional');
+
+  const stored = (await database().ref('config/timer').get()).val();
+  assert.equal(stored.endsAt, second.timer.endsAt, 'persisted so a restart resumes it');
+});
+
+runOrSkip('timer: set refuses the absurd in both directions', async () => {
+  assert.equal((await startTimer({ durationMs: 1_000 })).reason, 'too-short');
+  assert.equal((await startTimer({ durationMs: config.timer.maxMs + 1 })).reason, 'too-long');
+  assert.equal(getTimer(), null, 'a rejected set leaves no timer behind');
+});
+
+runOrSkip('timer: +/- adjusts in place and keeps the timer identity', async () => {
+  const { timer } = await startTimer({ durationMs: 10 * 60_000, label: 'Break', by: 'Mod' });
+  const added = await addTime(5 * 60_000);
+  assert.equal(added.timer.setAt, timer.setAt, 'extending must not restart the countdown');
+  assert.ok(Math.abs(added.remaining - 15 * 60_000) < 2_000, `~15m left, got ${added.remaining}`);
+  assert.equal(added.timer.label, 'Break', 'label survives');
+
+  const removed = await addTime(-14 * 60_000);
+  assert.ok(Math.abs(removed.remaining - 60_000) < 2_000, `~1m left, got ${removed.remaining}`);
+  assert.equal(removed.ended, false);
+
+  assert.equal((await addTime(config.timer.maxMs)).reason, 'too-long', 'the cap holds on adjust too');
+});
+
+runOrSkip('timer: subtracting past zero ends it rather than going negative', async () => {
+  await startTimer({ durationMs: 60_000, by: 'Mod' });
+  const res = await addTime(-5 * 60_000);
+  assert.equal(res.ended, true);
+  assert.equal(remainingMs(res.timer), 0, 'due now — the scheduler announces it like any expiry');
+
+  // A PAUSED timer has nothing ticking to notice, so it's cleared outright.
+  await startTimer({ durationMs: 60_000, by: 'Mod' });
+  await pauseTimer();
+  const paused = await addTime(-5 * 60_000);
+  assert.deepEqual([paused.ended, paused.timer], [true, null]);
+  assert.equal(getTimer(), null, 'cleared, not left frozen at zero');
+});
+
+runOrSkip('timer: pause freezes the clock, resume hands the remainder back', async () => {
+  await startTimer({ durationMs: 60_000, label: 'Break', by: 'Mod' });
+  const paused = await pauseTimer();
+  assert.equal(paused.timer.endsAt, null, 'no deadline while paused — wall time stops mattering');
+  await sleep(120);
+  assert.equal(remainingMs(getTimer()), paused.remaining, 'time passing does not drain a paused timer');
+  assert.equal((await pauseTimer()).reason, 'already');
+
+  const resumed = await resumeTimer();
+  assert.ok(resumed.timer.endsAt > Date.now(), 'a fresh deadline from the frozen remainder');
+  assert.ok(Math.abs(resumed.remaining - paused.remaining) < 2_000);
+  assert.equal((await resumeTimer()).reason, 'already');
+});
+
+runOrSkip('timer: clear reports what it dismissed; clearing nothing is a no-op', async () => {
+  await startTimer({ durationMs: 10 * 60_000, label: 'Break', by: 'Mod' });
+  const cleared = await clearTimer();
+  assert.equal(cleared.timer.label, 'Break');
+  assert.ok(cleared.remaining > 0, 'reports the time that was left');
+  assert.equal((await database().ref('config/timer').get()).exists(), false);
+  assert.equal((await clearTimer()).reason, 'none');
+});
+
+runOrSkip('scheduler: announces time-up exactly once, then clears the record', async () => {
+  const said = await withScheduler(running(120, { label: 'Break' }), { forMs: 400 });
+  assert.deepEqual(said, ["⏰ Time's up — Break!"], 'once, not once per tick');
+  assert.equal(getTimer(), null, 'the record is gone once it has been announced');
+});
+
+runOrSkip('scheduler: a timer that expired while the bot was down is cleared silently', async () => {
+  const stale = running(-(config.timer.graceMs + 60_000));
+  const said = await withScheduler(stale, { forMs: 200 });
+  assert.deepEqual(said, [], 'shouting "time\'s up" long after the fact is noise');
+  assert.equal(getTimer(), null, '…but it must not linger');
+});
+
+runOrSkip('scheduler: heads-up fires as the clock crosses a mark, and only then', async () => {
+  // A 2s timer with the mark at 1s: the crossing lands ~1s in, then ~16 more
+  // ticks pass below the mark — any repeat would show up here.
+  const said = await withScheduler(running(2_000, { label: 'Break' }), { marks: [1_000], forMs: 1_400 });
+  assert.deepEqual(headsUps(said), ['⏳ Break: 1s left.'], 'one heads-up, no repeats while below the mark');
+});
+
+runOrSkip('scheduler: a mark the timer was never long enough for is skipped', async () => {
+  // Span 2s against a 1.5s mark: it would fire almost immediately, which reads as
+  // nonsense ("5 minutes left" on a 5-minute timer). Requires 1.5x headroom.
+  // The window runs well past the mark, so silence means the GUARD held — not
+  // merely that the crossing hadn't come round yet.
+  const said = await withScheduler(running(2_000, { span: 2_000 }), { marks: [1_500], forMs: 900 });
+  assert.deepEqual(headsUps(said), []);
+});
+
+runOrSkip('scheduler: restarting mid-timer does not re-announce a passed mark', async () => {
+  // A timer already BELOW the mark when the scheduler first sees it (exactly the
+  // post-restart case) must not fire a heads-up for a mark it passed while down.
+  // Its span clears the 1.5x guard, so the mark is eligible — only first-sight
+  // suppression keeps it quiet.
+  const said = await withScheduler(running(2_000, { span: 10_000 }), { marks: [3_000], forMs: 600 });
+  assert.deepEqual(headsUps(said), []);
+});


### PR DESCRIPTION
One shared countdown a mod can set from chat ("brb 10", "raid starts in 5m").

```
!timer 10 Coffee break      set it — bare number = minutes; 90s · 45m · 1h30m · 5:30 also
                            work, and the words after the duration become the label
!timer +5   !timer -2m      add/remove time without restarting the countdown
!timer pause | resume       freeze / un-freeze (a bare !timer start also resumes)
!timer stop                 dismiss it
!timer                      PUBLIC — anyone can ask how long is left
```

kennyBot posts a heads-up as the clock crosses 5 min and 1 min, then calls
`⏰ Time's up — Coffee break!`. One timer at a time: a second `!timer` replaces the
first and says what it replaced.

## Design notes

- **Mixed public/mod**, the shape `!fact` and `!market` already use: `mod: false`
  with every control gated on `isMod` inline, so viewers can read the clock but
  not touch it.
- **Restart-safe by construction.** The record stores an absolute deadline in
  `config/timer`, not a live `setTimeout`, so a restart resumes the same
  countdown. Deliberately *not* restored is which heads-up marks already fired —
  a restart must not repeat a "1 minute left" it already posted.
- **No stale news.** A timer that expired while the bot was down is cleared
  silently once it is more than `graceMs` overdue.
- Announcements go through the mute-aware sender. The countdown is **not**
  live-gated — a pre-stream timer is a normal thing to want.

## Tests

- **16 offline** — parsing (`10` is ten *minutes*; `5:75` rejected; a label that
  looks time-ish stays a label), formatting, and the pure state helpers.
- **11 emulator** — record lifecycle plus the scheduler: fires exactly once,
  stale-clears silently, warns only on crossing, no back-warning after a restart.
- **1 e2e** — driven through the real dispatcher.

The scheduler tests assert on heads-up lines specifically rather than the whole
transcript: a `sleep(n)` on a busy event loop is a floor and not a ceiling, so an
overrun carrying the window past the deadline would otherwise make them flaky
(it did, once, before this was fixed).

Docs: README command table, `docs/CONFIG.md` runtime-knobs table and a `timer`
section. The okrafans commands page is updated in a companion PR on that repo.