### PR TITLE
feat: !reminder — scheduled chat nudges with DB-stored schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!timer +5` / `!timer -2m` | mod | add/remove time without restarting the countdown (bare number = minutes) |
 | `!timer pause\|resume\|stop` | mod | freeze / un-freeze / dismiss it |
 | `!timer` | everyone | how long is left. One timer at a time (a new one replaces it); the bot posts heads-ups at 5 min + 1 min, then calls time. Stored as a deadline in `config/timer`, so a restart resumes it |
+| `!reminder` | mod | list the scheduled reminders; `on\|off\|test <id>`, `at <id> <HH:MM…>`, `every\|jitter\|after\|lead <id> <min>`, `text\|leadtext <id> <msg>`, `zone`, `channel` — see below |
 | `!drop [itemId]` | mod | force a single loot drop |
 | `!drops on\|off\|every <min>\|status` | mod | auto chat-drop scheduler (rarity-weighted, while live) |
 | `!boss set <name>` / `!boss next` | mod | custom boss / advance to the next scripted season boss |
@@ -154,6 +155,30 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 \* Viewing raid status is open to everyone, but **mustering** (signing up with
 `!muster`) needs an active sub — same as `!create` and `!grab`. A lapsed sub keeps
 the hero they built and keeps earning EXP, but must re-sub to muster.
+
+### Scheduled reminders
+
+kennyBot posts recurring nudges on three schedule shapes. Every schedule is a
+**record in RTDB** (`config/reminders/<id>`), not a rule in code — a mod re-times
+one from chat with `!reminder` and it takes effect on the next tick.
+
+| id | Schedule | What it does |
+|---|---|---|
+| `wallpaper` | 30 min after going live, once per stream | "is Wallpaper Engine still running?" |
+| `ghosty` | daily 08:00 + 17:00 Pacific, 20-min heads-up | Ghosty's meal times |
+| `hydration` | every 60 min of live time, ±10 min jitter | drink some water |
+
+A reminder carries a `channel`: it fires **only** on that Twitch channel, and
+`channel: null` fires wherever the bot runs (that's hydration). So "this one is a
+Nikki thing" is a property of the data — there's no per-channel branch anywhere
+in the code, and `!reminder channel <id> <name|any>` re-points one from chat.
+
+All three are **live-gated** by default. A daily slot missed while offline is
+skipped rather than announced hours late, an `afterLive` reminder fires once per
+live session (a bot restart mid-stream doesn't repeat it), and an interval that
+came due during a long offline stretch is quietly re-armed instead of dumping a
+backlog. The defaults are seeded from `src/content/reminders.js` on first boot
+and **never** clobbered afterwards, so edited times survive every deploy.
 
 Mustering writes a snapshot of your hero onto the season roster. When a new boss
 is scheduled in the same season, participating adventurers roll forward into that

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,6 +41,7 @@ so a mod can change them **while the bot is running**. These are the
 | **Auto drop scheduler** — on/off + interval | `!drops on` · `!drops off` · `!drops every <min>` · `!drops status` | `config/dropScheduler` |
 | **Clip mode** — which of `!clip`'s outputs run | `!clipmode horizontal vertical twitch` · `!clipmode local\|all\|off` · `!clipmode status` | `config/clipMode` |
 | **Stream timer** — the one mod countdown | `!timer 10m [label]` · `!timer +5` · `!timer -2m` · `!timer pause` / `resume` · `!timer stop` | `config/timer` |
+| **Reminders** — schedules, text, on/off | `!reminder` · `!reminder at ghosty 08:00 17:00` · `!reminder every hydration 60` · `!reminder off <id>` | `config/reminders/<id>` |
 | **Live status** (set automatically by Twitch) | _(no command — EventSub / Helix poll set it)_ | `config/live` |
 | **Active season** | `!season start <id>` · `!season rollover <id>` | `config/season/current` |
 | **Active raid / boss / phase** | `!boss set <name>` · `!boss next` · `!raidnight` | `config/raid`, `bosses/...` |
@@ -225,6 +226,45 @@ missing.
 > Clip **length** is not configured here, or anywhere in kennyBot — it comes from
 > OBS's Replay Buffer and Aitum's Backtrack settings on the streamer's PC. See
 > [`clip-architecture.md`](clip-architecture.md).
+
+---
+
+## `reminders` — scheduled chat nudges (`!reminder`)
+
+The recurring pings: the Wallpaper Engine check, Ghosty's meal times, the hourly
+hydration nudge. **The schedules are not in this file.** Each reminder is a
+record in RTDB at `config/reminders/<id>`, seeded once from
+[`src/content/reminders.js`](../src/content/reminders.js) and edited from chat
+with `!reminder` — so re-timing Ghosty's dinner never needs a deploy, and a time
+you changed is **never** overwritten by a later release.
+
+The settings below are only the engine-wide bounds that apply to every reminder.
+
+| Key | Default | What it controls | Effect of changing it |
+|---|---|---|---|
+| `tickMs` | `20000` (20 s) | How often schedules are checked. | A daily slot can land up to this late. Minute-accuracy is all these need; lower only burns CPU. |
+| `dailyGraceMs` | `300000` (5 min) | How long after its wall-clock time a daily slot may still fire. Past it, the slot is skipped. | This is what stops a bot that boots at noon from announcing the 08:00 meal. Raise it if you'd rather have a slightly late ping than none; a per-reminder `graceMs` overrides it. |
+| `afterLiveWindowMs` | `7200000` (2 h) | How late an "N minutes after going live" reminder may still be announced. Past it the session is marked handled and nothing is said. | Only matters when the bot boots hours into a stream. |
+| `defaultTimeZone` | `'America/Los_Angeles'` | The zone a daily reminder uses when it names none of its own. | Per-reminder `timeZone` (set with `!reminder zone <id> <IANA>`) always wins. |
+| `maxTextLen` | `200` | Longest message text accepted from chat; longer is clipped with `…`. | Keeps a pasted paragraph out of a recurring announcement. |
+
+### The reminder record
+
+One of three `kind`s. Fields not used by a kind are simply ignored.
+
+| Field | Applies to | Meaning |
+|---|---|---|
+| `id` | all | Short name mods type: `!reminder off ghosty`. |
+| `enabled` | all | `false` makes it inert without deleting it (`!reminder on\|off <id>`). |
+| `channel` | all | Fires **only** on this Twitch channel. `null` = any channel the bot runs in. This is what makes a reminder channel-specific — there is no per-channel code. |
+| `liveOnly` | all | Default `true`: nothing is announced while the channel is offline. |
+| `text` | all | What it says. |
+| `afterMs` | `afterLive` | How long into a live session it fires. Once per session. |
+| `times` / `timeZone` | `daily` | Wall-clock `HH:MM` times in an IANA zone (DST-aware — 08:00 stays 08:00 across the change). |
+| `leadMs` / `leadText` | `daily` | An optional heads-up this long before each slot. `0` disables it; without `leadText` the wording is generated. |
+| `graceMs` | `daily` | Per-reminder override of `dailyGraceMs`. |
+| `everyMs` / `jitterMs` | `interval` | Period of **live** time between pings, ± the jitter (jitter is capped at half the period). |
+| `state` | all | Bot-managed: what has already fired. Persisted so a restart can't repeat an announcement. Don't hand-edit. |
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ import { createMessageHandler } from './src/events/chat.js';
 import { attachTwitchEvents } from './src/events/twitchEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
 import { startTimerScheduler } from './src/events/timerScheduler.js';
+import { startReminderScheduler } from './src/events/reminderScheduler.js';
+import { seedReminders } from './src/db/reminders.js';
 import { processDrops } from './src/db/drops.js';
 
 // Running version, read from the bundled package.json (in the image at /app).
@@ -162,6 +164,16 @@ async function main() {
     logger.warn('item catalog seed failed (non-fatal)', { err: String(err) });
   }
 
+  // ── Seed the default reminders (config/reminders). Creates only what's
+  //    MISSING — an id that already exists keeps whatever the mods set, so
+  //    edited times and text survive every deploy. Non-fatal like the seeds above. ──
+  try {
+    const rem = await seedReminders();
+    logger.info('reminders seeded', rem);
+  } catch (err) {
+    logger.warn('reminder seed failed (non-fatal)', { err: String(err) });
+  }
+
   // ── Twitch auth (persisted refresh token) ──
   const tokenStore = new TokenStore(process.env.TOKEN_STORE_DIR || './.tokens');
   const { authProvider, addRole } = await buildAuth({
@@ -279,6 +291,11 @@ async function main() {
   // Mod timer countdown (`!timer`): heads-up marks + "time's up". Resumes any
   // timer that was running before a restart from its stored deadline.
   shutdownHooks.push(startTimerScheduler({ send, logger }));
+
+  // Scheduled reminders (`!reminder`). Schedules are data in config/reminders,
+  // so this only supplies the clock and the channel — which is also what makes a
+  // reminder channel-specific without any per-channel branch in the code.
+  shutdownHooks.push(startReminderScheduler({ send, channel, logger }));
 
   // ── Live gate: Helix poll (always) + EventSub (when broadcaster auth fits) ──
   const setLiveBound = (live, source) => {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node --watch index.js",
     "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",

--- a/src/commands/mod/reminder.js
+++ b/src/commands/mod/reminder.js
@@ -1,0 +1,157 @@
+// !reminder (mod) — the scheduled chat nudges: the Wallpaper Engine check,
+// Ghosty's meals, the hourly hydration ping. Every schedule is a record in RTDB
+// (config/reminders/<id>), so all of this edits data — nothing here is baked
+// into a release, and a change takes effect on the next tick.
+//   !reminder                          — list them all, with what fires when
+//   !reminder on|off <id>              — enable / disable one
+//   !reminder test <id>                — say it right now (ignores every gate)
+//   !reminder at <id> <HH:MM…>         — daily times     (e.g. !reminder at ghosty 08:00 17:00)
+//   !reminder lead <id> <min>          — daily heads-up lead (0 = none)
+//   !reminder every <id> <min>         — interval period
+//   !reminder jitter <id> <min>        — interval wobble (±)
+//   !reminder after <id> <min>         — afterLive delay
+//   !reminder zone <id> <IANA>         — daily time zone
+//   !reminder text|leadtext <id> <msg> — what it says
+//   !reminder channel <id> <name|any>  — which channel it belongs to
+import {
+  listReminders, getReminder, editReminder, cleanText, isValidTimeZone,
+} from '../../db/reminders.js';
+import { describeSchedule } from '../../rules/reminders.js';
+
+const USAGE = 'Usage: !reminder · on|off|test <id> · at <id> <HH:MM…> · every|jitter|after|lead <id> <min> · text|leadtext <id> <msg> · zone <id> <IANA> · channel <id> <name|any>';
+
+/** Minutes → ms from a chat argument, or null when it isn't a sane number. */
+function minutesArg(raw) {
+  const min = Number(raw);
+  if (!Number.isFinite(min) || min < 0 || min > 24 * 60) return null;
+  return Math.round(min * 60_000);
+}
+
+/** `✅ ghosty — daily 08:00, 17:00 Los Angeles +20m heads-up · while live · #nikkibreanne` */
+function summarize(reminder) {
+  const scope = reminder.channel ? ` · #${reminder.channel}` : '';
+  const live = reminder.liveOnly === false ? ' · always' : ' · while live';
+  return `${reminder.enabled === false ? '⏸️' : '✅'} ${reminder.id} — ${describeSchedule(reminder)}${live}${scope}`;
+}
+
+// Twitch drops anything past ~500 characters, so a long list is trimmed here
+// rather than silently losing its tail mid-word.
+const LIST_BUDGET = 440;
+
+/** Join as many summaries as fit, noting how many were left out. */
+function listLine(reminders) {
+  const kept = [];
+  let used = 0;
+  for (const line of reminders.map(summarize)) {
+    if (used + line.length > LIST_BUDGET && kept.length) break;
+    kept.push(line);
+    used += line.length + 5;
+  }
+  const extra = reminders.length - kept.length;
+  return `⏰ ${kept.join('  ·  ')}${extra > 0 ? `  ·  (+${extra} more)` : ''}`;
+}
+
+export default {
+  names: ['reminder', 'reminders'],
+  mod: true,
+  cooldownMs: 2_000,
+  help: '!reminder — list/edit the scheduled reminders (times, text, on/off)',
+  async run({ user, args, reply }) {
+    const sub = (args[0] || 'list').toLowerCase();
+
+    // ── list ──
+    if (sub === 'list' || sub === 'status') {
+      const all = listReminders();
+      if (!all.length) { reply('No reminders configured.'); return; }
+      reply(listLine(all));
+      return;
+    }
+
+    const id = String(args[1] || '').toLowerCase();
+    if (!id) { reply(USAGE); return; }
+    const reminder = getReminder(id);
+    if (!reminder) {
+      reply(`No reminder called “${id}”. Known: ${listReminders().map((r) => r.id).join(', ') || '(none)'}`);
+      return;
+    }
+    const rest = args.slice(2).join(' ').trim();
+
+    // ── test: say it now, whatever the schedule and gates would decide ──
+    if (sub === 'test' || sub === 'fire') {
+      reply(reminder.text || `(reminder “${id}” has no text)`);
+      return;
+    }
+
+    // ── on / off ──
+    if (sub === 'on' || sub === 'off' || sub === 'enable' || sub === 'disable') {
+      const enabled = sub === 'on' || sub === 'enable';
+      const res = await editReminder(id, { enabled });
+      if (!res.ok) { reply(`Couldn't update ${id} (${res.reason}).`); return; }
+      reply(`${enabled ? '✅' : '⏸️'} ${id} ${enabled ? 'on' : 'off'} — ${describeSchedule(res.reminder)}.`);
+      return;
+    }
+
+    // ── daily times ──
+    if (sub === 'at' || sub === 'times') {
+      const times = args.slice(2).map((t) => t.replace(/,$/, ''));
+      if (!times.length) { reply(`Usage: !reminder at ${id} 08:00 17:00`); return; }
+      const res = await editReminder(id, { times });
+      if (!res.ok) {
+        reply(res.reason.startsWith('bad-time')
+          ? `“${res.reason.split(':').slice(1).join(':')}” isn't a time — use 24-hour HH:MM (e.g. 08:00 17:00).`
+          : `Couldn't update ${id} (${res.reason}).`);
+        return;
+      }
+      reply(`⏰ ${id} — ${describeSchedule(res.reminder)}.`);
+      return;
+    }
+
+    // ── numeric knobs, all in minutes ──
+    const MINUTE_KEYS = { lead: 'leadMs', every: 'everyMs', jitter: 'jitterMs', after: 'afterMs' };
+    if (MINUTE_KEYS[sub]) {
+      const ms = minutesArg(args[2]);
+      if (ms == null) { reply(`Usage: !reminder ${sub} ${id} <minutes>`); return; }
+      const res = await editReminder(id, { [MINUTE_KEYS[sub]]: ms });
+      if (!res.ok) {
+        reply(res.reason === 'too-often'
+          ? 'That would fire more than once a minute — pick 1 minute or more.'
+          : `Couldn't update ${id} (${res.reason}).`);
+        return;
+      }
+      reply(`⏰ ${id} — ${describeSchedule(res.reminder)}.`);
+      return;
+    }
+
+    // ── message text ──
+    if (sub === 'text' || sub === 'say' || sub === 'leadtext') {
+      const text = cleanText(rest);
+      if (!text) { reply(`Usage: !reminder ${sub} ${id} <what it should say>`); return; }
+      const res = await editReminder(id, sub === 'leadtext' ? { leadText: text } : { text });
+      if (!res.ok) { reply(`Couldn't update ${id} (${res.reason}).`); return; }
+      reply(`📝 ${id} ${sub === 'leadtext' ? 'heads-up' : 'message'} updated → ${text}`);
+      return;
+    }
+
+    // ── time zone ──
+    if (sub === 'zone' || sub === 'tz') {
+      if (!rest) { reply(`Usage: !reminder zone ${id} America/Los_Angeles`); return; }
+      if (!isValidTimeZone(rest)) { reply(`“${rest}” isn't a time zone I know — use an IANA name like America/Los_Angeles.`); return; }
+      const res = await editReminder(id, { timeZone: rest });
+      if (!res.ok) { reply(`Couldn't update ${id} (${res.reason}).`); return; }
+      reply(`🌍 ${id} — ${describeSchedule(res.reminder)}.`);
+      return;
+    }
+
+    // ── which channel it belongs to ──
+    if (sub === 'channel') {
+      if (!rest) { reply(`Usage: !reminder channel ${id} <channel|any>`); return; }
+      const any = ['any', 'all', 'none', '*'].includes(rest.toLowerCase());
+      const res = await editReminder(id, { channel: any ? null : rest });
+      if (!res.ok) { reply(`Couldn't update ${id} (${res.reason}).`); return; }
+      reply(`📺 ${id} → ${res.reminder.channel ? `#${res.reminder.channel} only` : 'any channel'}.`);
+      return;
+    }
+
+    reply(`@${user.displayName} ${USAGE}`);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -30,8 +30,9 @@ import boss from './mod/boss.js';
 import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 import timer from './mod/timer.js';
+import reminder from './mod/reminder.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/config.js
+++ b/src/config.js
@@ -163,6 +163,22 @@ export const config = {
     maxLabelLen: 60,
   },
 
+  // ── Reminders (`!reminder`) ──────────────────────────────────────────────
+  // Scheduled chat nudges — the wallpaper check, Ghosty's meals, hydration. The
+  // SCHEDULES are data in RTDB (config/reminders/<id>, seeded from
+  // src/content/reminders.js); these are only the engine-wide bounds.
+  reminders: {
+    tickMs: 20_000, // how often schedules are evaluated — minute-accurate is plenty
+    // A daily slot only fires within this long after its wall-clock time, so a
+    // bot that boots at noon never announces the 08:00 one.
+    dailyGraceMs: 5 * 60_000,
+    // How late an `afterLive` reminder may still be announced. Past this the
+    // session is marked handled and nothing is said (the bot booted mid-stream).
+    afterLiveWindowMs: 2 * 60 * 60_000,
+    defaultTimeZone: 'America/Los_Angeles', // when a daily reminder names none
+    maxTextLen: 200,
+  },
+
   // ── Live gate (spec §5.1) ────────────────────────────────────────────────
   liveGate: {
     pollIntervalMs: 45_000, // Helix poll fallback cadence (30–60s)

--- a/src/content/reminders.js
+++ b/src/content/reminders.js
@@ -1,0 +1,46 @@
+// DEFAULT REMINDERS — the seed for config/reminders/<id>. Seeded once, never
+// clobbered (src/db/reminders.js), so anything a mod changes from chat or in the
+// console survives every deploy. Editing a default here only affects a database
+// that has never seen that id.
+//
+// `channel` is what makes a reminder channel-specific: it fires only on that
+// Twitch channel, and `channel: null` fires on whichever channel the bot runs
+// in. That keeps "this one is a Nikki thing" a property of the data — no
+// per-channel branch anywhere in the code.
+//
+// Schedule shapes are documented in src/rules/reminders.js; the knobs each kind
+// reads are in docs/CONFIG.md.
+
+export const DEFAULT_REMINDERS = [
+  {
+    id: 'wallpaper',
+    enabled: true,
+    channel: 'nikkibreanne',
+    kind: 'afterLive',
+    liveOnly: true,
+    afterMs: 30 * 60_000, // half an hour into the stream
+    text: '🖥️ Wallpaper Engine check — is it still running? Shut it down if you are done with it.',
+  },
+  {
+    id: 'ghosty',
+    enabled: true,
+    channel: 'nikkibreanne',
+    kind: 'daily',
+    liveOnly: true, // no point announcing Ghosty's dinner to an empty channel
+    timeZone: 'America/Los_Angeles',
+    times: ['08:00', '17:00'],
+    leadMs: 20 * 60_000, // heads-up at 07:40 / 16:40
+    text: '🐾 Ghosty meal time! Go feed the beast.',
+    leadText: '🐾 Heads up — Ghosty eats in 20 minutes.',
+  },
+  {
+    id: 'hydration',
+    enabled: true,
+    channel: null, // every channel, not just Nikki's
+    kind: 'interval',
+    liveOnly: true,
+    everyMs: 60 * 60_000,
+    jitterMs: 10 * 60_000, // ±10 min so it never lands on the same beat twice
+    text: '💧 Hydration check — go drink some water. Chat, you too. 🌱',
+  },
+];

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -6,9 +6,12 @@
 import { database, PATHS, SERVER_TIMESTAMP } from './firebase.js';
 import { config as gameConfig } from '../config.js';
 
-/** @type {{ live: boolean, expMode: string, chatMuted: boolean, season: any, raid: any, dropScheduler: any, timer: any }} */
+/** @type {{ live: boolean, liveSince: number|null, expMode: string, chatMuted: boolean, season: any, raid: any, dropScheduler: any, timer: any, reminders: any }} */
 const mirror = {
   live: false,
+  // When the current live session began (null when offline). Stamped by setLive
+  // on the OFF→ON edge only, so a restart mid-stream keeps the original start.
+  liveSince: null,
   expMode: gameConfig.liveGate.defaultExpMode,
   // Mod kill-switch for OUTBOUND chat (`!mute`). When true the bot stays fully
   // connected — listening, granting EXP, processing drops, holding the lease —
@@ -25,6 +28,9 @@ const mirror = {
   // config/timer: the one mod-set countdown, or null. Read once a second by the
   // timer scheduler, so it belongs in the mirror rather than an RTDB read loop.
   timer: null,
+  // config/reminders: id → scheduled-nudge record. Evaluated on every reminder
+  // tick, so it's mirrored rather than re-read.
+  reminders: {},
 };
 
 let started = false;
@@ -55,6 +61,8 @@ export async function startConfigMirror(logger = console) {
   const raidRef = db.ref(PATHS.configRaid());
   const dropRef = db.ref(PATHS.configDropScheduler());
   const timerRef = db.ref(PATHS.configTimer());
+  const liveSinceRef = db.ref(PATHS.configLiveSince());
+  const remindersRef = db.ref(PATHS.reminders());
 
   // Seed drop-scheduler defaults once (never clobber a mod's settings).
   await dropRef.transaction((v) => (v == null ? { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec } : v));
@@ -67,11 +75,13 @@ export async function startConfigMirror(logger = console) {
   raidRef.on('value', (s) => { mirror.raid = s.val(); });
   dropRef.on('value', (s) => { if (s.val()) mirror.dropScheduler = s.val(); });
   timerRef.on('value', (s) => { mirror.timer = s.val() || null; });
+  liveSinceRef.on('value', (s) => { mirror.liveSince = s.val() || null; });
+  remindersRef.on('value', (s) => { mirror.reminders = s.val() || {}; });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap] = await Promise.all([
+  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap, liveSinceSnap, remindersSnap] = await Promise.all([
     liveRef.get(), expRef.get(), mutedRef.get(), clipRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
-    timerRef.get(),
+    timerRef.get(), liveSinceRef.get(), remindersRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
@@ -81,6 +91,8 @@ export async function startConfigMirror(logger = console) {
   mirror.raid = raidSnap.val();
   if (dropSnap.val()) mirror.dropScheduler = dropSnap.val();
   mirror.timer = timerSnap.val() || null;
+  mirror.liveSince = liveSinceSnap.val() || null;
+  mirror.reminders = remindersSnap.val() || {};
   logger.info?.('config mirror warm', {
     live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, clipMode: mirror.clipMode,
   });
@@ -95,6 +107,15 @@ export function getConfig() {
     clipMode: mirror.clipMode,
     season: mirror.season,
   };
+}
+
+/**
+ * When the current live session started (ms epoch), or null when offline.
+ * Stamped on the OFF→ON edge only — a bot restart mid-stream sees no edge, so
+ * the original start survives and "30 minutes after going live" stays honest.
+ */
+export function getLiveSince() {
+  return mirror.liveSince;
 }
 
 /** True when a mod has muted the bot's outbound chat (`!mute`). Hot-path read. */
@@ -140,6 +161,32 @@ export async function setTimerState(timer) {
   return mirror.timer;
 }
 
+/** All reminder records as `{ id: record }` (see src/db/reminders.js). */
+export function getReminders() {
+  return mirror.reminders || {};
+}
+
+/**
+ * Merge a patch into one reminder (persisted + mirrored synchronously, so a mod
+ * running `!reminder off ghosty` then `!reminder` reads their own write). Passing
+ * a null VALUE for a key removes it, per RTDB update semantics.
+ */
+export async function patchReminder(id, patch) {
+  const merged = { ...(mirror.reminders?.[id] || {}), ...patch, id };
+  for (const [k, v] of Object.entries(patch)) if (v === null) delete merged[k];
+  mirror.reminders = { ...(mirror.reminders || {}), [id]: merged };
+  await database().ref(PATHS.reminder(id)).update({ ...patch, id });
+  return merged;
+}
+
+/** Replace a reminder's bot-managed firing state (what has already gone out). */
+export async function setReminderState(id, state) {
+  const cur = mirror.reminders?.[id];
+  if (cur) mirror.reminders = { ...mirror.reminders, [id]: { ...cur, state } };
+  await database().ref(PATHS.reminderState(id)).set(state || null);
+  return state;
+}
+
 /**
  * Patch the config/raid pointer (active-raid + phase + schedule). The website's
  * muster/live pages key off this (UI contract).
@@ -157,8 +204,17 @@ export async function setRaidPointer(patch) {
 export async function setLive(value, source = 'unknown', logger = console) {
   const next = Boolean(value);
   if (mirror.live === next) return false;
-  await database().ref(PATHS.configLive()).set(next);
-  logger.info?.('live status changed', { live: next, source });
+  // Stamp the session start on the same write as the flag, so "N minutes after
+  // going live" can never read a live channel with no start time. Written only
+  // on an EDGE: a restart while already live leaves the original stamp alone.
+  const startedAt = next ? Date.now() : null;
+  mirror.live = next;
+  mirror.liveSince = startedAt;
+  await database().ref().update({
+    [PATHS.configLive()]: next,
+    [PATHS.configLiveSince()]: startedAt, // null removes it (offline)
+  });
+  logger.info?.('live status changed', { live: next, source, startedAt });
   return true;
 }
 

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -80,6 +80,10 @@ export async function closeFirebase() {
  */
 export const PATHS = {
   configLive: () => 'config/live',
+  // When the CURRENT live session started (null when offline). Reminders that
+  // count from "going live" need this, and persisting it is what stops a bot
+  // restart mid-stream from re-running them.
+  configLiveSince: () => 'config/liveSince',
   configExpMode: () => 'config/expMode',
   configChatMuted: () => 'config/chatMuted',
   configClipMode: () => 'config/clipMode',
@@ -90,6 +94,13 @@ export const PATHS = {
   // memory) so a restart resumes it from `endsAt` instead of losing it — the
   // same "never a timer a restart could lose" rule the raid phases follow.
   configTimer: () => 'config/timer',
+  // REMINDERS (`!reminder`): scheduled chat nudges. Schedules are DATA here, not
+  // code — seeded from src/content/reminders.js and editable from chat. Each
+  // record's `state` (what has already fired) lives under it so firing stays
+  // idempotent across restarts.
+  reminders: () => 'config/reminders',
+  reminder: (id) => `config/reminders/${id}`,
+  reminderState: (id) => `config/reminders/${id}/state`,
   configLock: () => 'config/lock',
   // OKRA FACTS (/info/): approved facts are client-read-only; the submission
   // queue + counter are admin-only.

--- a/src/db/reminders.js
+++ b/src/db/reminders.js
@@ -1,0 +1,97 @@
+// REMINDERS persistence. The schedules themselves are DATA at
+// config/reminders/<id> — seeded once from src/content/reminders.js and edited
+// from chat with `!reminder` — so changing when Ghosty eats never needs a
+// deploy. The decision of what's due is pure and lives in src/rules/reminders.js.
+//
+// Seeding is idempotent and NEVER clobbers: a record that already exists is left
+// exactly as the mods left it, the same contract the fact and item-catalog seeds
+// follow. That's what makes an edited time survive the next release.
+
+import { database, PATHS } from './firebase.js';
+import { getReminders, patchReminder, setReminderState } from './configStore.js';
+import { DEFAULT_REMINDERS } from '../content/reminders.js';
+import { parseClock, normalizeChannel } from '../rules/reminders.js';
+import { config } from '../config.js';
+
+export { getReminders, patchReminder, setReminderState };
+
+/**
+ * Create any missing default reminder. Existing ids are untouched.
+ * @returns {Promise<{seeded: string[], kept: string[]}>}
+ */
+export async function seedReminders(defaults = DEFAULT_REMINDERS) {
+  const seeded = [];
+  const kept = [];
+  for (const def of defaults) {
+    // Returning undefined ABORTS the transaction — the existing record isn't
+    // even rewritten, so a mod's edited times can't be lost to a race here.
+    const res = await database().ref(PATHS.reminder(def.id)).transaction((cur) => (cur == null ? def : undefined));
+    (res.committed ? seeded : kept).push(def.id);
+  }
+  return { seeded, kept };
+}
+
+/** One reminder by id (from the mirror), or undefined. */
+export function getReminder(id) {
+  return getReminders()[id];
+}
+
+/** Reminder records as a stable, id-sorted list — the order `!reminder` prints. */
+export function listReminders() {
+  return Object.entries(getReminders())
+    .filter(([, r]) => r && typeof r === 'object')
+    .map(([id, r]) => ({ ...r, id: r.id || id }))
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+}
+
+/** Collapse whitespace and clip an announcement to something chat-sized. */
+export function cleanText(raw) {
+  const text = String(raw || '').replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  return text.length > config.reminders.maxTextLen
+    ? `${text.slice(0, config.reminders.maxTextLen - 1)}…`
+    : text;
+}
+
+/**
+ * Validate + apply a schedule edit from chat. Returns the reason a change was
+ * refused rather than writing something the scheduler would silently ignore.
+ * @param {string} id
+ * @param {{times?: string[], leadMs?: number, everyMs?: number, jitterMs?: number,
+ *          afterMs?: number, text?: string, leadText?: string, enabled?: boolean,
+ *          channel?: string|null, timeZone?: string}} patch
+ * @returns {Promise<{ok:true,reminder:object}|{ok:false,reason:string}>}
+ */
+export async function editReminder(id, patch) {
+  const cur = getReminder(id);
+  if (!cur) return { ok: false, reason: 'unknown' };
+
+  if (patch.times) {
+    if (!patch.times.length) return { ok: false, reason: 'no-times' };
+    for (const t of patch.times) if (parseClock(t) == null) return { ok: false, reason: `bad-time:${t}` };
+  }
+  if (patch.timeZone && !isValidTimeZone(patch.timeZone)) return { ok: false, reason: 'bad-zone' };
+  for (const key of ['leadMs', 'everyMs', 'jitterMs', 'afterMs']) {
+    if (patch[key] == null) continue;
+    if (!Number.isFinite(patch[key]) || patch[key] < 0) return { ok: false, reason: `bad-${key}` };
+  }
+  if (patch.everyMs != null && patch.everyMs < 60_000) return { ok: false, reason: 'too-often' };
+
+  const next = { ...patch };
+  if (patch.channel !== undefined) next.channel = patch.channel ? normalizeChannel(patch.channel) : null;
+  // A schedule change invalidates what was already scheduled off the old one.
+  if (patch.everyMs != null || patch.jitterMs != null) next.state = { ...(cur.state || {}), nextAt: null };
+
+  const reminder = await patchReminder(id, next);
+  return { ok: true, reminder };
+}
+
+/** True when the runtime actually knows this IANA zone (a typo must not stick). */
+export function isValidTimeZone(timeZone) {
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/events/reminderScheduler.js
+++ b/src/events/reminderScheduler.js
@@ -1,0 +1,60 @@
+// Reminder tick — walks every stored reminder against the pure evaluator
+// (src/rules/reminders.js) and says whatever came due. All the scheduling
+// judgement lives in that evaluator; this file only supplies the clock, the
+// channel, and the writes.
+//
+// Two invariants worth keeping in mind when editing:
+//   * state is persisted BEFORE the announcement, so a crash between the two
+//     costs a reminder rather than repeating one forever;
+//   * one reminder blowing up must not stop the others — each is independent.
+import { getConfig, getLiveSince } from '../db/configStore.js';
+import { listReminders, setReminderState } from '../db/reminders.js';
+import { evaluateReminder } from '../rules/reminders.js';
+import { config } from '../config.js';
+
+/**
+ * @param {{
+ *   send: { say: (t: string) => Promise<void> },
+ *   channel: string,
+ *   logger: any,
+ *   rng?: () => number,
+ * }} deps
+ *   `send` is the mute-aware wrapper — a muted bot stays quiet while schedules
+ *   keep advancing, so unmuting doesn't unleash a backlog.
+ * @returns {() => void} stop function
+ */
+export function startReminderScheduler({ send, channel, logger, rng = Math.random }) {
+  let busy = false;
+
+  async function tick() {
+    if (busy) return; // a slow RTDB write must not overlap the next tick
+    busy = true;
+    try {
+      const ctx = {
+        now: Date.now(),
+        live: Boolean(getConfig().live),
+        liveSince: getLiveSince(),
+        channel,
+        config: config.reminders,
+      };
+      for (const reminder of listReminders()) {
+        try {
+          const { due, state, changed } = evaluateReminder(reminder, ctx, rng);
+          if (changed) await setReminderState(reminder.id, state);
+          if (due) {
+            send.say(due.text);
+            logger.info?.('reminder fired', { id: reminder.id, kind: due.kind });
+          }
+        } catch (err) {
+          logger.error?.('reminder failed', { id: reminder?.id, err: String(err?.stack || err) });
+        }
+      }
+    } finally {
+      busy = false;
+    }
+  }
+
+  const interval = setInterval(() => { tick().catch(() => {}); }, config.reminders.tickMs);
+  interval.unref?.();
+  return () => clearInterval(interval);
+}

--- a/src/rules/reminders.js
+++ b/src/rules/reminders.js
@@ -1,0 +1,203 @@
+// REMINDERS — the pure "is anything due right now?" engine. Like the rest of
+// rules/*, it takes a clock and an RNG as arguments and touches no I/O, so every
+// schedule below is testable without waiting for a real hour to pass (see
+// test/rules/reminders.test.js, which runs offline in CI).
+//
+// Three schedule kinds cover what's wanted, and each is data — a reminder is a
+// record in RTDB (config/reminders/<id>), never a hardcoded rule:
+//
+//   afterLive  once per live session, N ms after the stream went live
+//              (e.g. "is Wallpaper Engine still running?" at +30 min)
+//   daily      at wall-clock times in a named time zone, with an optional
+//              heads-up lead (e.g. Ghosty eats at 08:00 + 17:00 PT, warned 20
+//              min ahead). Skipped outright when the channel isn't live — a meal
+//              ping three hours late is worse than none.
+//   interval   every N ms of live time, ± jitter (e.g. hydration each hour).
+//
+// A reminder with a `channel` fires ONLY on that channel; `channel: null` fires
+// anywhere. That's what makes "Nikki-specific" a property of the data instead of
+// an `if (channel === 'nikkibreanne')` buried in the scheduler.
+//
+// Each evaluation returns the reminder's next STATE alongside anything due, so
+// the caller persists exactly one thing: `{ due, state, changed }`. State is
+// what makes firing idempotent across restarts — a bot that comes back up
+// mid-stream must not re-announce what it already said.
+
+const DAY_MS = 86_400_000;
+const MAX_FIRED_KEYS = 8; // enough to dedupe a day of slots; bounded so it can't grow
+
+export const KINDS = ['afterLive', 'daily', 'interval'];
+
+const num = (v, fallback) => (Number.isFinite(Number(v)) ? Number(v) : fallback);
+const mod = (n, m) => ((n % m) + m) % m;
+
+/** Twitch channels appear as `nikkibreanne`, `#nikkibreanne`, or mixed case. */
+export function normalizeChannel(name) {
+  return String(name || '').trim().replace(/^#/, '').toLowerCase();
+}
+
+/** `HH:MM` → minutes past midnight, or null if it isn't a clock time. */
+export function parseClock(text) {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(String(text || '').trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h > 23 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/** minutes past midnight → `HH:MM`. */
+export function formatClock(minutes) {
+  const t = mod(Math.round(minutes), 1440);
+  return `${String(Math.floor(t / 60)).padStart(2, '0')}:${String(t % 60).padStart(2, '0')}`;
+}
+
+/**
+ * Where the wall clock stands in `timeZone` at instant `now`. Returned as a
+ * calendar date (for dedupe keys) plus minutes/seconds past local midnight, so
+ * the daily comparison is a plain subtraction and needs no DST arithmetic: the
+ * zone's own offset is already baked into what Intl reports.
+ */
+export function zonedNow(now, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone, year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23',
+  }).formatToParts(new Date(now));
+  const get = (type) => parts.find((p) => p.type === type)?.value;
+  return {
+    date: `${get('year')}-${get('month')}-${get('day')}`,
+    minutes: Number(get('hour')) * 60 + Number(get('minute')),
+    seconds: Number(get('second')),
+  };
+}
+
+/** Wording for a heads-up when the reminder doesn't carry its own `leadText`. */
+function defaultLeadText(reminder, leadMs) {
+  const mins = Math.round(leadMs / 60_000);
+  return `⏰ In ${mins} min — ${String(reminder.text || '').replace(/^[^\p{L}\p{N}]+/u, '')}`;
+}
+
+/**
+ * Decide what (if anything) a reminder should say right now.
+ * @param {object} reminder the stored record (config/reminders/<id>)
+ * @param {{ now: number, live: boolean, liveSince: number|null, channel: string, config: object }} ctx
+ * @param {() => number} rng injected for jitter (deterministic in tests)
+ * @returns {{ due: {kind:'main'|'lead', text:string}|null, state: object, changed: boolean }}
+ */
+export function evaluateReminder(reminder, ctx, rng = Math.random) {
+  const state = { ...(reminder?.state || {}) };
+  const idle = { due: null, state: reminder?.state || {}, changed: false };
+  if (!reminder || reminder.enabled === false) return idle;
+  if (!KINDS.includes(reminder.kind)) return idle;
+  if (reminder.channel && normalizeChannel(reminder.channel) !== normalizeChannel(ctx.channel)) return idle;
+  if (reminder.liveOnly !== false && !ctx.live) return idle;
+  if (!String(reminder.text || '').trim()) return idle; // nothing to say
+
+  if (reminder.kind === 'afterLive') return dueAfterLive(reminder, ctx, state, idle);
+  if (reminder.kind === 'daily') return dueDaily(reminder, ctx, state, idle);
+  return dueInterval(reminder, ctx, state, idle, rng);
+}
+
+/** Once per live session, `afterMs` into the stream. */
+function dueAfterLive(reminder, ctx, state, idle) {
+  const since = ctx.liveSince;
+  if (!since) return idle; // live but we don't know since when — wait for the stamp
+  if (state.firedSession === since) return idle; // already handled this stream
+  const elapsed = ctx.now - since;
+  const afterMs = Math.max(0, num(reminder.afterMs, 30 * 60_000));
+  if (elapsed < afterMs) return idle;
+
+  state.firedSession = since;
+  // Bot was down through the whole window (it booted hours into the stream):
+  // announce nothing, but mark the session so it can't fire late on the next tick.
+  const windowMs = Math.max(0, num(reminder.windowMs, num(ctx.config?.afterLiveWindowMs, 2 * 60 * 60_000)));
+  if (elapsed > afterMs + windowMs) return { due: null, state, changed: true };
+
+  state.lastFiredAt = ctx.now;
+  return { due: { kind: 'main', text: reminder.text }, state, changed: true };
+}
+
+/**
+ * At each `times` entry (and its lead) in the reminder's time zone. Fires only
+ * inside a short grace after the slot, so a bot that boots at noon never shouts
+ * about the 8am one; a slot missed while offline is simply skipped.
+ */
+function dueDaily(reminder, ctx, state, idle) {
+  const timeZone = reminder.timeZone || ctx.config?.defaultTimeZone || 'America/Los_Angeles';
+  const graceMs = Math.max(0, num(reminder.graceMs, num(ctx.config?.dailyGraceMs, 5 * 60_000)));
+  const leadMs = Math.max(0, num(reminder.leadMs, 0));
+  const times = Array.isArray(reminder.times) ? reminder.times : [];
+  const fired = Array.isArray(state.firedKeys) ? state.firedKeys : [];
+
+  const { date, minutes, seconds } = zonedNow(ctx.now, timeZone);
+  const nowMs = minutes * 60_000 + seconds * 1000;
+
+  for (const time of times) {
+    const target = parseClock(time);
+    if (target == null) continue;
+    const slots = [{ at: target * 60_000, kind: 'main', text: reminder.text }];
+    if (leadMs > 0) {
+      // A lead can land before local midnight (e.g. 00:10 warned 20 min ahead);
+      // wrapping keeps it on the calendar day it actually happens, which is also
+      // the day its dedupe key belongs to.
+      slots.push({
+        at: mod(target * 60_000 - leadMs, DAY_MS),
+        kind: 'lead',
+        text: reminder.leadText || defaultLeadText(reminder, leadMs),
+      });
+    }
+    for (const slot of slots) {
+      const sinceSlot = nowMs - slot.at;
+      if (sinceSlot < 0 || sinceSlot > graceMs) continue;
+      const key = `${date}|${time}|${slot.kind}`;
+      if (fired.includes(key)) continue;
+      state.firedKeys = [...fired, key].slice(-MAX_FIRED_KEYS);
+      state.lastFiredAt = ctx.now;
+      return { due: { kind: slot.kind, text: slot.text }, state, changed: true };
+    }
+  }
+  return idle;
+}
+
+/** Every `everyMs` of LIVE time, ± `jitterMs`. */
+function dueInterval(reminder, ctx, state, idle, rng) {
+  const everyMs = Math.max(60_000, num(reminder.everyMs, 60 * 60_000));
+  const jitterMs = Math.min(Math.max(0, num(reminder.jitterMs, 0)), Math.floor(everyMs / 2));
+  const roll = () => ctx.now + everyMs + Math.round((rng() * 2 - 1) * jitterMs);
+
+  if (!Number.isFinite(state.nextAt)) { // first live tick — start the cycle
+    state.nextAt = roll();
+    return { due: null, state, changed: true };
+  }
+  if (ctx.now < state.nextAt) return idle;
+
+  const overdue = ctx.now - state.nextAt;
+  state.nextAt = roll();
+  // More than a full period late means the slot passed while the channel was
+  // offline (or the bot was down). Pick the cycle back up, quietly.
+  if (overdue > everyMs) return { due: null, state, changed: true };
+
+  state.lastFiredAt = ctx.now;
+  return { due: { kind: 'main', text: reminder.text }, state, changed: true };
+}
+
+/** One-line schedule summary for `!reminder` (pure, so it's covered by tests). */
+export function describeSchedule(reminder) {
+  const mins = (ms) => Math.round(num(ms, 0) / 60_000);
+  if (reminder.kind === 'afterLive') return `${mins(reminder.afterMs)}m after going live`;
+  if (reminder.kind === 'daily') {
+    const times = (reminder.times || []).join(', ') || '(no times set)';
+    const lead = num(reminder.leadMs, 0) > 0 ? ` +${mins(reminder.leadMs)}m heads-up` : '';
+    return `daily ${times} ${shortZone(reminder.timeZone)}${lead}`;
+  }
+  if (reminder.kind === 'interval') {
+    const jitter = num(reminder.jitterMs, 0) > 0 ? ` ±${mins(reminder.jitterMs)}m` : '';
+    return `every ${mins(reminder.everyMs)}m${jitter}`;
+  }
+  return 'unscheduled';
+}
+
+/** `America/Los_Angeles` → `Los Angeles` — enough to tell zones apart in chat. */
+function shortZone(timeZone) {
+  return String(timeZone || '').split('/').pop().replace(/_/g, ' ') || 'local';
+}

--- a/test/e2e/commands.e2e.test.js
+++ b/test/e2e/commands.e2e.test.js
@@ -55,6 +55,7 @@ beforeEach(async () => {
   // season, a raid pointing at wiped data). Season 'e2e' + passive EXP off + not
   // muted + no active raid is the clean slate every scenario starts from.
   await database().ref('config/raid').remove().catch(() => {});
+  await database().ref('config/reminders').remove().catch(() => {}); // scenarios re-seed what they need
   await setChatMuted(false);
   await setExpMode('off'); // passive EXP off → replies aren't polluted by level-ups
   await setSeason({ id: 'e2e', name: 'E2E Season', startsAt: Date.now() });

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -13,6 +13,7 @@ import { openMarket } from '../../src/db/market.js';
 import { setDrop } from '../../src/db/drops.js';
 import { setupRaidWeek, enlist } from '../../src/db/raid.js';
 import { seedCuratedFacts, orderedFacts } from '../../src/db/facts.js';
+import { seedReminders, listReminders } from '../../src/db/reminders.js';
 import { getRaidPointer, getConfig, setLive, setClipMode } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
@@ -58,7 +59,14 @@ async function raidWeek({ bossName = 'The Test Warden', enlistUsers = [] } = {})
   return { seasonId, weekId };
 }
 
-export const fixtures = { player, loot, wallet, market, drop, facts, leaderboard, raidWeek };
+/** Seed the default reminders and wait for the config mirror to see them. */
+async function reminders() {
+  const res = await seedReminders();
+  await until(() => listReminders().length >= res.seeded.length + res.kept.length);
+  return res;
+}
+
+export const fixtures = { player, loot, wallet, market, drop, facts, leaderboard, raidWeek, reminders };
 
 // ── scenarios (one per command primary name) ─────────────────────────────────
 export const SCENARIOS = [
@@ -369,6 +377,26 @@ export const SCENARIOS = [
       await fx.raidWeek({ enlistUsers: [u('e2e_rn_hero', { login: 'hero', name: 'Hero' })] });
       const reply = await bot.send(u('e2e_rn_mod', { login: 'mod', name: 'Mod', mod: true }), '!raidnight');
       assert.match(reply, /RAID NIGHT/i);
+    },
+  },
+  {
+    command: 'reminder', title: 'mod lists and re-times a scheduled reminder',
+    run: async ({ bot, u, fx }) => {
+      await fx.reminders();
+      const mod = u('e2e_rem', { login: 'mod', name: 'Mod', mod: true });
+      assert.match(await bot.send(mod, '!reminder'), /ghosty.*daily 08:00, 17:00/i);
+
+      // Re-time Ghosty's meals from chat — the point of keeping schedules in the DB.
+      assert.match(await bot.send(mod, '!reminder at ghosty 09:30 18:30'), /09:30, 18:30/);
+      assert.deepEqual((await database().ref('config/reminders/ghosty/times').get()).val(), ['09:30', '18:30']);
+
+      assert.match(await bot.send(mod, '!reminder at ghosty half-past-nine'), /isn't a time/i);
+      assert.match(await bot.send(mod, '!reminder off hydration'), /hydration off/i);
+      assert.match(await bot.send(mod, '!reminder test wallpaper'), /Wallpaper Engine/i);
+      assert.match(await bot.send(mod, '!reminder every hydration 45'), /every 45m/);
+      assert.match(await bot.send(mod, '!reminder nope ghosty'), /Usage/i);
+      // A non-mod gets nothing at all (the whole command is mod-gated).
+      assert.equal(await bot.send(u('e2e_rem_v', { login: 'viewer' }), '!reminder'), '');
     },
   },
   {

--- a/test/reminders.test.js
+++ b/test/reminders.test.js
@@ -1,0 +1,169 @@
+// REMINDERS — the stateful half: seeding into config/reminders (and NOT
+// clobbering what mods changed), schedule edits, the liveSince stamp that the
+// "30 minutes after going live" reminder counts from, and the scheduler tick
+// that ties it together. The scheduling judgement itself is covered offline in
+// test/rules/reminders.test.js. Skipped without the emulator host.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { startConfigMirror, setLive, getLiveSince, getConfig } from '../src/db/configStore.js';
+import { seedReminders, listReminders, getReminder, editReminder, patchReminder } from '../src/db/reminders.js';
+import { startReminderScheduler } from '../src/events/reminderScheduler.js';
+import { DEFAULT_REMINDERS } from '../src/content/reminders.js';
+import { config } from '../src/config.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+const silentLogger = { info() {}, warn() {}, error() {}, debug() {} };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll until the RTDB listener has echoed a change into the mirror. */
+async function until(pred, ms = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (pred()) return true;
+    await sleep(15);
+  }
+  return pred();
+}
+
+async function wipe() {
+  await database().ref('config/reminders').remove().catch(() => {});
+  await setLive(false, 'test', silentLogger);
+  await until(() => Object.keys(listReminders()).length === 0 && !getConfig().live);
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(silentLogger);
+});
+after(async () => { if (host) { await wipe(); await closeFirebase(); } });
+beforeEach(async () => { if (host) await wipe(); });
+
+runOrSkip('seed: creates the shipped defaults, and is a no-op the second time', async () => {
+  const first = await seedReminders();
+  assert.deepEqual(first.seeded.sort(), DEFAULT_REMINDERS.map((r) => r.id).sort());
+  const second = await seedReminders();
+  assert.deepEqual(second.seeded, [], 'a redeploy must not re-seed');
+  await until(() => listReminders().length === DEFAULT_REMINDERS.length);
+  assert.equal(getReminder('ghosty').channel, 'nikkibreanne', 'Nikki-specific by data, not by code');
+  // RTDB stores no nulls, so "any channel" comes back absent rather than null —
+  // which is why the evaluator tests falsiness and never `=== null`.
+  assert.ok(!getReminder('hydration').channel, 'hydration runs on any channel');
+});
+
+runOrSkip('seed: NEVER clobbers a schedule a mod has changed', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('ghosty')));
+  await editReminder('ghosty', { times: ['09:30'], text: 'custom feeding time' });
+
+  await seedReminders(); // a deploy happens
+  const stored = (await database().ref('config/reminders/ghosty').get()).val();
+  assert.deepEqual(stored.times, ['09:30'], 'the mod-set time survived the deploy');
+  assert.equal(stored.text, 'custom feeding time');
+});
+
+runOrSkip('edit: validates times, zones and periods instead of storing nonsense', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('ghosty')));
+
+  assert.match((await editReminder('ghosty', { times: ['25:00'] })).reason, /^bad-time/);
+  assert.equal((await editReminder('ghosty', { times: [] })).reason, 'no-times');
+  assert.equal((await editReminder('ghosty', { timeZone: 'Mars/Olympus' })).reason, 'bad-zone');
+  assert.equal((await editReminder('hydration', { everyMs: 30_000 })).reason, 'too-often');
+  assert.equal((await editReminder('nope', { enabled: false })).reason, 'unknown');
+  assert.deepEqual(getReminder('ghosty').times, ['08:00', '17:00'], 'nothing bad was written');
+
+  const ok = await editReminder('ghosty', { times: ['07:15', '18:45'], timeZone: 'Europe/London' });
+  assert.deepEqual(ok.reminder.times, ['07:15', '18:45']);
+  assert.equal(ok.reminder.timeZone, 'Europe/London');
+});
+
+runOrSkip('edit: changing the interval re-arms the next ping', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('hydration')));
+  await patchReminder('hydration', { state: { nextAt: Date.now() + 45 * 60_000 } });
+
+  const res = await editReminder('hydration', { everyMs: 30 * 60_000 });
+  assert.equal(res.reminder.state.nextAt, null, 'the old schedule must not outlive the change');
+});
+
+runOrSkip('edit: a reminder can be pointed at another channel, or at all of them', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('wallpaper')));
+  assert.equal((await editReminder('wallpaper', { channel: '#SomeoneElse' })).reminder.channel, 'someoneelse', 'normalized');
+  assert.ok(!(await editReminder('wallpaper', { channel: null })).reminder.channel, 'back to any channel');
+  assert.equal((await database().ref('config/reminders/wallpaper/channel').get()).val(), null, 'cleared in RTDB too');
+});
+
+runOrSkip('liveSince is stamped on the way up and cleared on the way down', async () => {
+  const before = Date.now();
+  await setLive(true, 'test', silentLogger);
+  await until(() => Boolean(getLiveSince()));
+  const stamped = getLiveSince();
+  assert.ok(stamped >= before, 'stamped when the stream started');
+  assert.equal((await database().ref('config/liveSince').get()).val(), stamped, 'persisted for restarts');
+
+  // An idempotent repeat (the Helix poll re-reporting live) is NOT a new session.
+  assert.equal(await setLive(true, 'test-again', silentLogger), false, 'no edge, no write');
+  assert.equal(getLiveSince(), stamped, 'a restart mid-stream keeps the original start');
+
+  await setLive(false, 'test', silentLogger);
+  await until(() => getLiveSince() == null);
+  assert.equal((await database().ref('config/liveSince').get()).val(), null, 'cleared when offline');
+});
+
+runOrSkip('scheduler: announces a due reminder once and persists that it did', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('hydration')));
+  // Arm hydration to be due right now, and disable the others so the tick is
+  // unambiguous. A tiny tickMs keeps the test in milliseconds.
+  await editReminder('wallpaper', { enabled: false });
+  await editReminder('ghosty', { enabled: false });
+  await patchReminder('hydration', { state: { nextAt: Date.now() - 1000 } });
+  await setLive(true, 'test', silentLogger);
+  await until(() => getConfig().live === true);
+
+  const said = [];
+  const originalTick = config.reminders.tickMs;
+  config.reminders.tickMs = 25;
+  const stop = startReminderScheduler({
+    send: { say: (t) => { said.push(t); } }, channel: 'nikkibreanne', logger: silentLogger, rng: () => 0.5,
+  });
+  try {
+    await sleep(300);
+  } finally {
+    stop();
+    config.reminders.tickMs = originalTick;
+  }
+
+  assert.equal(said.length, 1, `exactly one ping, got ${said.length}`);
+  assert.match(said[0], /Hydration/);
+  const stored = (await database().ref('config/reminders/hydration/state').get()).val();
+  assert.ok(stored.nextAt > Date.now(), 're-armed for the next hour, in RTDB so a restart keeps it');
+});
+
+runOrSkip('scheduler: stays silent for a channel the reminder does not belong to', async () => {
+  await seedReminders();
+  await until(() => Boolean(getReminder('hydration')));
+  await editReminder('hydration', { channel: 'nikkibreanne' });
+  await patchReminder('hydration', { state: { nextAt: Date.now() - 1000 } });
+  await setLive(true, 'test', silentLogger);
+  await until(() => getConfig().live === true);
+
+  const said = [];
+  const originalTick = config.reminders.tickMs;
+  config.reminders.tickMs = 25;
+  const stop = startReminderScheduler({
+    send: { say: (t) => { said.push(t); } }, channel: 'a_different_channel', logger: silentLogger,
+  });
+  try {
+    await sleep(200);
+  } finally {
+    stop();
+    config.reminders.tickMs = originalTick;
+  }
+  assert.deepEqual(said, [], 'another streamer running this bot must not get Nikki\'s reminders');
+});

--- a/test/rules/reminders.test.js
+++ b/test/rules/reminders.test.js
@@ -1,0 +1,281 @@
+// REMINDER SCHEDULING — the pure evaluator. Clock, live state, channel and RNG
+// are all injected, so every case below is exact and instant: no waiting for an
+// hour to pass, no flaky "close enough" timing. Runs offline in CI (`npm test`).
+//
+// The failures that matter here are the ones a live stream would show first:
+// a reminder firing on the wrong channel, Ghosty's 8am ping arriving at noon
+// because the bot restarted, a hydration ping repeating every tick, or the meal
+// times silently drifting an hour when Pacific time changes.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  evaluateReminder, describeSchedule, zonedNow, parseClock, formatClock, normalizeChannel,
+} from '../../src/rules/reminders.js';
+import { DEFAULT_REMINDERS } from '../../src/content/reminders.js';
+import { config } from '../../src/config.js';
+
+const MIN = 60_000;
+const PT = 'America/Los_Angeles';
+const byId = (id) => structuredClone(DEFAULT_REMINDERS.find((r) => r.id === id));
+
+/** ctx with the defaults a live nikkibreanne stream would have. */
+function ctx(overrides = {}) {
+  return {
+    now: Date.parse('2026-08-09T18:00:00Z'),
+    live: true,
+    liveSince: Date.parse('2026-08-09T17:00:00Z'),
+    channel: 'nikkibreanne',
+    config: config.reminders,
+    ...overrides,
+  };
+}
+
+/** An instant expressed as PACIFIC wall-clock, so the test reads like the schedule. */
+const pacific = (isoLocal, offset) => Date.parse(`${isoLocal}${offset}`);
+
+// ── gates that apply to every kind ───────────────────────────────────────────
+
+test('a channel-specific reminder never fires on another channel', () => {
+  const r = byId('ghosty');
+  const at8 = pacific('2026-08-09T08:00:30', '-07:00');
+  const mine = evaluateReminder(r, ctx({ now: at8, channel: 'nikkibreanne' }));
+  const theirs = evaluateReminder(r, ctx({ now: at8, channel: 'someoneelse' }));
+  assert.ok(mine.due, 'fires on its own channel');
+  assert.equal(theirs.due, null, 'a Nikki reminder must stay off other channels');
+  assert.equal(theirs.changed, false, 'and must not even record state there');
+});
+
+test('channel matching ignores the leading # and case', () => {
+  const r = { ...byId('ghosty'), channel: 'NikkiBreanne' };
+  const at8 = pacific('2026-08-09T08:00:30', '-07:00');
+  assert.ok(evaluateReminder(r, ctx({ now: at8, channel: '#nikkibreanne' })).due);
+  assert.equal(normalizeChannel('#NikkiBreanne '), 'nikkibreanne');
+});
+
+test('a null channel fires wherever the bot is running', () => {
+  const c = ctx({ channel: 'anyone-at-all' });
+  const r = { ...byId('hydration'), state: { nextAt: c.now - 1000 } }; // just came due
+  assert.ok(evaluateReminder(r, c).due, 'hydration is not Nikki-specific');
+});
+
+test('nothing fires while the channel is offline, and no state is touched', () => {
+  for (const id of ['wallpaper', 'ghosty', 'hydration']) {
+    const r = byId(id);
+    const res = evaluateReminder(r, ctx({ live: false, liveSince: null, now: pacific('2026-08-09T08:00:30', '-07:00') }));
+    assert.deepEqual([res.due, res.changed], [null, false], `${id} must stay quiet while offline`);
+  }
+});
+
+test('a disabled reminder is inert', () => {
+  const r = { ...byId('hydration'), enabled: false, state: { nextAt: 1 } };
+  assert.equal(evaluateReminder(r, ctx()).due, null);
+});
+
+// ── afterLive: the Wallpaper Engine check ────────────────────────────────────
+
+test('wallpaper check fires once, 30 minutes into the stream', () => {
+  const r = byId('wallpaper');
+  const liveSince = Date.parse('2026-08-09T17:00:00Z');
+
+  const early = evaluateReminder(r, ctx({ liveSince, now: liveSince + 29 * MIN }));
+  assert.equal(early.due, null, 'not a minute early');
+
+  const on = evaluateReminder(r, ctx({ liveSince, now: liveSince + 30 * MIN }));
+  assert.match(on.due.text, /Wallpaper Engine/);
+  assert.equal(on.state.firedSession, liveSince, 'the session is marked so it cannot repeat');
+
+  const again = evaluateReminder({ ...r, state: on.state }, ctx({ liveSince, now: liveSince + 45 * MIN }));
+  assert.deepEqual([again.due, again.changed], [null, false], 'once per stream, not once per tick');
+});
+
+test('wallpaper check fires again on the NEXT stream, not on a bot restart', () => {
+  const r = byId('wallpaper');
+  const first = Date.parse('2026-08-09T17:00:00Z');
+  const fired = evaluateReminder(r, ctx({ liveSince: first, now: first + 30 * MIN })).state;
+
+  // Same session (a restart keeps liveSince) → still silent.
+  const restart = evaluateReminder({ ...r, state: fired }, ctx({ liveSince: first, now: first + 31 * MIN }));
+  assert.equal(restart.due, null, 'a restart mid-stream must not re-announce');
+
+  // A genuinely new stream has a new liveSince → it fires again.
+  const second = first + 20 * 60 * MIN;
+  const next = evaluateReminder({ ...r, state: fired }, ctx({ liveSince: second, now: second + 30 * MIN }));
+  assert.ok(next.due, 'a new stream gets its own check');
+});
+
+test('wallpaper check goes quiet — but marks the session — if the bot booted hours late', () => {
+  const r = byId('wallpaper');
+  const liveSince = Date.parse('2026-08-09T17:00:00Z');
+  const late = liveSince + 30 * MIN + config.reminders.afterLiveWindowMs + MIN;
+  const res = evaluateReminder(r, ctx({ liveSince, now: late }));
+  assert.equal(res.due, null, 'a check three hours late is noise');
+  assert.equal(res.state.firedSession, liveSince, 'still marked, so it cannot fire on the next tick either');
+});
+
+test('afterLive waits for the live stamp rather than guessing', () => {
+  const res = evaluateReminder(byId('wallpaper'), ctx({ liveSince: null }));
+  assert.deepEqual([res.due, res.changed], [null, false]);
+});
+
+// ── daily: Ghosty's meals ────────────────────────────────────────────────────
+
+test("Ghosty's meal fires at 08:00 and 17:00 Pacific, with a 20-minute heads-up", () => {
+  const r = byId('ghosty');
+  const cases = [
+    ['2026-08-09T07:40:05', 'lead', /20 minutes/],
+    ['2026-08-09T08:00:05', 'main', /meal time/i],
+    ['2026-08-09T16:40:05', 'lead', /20 minutes/],
+    ['2026-08-09T17:00:05', 'main', /meal time/i],
+  ];
+  for (const [local, kind, text] of cases) {
+    const res = evaluateReminder(r, ctx({ now: pacific(local, '-07:00') }));
+    assert.equal(res.due?.kind, kind, `${local} should fire the ${kind}`);
+    assert.match(res.due.text, text);
+  }
+});
+
+test('a meal slot fires once, then not again for the rest of that day', () => {
+  const r = byId('ghosty');
+  const first = evaluateReminder(r, ctx({ now: pacific('2026-08-09T08:00:05', '-07:00') }));
+  const second = evaluateReminder({ ...r, state: first.state }, ctx({ now: pacific('2026-08-09T08:02:00', '-07:00') }));
+  assert.equal(second.due, null, 'still inside the grace window, but already said');
+
+  // …and the same clock time TOMORROW is a different slot, so it fires again.
+  const tomorrow = evaluateReminder({ ...r, state: first.state }, ctx({ now: pacific('2026-08-10T08:00:05', '-07:00') }));
+  assert.equal(tomorrow.due?.kind, 'main');
+});
+
+test('a meal slot missed while offline is skipped, not announced late', () => {
+  const r = byId('ghosty');
+  // Bot comes up (or the stream starts) well after 08:00 — outside the grace.
+  const res = evaluateReminder(r, ctx({ now: pacific('2026-08-09T11:30:00', '-07:00') }));
+  assert.deepEqual([res.due, res.changed], [null, false], 'an 8am meal ping at 11:30 helps nobody');
+});
+
+test('the grace window is respected exactly at its edges', () => {
+  const r = byId('ghosty');
+  const grace = config.reminders.dailyGraceMs;
+  const slot = pacific('2026-08-09T08:00:00', '-07:00');
+  assert.ok(evaluateReminder(r, ctx({ now: slot + grace - 1000 })).due, 'inside the window');
+  assert.equal(evaluateReminder(r, ctx({ now: slot + grace + 1000 })).due, null, 'past it');
+  assert.equal(evaluateReminder(r, ctx({ now: slot - 1000 })).due, null, 'never early');
+});
+
+test('meal times follow Pacific WALL CLOCK across the DST change', () => {
+  const r = byId('ghosty');
+  // Same local 08:00, one in PDT (UTC-7) and one in PST (UTC-8): both must fire,
+  // which a naive fixed-offset schedule would get wrong by an hour half the year.
+  assert.ok(evaluateReminder(r, ctx({ now: pacific('2026-08-09T08:00:05', '-07:00') })).due, 'PDT summer');
+  assert.ok(evaluateReminder(r, ctx({ now: pacific('2026-01-09T08:00:05', '-08:00') })).due, 'PST winter');
+  // 08:00 UTC is the middle of the night in Pacific — nothing is due.
+  assert.equal(evaluateReminder(r, ctx({ now: Date.parse('2026-08-09T08:00:05Z') })).due, null);
+});
+
+test('daily reminders honour a different time zone', () => {
+  const r = { ...byId('ghosty'), timeZone: 'Europe/London', times: ['09:00'], leadMs: 0 };
+  assert.ok(evaluateReminder(r, ctx({ now: Date.parse('2026-08-09T08:00:05Z') })).due, '09:00 BST = 08:00 UTC');
+  assert.equal(evaluateReminder(r, ctx({ now: Date.parse('2026-08-09T09:00:05Z') })).due, null);
+});
+
+test('the fired-key list stays bounded as days go by', () => {
+  let state;
+  for (let day = 1; day <= 12; day++) {
+    const now = pacific(`2026-08-${String(day).padStart(2, '0')}T08:00:05`, '-07:00');
+    const res = evaluateReminder({ ...byId('ghosty'), state }, ctx({ now }));
+    state = res.state;
+  }
+  assert.ok(state.firedKeys.length <= 8, `dedupe keys must not grow forever (${state.firedKeys.length})`);
+});
+
+test('a lead that lands before local midnight keeps its own day key', () => {
+  const r = { ...byId('ghosty'), times: ['00:10'], leadMs: 20 * MIN, leadText: 'soon' };
+  const res = evaluateReminder(r, ctx({ now: pacific('2026-08-09T23:50:05', '-07:00') }));
+  assert.equal(res.due?.kind, 'lead');
+  assert.ok(res.state.firedKeys[0].startsWith('2026-08-09'), 'keyed to the day it actually fires');
+});
+
+test('a daily reminder with no leadText still warns in plain English', () => {
+  const r = { ...byId('ghosty'), leadText: null };
+  const res = evaluateReminder(r, ctx({ now: pacific('2026-08-09T07:40:05', '-07:00') }));
+  assert.match(res.due.text, /In 20 min/);
+});
+
+// ── interval: hydration ──────────────────────────────────────────────────────
+
+test('hydration schedules its first ping an hour out instead of firing at once', () => {
+  const r = byId('hydration');
+  const now = Date.parse('2026-08-09T17:00:00Z');
+  const res = evaluateReminder(r, ctx({ now }), () => 0.5);
+  assert.equal(res.due, null, 'nobody needs a hydration ping two seconds into the stream');
+  assert.equal(res.state.nextAt, now + 60 * MIN, 'rng 0.5 = no jitter');
+});
+
+test('hydration fires when due, then re-arms for the next hour', () => {
+  const now = Date.parse('2026-08-09T18:00:00Z');
+  const r = { ...byId('hydration'), state: { nextAt: now - 1000 } };
+  const res = evaluateReminder(r, ctx({ now }), () => 0.5);
+  assert.match(res.due.text, /Hydration/);
+  assert.equal(res.state.nextAt, now + 60 * MIN);
+});
+
+test('hydration jitter stays inside ±10 minutes at both extremes', () => {
+  const now = Date.parse('2026-08-09T18:00:00Z');
+  const r = { ...byId('hydration'), state: { nextAt: now } };
+  const low = evaluateReminder(r, ctx({ now }), () => 0).state.nextAt;
+  const high = evaluateReminder(r, ctx({ now }), () => 1).state.nextAt;
+  assert.equal(low, now + 50 * MIN, 'earliest = period − jitter');
+  assert.equal(high, now + 70 * MIN, 'latest = period + jitter');
+});
+
+test('jitter can never exceed half the period, however it is configured', () => {
+  const now = Date.parse('2026-08-09T18:00:00Z');
+  const r = { ...byId('hydration'), everyMs: 10 * MIN, jitterMs: 60 * MIN, state: { nextAt: now } };
+  const earliest = evaluateReminder(r, ctx({ now }), () => 0).state.nextAt;
+  assert.ok(earliest > now, 'a runaway jitter must not schedule the next ping in the past');
+});
+
+test('a ping missed across a long offline stretch is re-armed, not fired late', () => {
+  const now = Date.parse('2026-08-09T18:00:00Z');
+  const r = { ...byId('hydration'), state: { nextAt: now - 5 * 60 * MIN } }; // 5h overdue
+  const res = evaluateReminder(r, ctx({ now }), () => 0.5);
+  assert.equal(res.due, null, 'coming back from an offline day must not dump a backlog');
+  assert.equal(res.state.nextAt, now + 60 * MIN);
+});
+
+test('a short dropout keeps the cycle rather than restarting it', () => {
+  const now = Date.parse('2026-08-09T18:00:00Z');
+  const r = { ...byId('hydration'), state: { nextAt: now - 3 * MIN } }; // due during a brief drop
+  assert.ok(evaluateReminder(r, ctx({ now }), () => 0.5).due, 'fires just after coming back');
+});
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+test('clock parsing accepts real times and rejects the rest', () => {
+  assert.equal(parseClock('08:00'), 480);
+  assert.equal(parseClock('8:05'), 485);
+  assert.equal(parseClock('23:59'), 1439);
+  for (const bad of ['24:00', '08:60', '8', '0800', 'noon', '']) assert.equal(parseClock(bad), null, bad);
+  assert.equal(formatClock(485), '08:05');
+});
+
+test('zonedNow reports the wall clock of the named zone', () => {
+  const at = Date.parse('2026-08-09T15:04:05Z');
+  assert.deepEqual(zonedNow(at, PT), { date: '2026-08-09', minutes: 8 * 60 + 4, seconds: 5 });
+  assert.equal(zonedNow(at, 'UTC').minutes, 15 * 60 + 4);
+});
+
+test('schedules describe themselves the way the chat list shows them', () => {
+  assert.equal(describeSchedule(byId('wallpaper')), '30m after going live');
+  assert.equal(describeSchedule(byId('ghosty')), 'daily 08:00, 17:00 Los Angeles +20m heads-up');
+  assert.equal(describeSchedule(byId('hydration')), 'every 60m ±10m');
+});
+
+test('the shipped defaults are coherent — ids unique, kinds known, text present', () => {
+  const ids = DEFAULT_REMINDERS.map((r) => r.id);
+  assert.equal(new Set(ids).size, ids.length, 'duplicate reminder id');
+  for (const r of DEFAULT_REMINDERS) {
+    assert.ok(['afterLive', 'daily', 'interval'].includes(r.kind), `${r.id}: unknown kind`);
+    assert.ok(r.text?.trim(), `${r.id}: nothing to say`);
+    if (r.kind === 'daily') for (const t of r.times) assert.ok(parseClock(t) != null, `${r.id}: bad time ${t}`);
+  }
+});


### PR DESCRIPTION
> Rebased onto `main` after #53 merged — one clean commit, reminders only.

Three recurring nudges, on three schedule shapes:

| id | Schedule | Channel |
|---|---|---|
| `wallpaper` | 30 min after going live, once per stream | nikkibreanne only |
| `ghosty` | daily 08:00 + 17:00 Pacific, 20-min heads-up (07:40 / 16:40) | nikkibreanne only |
| `hydration` | every 60 min of live time, ±10 min jitter | any channel |

## Nothing is hardcoded

Each reminder is a record at `config/reminders/<id>`, seeded once from
`src/content/reminders.js` and **never** clobbered afterwards — so a time a mod
changed survives every deploy. `channel` is a *field*: it fires only on that
Twitch channel, and `null` fires wherever the bot runs. That is what makes "this
one is a Nikki thing" a property of the data rather than an
`if (channel === 'nikkibreanne')` buried in the scheduler.

Mods get full control from chat — `on|off|test`, `at <id> 09:00 18:00`,
`every|jitter|after|lead`, `text|leadtext`, `zone`, `channel`. Bad input (`8am`,
`25:00`, `Mars/Olympus`, sub-minute periods) is refused rather than stored.

## Behaviour under real conditions

All three are live-gated. A daily slot missed while offline is **skipped** rather
than announced hours late; an `afterLive` reminder fires once per live session so
a restart mid-stream can't repeat it; an interval that came due during a long
offline stretch is quietly re-armed instead of dumping a backlog.

"30 minutes after going live" needed a live **start time**, which didn't exist —
`config/live` is only a boolean. `setLive` now stamps `config/liveSince` on the
OFF→ON **edge**, on the same write. Both EventSub and the Helix poll feed it and
it is idempotent, so a restart while already live sees no edge and keeps the
original stamp.

## Tests

All the scheduling judgement is a pure function (`src/rules/reminders.js`) with
clock, live state, channel and RNG injected — so **28 offline tests** run in
milliseconds with no waiting and no flake:

- 08:00 Pacific fires in **both PDT and PST** (a fixed-offset schedule would drift
  an hour half the year); 08:00 UTC correctly fires nothing
- a Nikki reminder stays silent on another channel, and doesn't even record state there
- the wallpaper check survives a restart without repeating, but fires again next stream
- an 8am ping is *not* delivered at 11:30; hydration jitter is exactly ±10 min at
  both RNG extremes; a backlog after an offline day is re-armed, not dumped

Plus **8 emulator tests** (seeding never clobbers an edit, validation, the
`liveSince` edge, the scheduler firing once and persisting) and an **e2e
scenario** through the real dispatcher.

Docs: README gets a "Scheduled reminders" section, `docs/CONFIG.md` gets the
runtime row, the engine bounds, and a full field reference for the reminder
record. The okrafans commands page is updated in a companion PR on that repo.

## Flagged

`hydration` is `channel: null`, so if this bot ever runs for another channel it
fires there too — intended, and `!reminder channel hydration <name>` narrows it.