### PR TITLE
fix: !offer accept silently doing nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,13 @@ inclusive rolls · slots = weapon/armor/trinket · season = **6 weeks** · EXP =
 `auto`. Repo is intended **open source** (security rests on locked RTDB rules +
 runtime-injected secrets, not code secrecy).
 
+**Chat surface:** responses stay **sub-verbs** — `!offer accept`, `!trade
+counter`, `!duel accept`. Bare `!accept` / `!decline` are deliberately NOT
+registered: the channel runs other bots, and claiming names that common risks two
+bots answering one message. (A viewer typing `!accept` therefore gets nothing;
+that is intended, and the dispatcher logs it at debug so it stays diagnosable.)
+No command links the source repo — chat replies point at okrafans.com only.
+
 **Content:** 72 items / 18 bosses (3 seasons) / per-class + boss ability kits live
 in `src/content/`; boss HP scales to the mustered roster (`scaleBossHp`).
 Sub-tier boosts combat power + EXP; victory loot rewards participants + survivors

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node --watch index.js",
     "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js test/cooldown.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",

--- a/src/commands/kennycommands.js
+++ b/src/commands/kennycommands.js
@@ -1,5 +1,8 @@
 // !kennycommands — point chat at the full command reference (like Nightbot's
 // !commands). The website hosts the always-current list; this just links to it.
+//
+// NOTE: no command links the source repo. Chat replies point at okrafans.com and
+// nothing else — the same rule that keeps the capture rig out of !clip's replies.
 import { config } from '../config.js';
 
 export default {
@@ -8,6 +11,6 @@ export default {
   cooldownMs: 10_000,
   help: '!kennycommands — the full list of everything kennyBot can do',
   async run({ reply }) {
-    reply(`🤖 Everything I can do → ${config.siteUrl}/commands/  ·  source: github.com/nikkibreanne/kennyBot`);
+    reply(`🤖 Everything I can do → ${config.siteUrl}/commands/`);
   },
 };

--- a/src/commands/offer.js
+++ b/src/commands/offer.js
@@ -8,6 +8,10 @@ export default {
   names: ['offer', 'gift'],
   mod: false,
   cooldownMs: 3_000,
+  // The recipient answers the bot's own prompt with `!offer accept`, often right
+  // after looking at it with a bare `!offer` (or mistyping it once). Keying the
+  // cooldown per sub-verb keeps those from cancelling each other out.
+  cooldownPerSubcommand: true,
   help: '!offer @user <item|#> [+ credits] — GIVE an item/credits to someone (one-way); they reply !offer accept / decline',
   run: (ctx) => runExchange(ctx, 'offer'),
 };

--- a/src/commands/trade.js
+++ b/src/commands/trade.js
@@ -130,7 +130,18 @@ export async function runExchange({ user, args, reply }, openKind) {
 
   // ── otherwise: open a new exchange (args[0] is the target) ──
   const { itemRef, credits } = parseStake(args.slice(1).join(' '));
-  if (!itemRef && !(credits > 0)) { reply(`@${user.displayName} usage: !${openKind} @user <item # or name> [+ credits]  (see !bag)`); return; }
+  if (!itemRef && !(credits > 0)) {
+    // Nothing staked. If they already have an exchange going, this is far more
+    // likely a fumbled response verb (`!offer acept`) than an attempt to open a
+    // second one — point at the reply they meant rather than the open syntax.
+    const pending = await getTradeFor(user.login);
+    if (pending) {
+      reply(`@${user.displayName} you have a pending ${pending.kind} — reply !${pending.kind} accept · counter · decline (or !${pending.kind} to see it).`);
+      return;
+    }
+    reply(`@${user.displayName} usage: !${openKind} @user <item # or name> [+ credits]  (see !bag)`);
+    return;
+  }
   const res = await openTrade({ fromId: user.id, fromLogin: user.login, fromName: user.displayName, toRaw: args[0], itemRef: itemRef || null, credits, kind: openKind });
   if (!res.ok) { reply(`@${user.displayName} ${reasonText(res)}`); return; }
   const t = res.trade;
@@ -145,6 +156,7 @@ export default {
   names: ['trade'],
   mod: false,
   cooldownMs: 3_000,
+  cooldownPerSubcommand: true, // see offer.js — accept/counter answer a bot prompt
   help: '!trade @user <item|#> [+ credits] — offer a SWAP; the other player must !trade counter <item|#> [+ credits] before !trade accept (or !trade decline)',
   run: (ctx) => runExchange(ctx, 'trade'),
 };

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -38,9 +38,21 @@ export function createMessageHandler({ sender, channel, botUserId, logger, onAct
     if (!def) return;
     if (def.mod && !user.isMod && !user.isBroadcaster) return; // silently ignore non-mods
 
-    const key = `${user.id}:${name}`;
+    // Per-user command cooldown. Commands whose sub-verbs ANSWER a prompt the bot
+    // posted (`!offer accept`, `!trade counter`) opt into keying it per sub-verb:
+    // otherwise glancing at the offer — or fat-fingering it — burns the window and
+    // the accept that follows is dropped, which reads in chat as a broken bot.
+    // Per sub-verb still stops the thing the cooldown is for (the SAME command
+    // repeated), and each verb keeps its own window.
+    const sub = def.cooldownPerSubcommand ? `:${String(args[0] || '').toLowerCase()}` : '';
+    const key = `${user.id}:${name}${sub}`;
     const now = Date.now();
-    if (def.cooldownMs && now - (cmdCooldown.get(key) || 0) < def.cooldownMs) return;
+    if (def.cooldownMs && now - (cmdCooldown.get(key) || 0) < def.cooldownMs) {
+      // Never drop a command without a trace: "it did nothing and there was
+      // nothing in the logs" is how this cost a stream's worth of debugging.
+      logger.debug('command dropped by cooldown', { command: name, sub: args[0] || null, userId: user.id });
+      return;
+    }
     cmdCooldown.set(key, now);
 
     // Outbound mute (`!mute`): swallow every reply while muted EXCEPT for

--- a/src/events/chat.js
+++ b/src/events/chat.js
@@ -35,8 +35,19 @@ export function createMessageHandler({ sender, channel, botUserId, logger, onAct
 
   async function dispatchCommand(user, args, name) {
     const def = getCommand(name);
-    if (!def) return;
-    if (def.mod && !user.isMod && !user.isBroadcaster) return; // silently ignore non-mods
+    if (!def) {
+      // Staying quiet is deliberate — the channel runs other bots, and answering
+      // every stray `!` would be noise. But it must not be INVISIBLE: a viewer
+      // typing `!accept` (instead of `!offer accept`) got no reply and left no
+      // trace, which is indistinguishable from the bot being broken. Debug-level,
+      // so it costs nothing until someone goes looking.
+      logger.debug('unknown command ignored', { command: name, userId: user.id, login: user.login });
+      return;
+    }
+    if (def.mod && !user.isMod && !user.isBroadcaster) {
+      logger.debug('mod-only command ignored', { command: name, userId: user.id, login: user.login });
+      return;
+    }
 
     // Per-user command cooldown. Commands whose sub-verbs ANSWER a prompt the bot
     // posted (`!offer accept`, `!trade counter`) opt into keying it per sub-verb:

--- a/test/cooldown.test.js
+++ b/test/cooldown.test.js
@@ -1,0 +1,111 @@
+// Per-user COMMAND COOLDOWN behaviour, driven through the real chat dispatcher
+// against the emulator.
+//
+// This is the one thing no other test covered, and it cost a live stream: a gift
+// was made with `!offer`, the recipient glanced at it with a bare `!offer`, and
+// their `!offer accept` a second later was dropped by the 3s cooldown — no chat
+// reply, no log line, so it looked like the bot was broken. Every other test
+// here deliberately sidesteps cooldowns (the e2e harness rebuilds the handler per
+// message; mute.test.js uses a fresh user id per send), so the gap was invisible.
+//
+// ONE handler is used throughout, exactly like production, so the cooldown map
+// actually accumulates.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase } from '../src/db/firebase.js';
+import { startConfigMirror, setExpMode } from '../src/db/configStore.js';
+import { createMessageHandler } from '../src/events/chat.js';
+import { createPlayer, getPlayer, addLoot } from '../src/db/players.js';
+import { seedCuratedFacts } from '../src/db/facts.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+
+const ITEM = 'itm_s1_thornnettle_dirk';
+const giver = { id: 'u_cd_giver', login: 'nikkibreanne', name: 'NikkiBreAnne' };
+const taker = { id: 'u_cd_taker', login: 'okrafan', name: 'OkraFan' };
+
+const sent = [];
+const drops = []; // what the dispatcher logged when it dropped a command
+const logger = {
+  info() {}, warn() {}, error() {},
+  debug: (msg, meta) => { if (String(msg).includes('cooldown')) drops.push(meta); },
+};
+const sender = { say: (t) => { sent.push(t); return Promise.resolve(); }, action: () => Promise.resolve() };
+
+let handler;
+
+/** Send one chat line and return what the bot said ('' when it stayed silent). */
+async function say(user, text) {
+  sent.length = 0;
+  await handler('#nikkibreanne', user.login, text, {
+    userInfo: {
+      userId: user.id, userName: user.login, displayName: user.name,
+      isMod: false, isBroadcaster: false, isSubscriber: true,
+    },
+  });
+  return sent.join(' ⏎ ');
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(logger);
+  await setExpMode('off'); // keep level-up chatter out of the assertions
+});
+after(async () => { if (host) await closeFirebase(); });
+
+beforeEach(async () => {
+  if (!host) return;
+  drops.length = 0;
+  for (const p of ['players', 'usernames', 'trades', 'wallets', 'counters', 'facts']) {
+    await database().ref(p).remove().catch(() => {});
+  }
+  // A FRESH handler per test — otherwise one test's cooldowns leak into the next.
+  // Within a test it is reused, which is the whole point.
+  handler = createMessageHandler({ sender, channel: '#nikkibreanne', botUserId: 'bot', logger, onActivity() {} });
+  await createPlayer({ userId: giver.id, login: giver.login, displayName: giver.name, className: 'Berserker', isSubscriber: true });
+  await addLoot(giver.id, ITEM);
+  await createPlayer({ userId: taker.id, login: taker.login, displayName: taker.name, className: 'Guardian', isSubscriber: true });
+});
+
+runOrSkip('offer: looking at a gift does not swallow the accept that follows', async () => {
+  assert.match(await say(giver, `!offer @${taker.login} ${ITEM}`), /offers you/);
+  assert.match(await say(taker, '!offer'), /Offer:/, 'recipient checks what it is…');
+  const accept = await say(taker, '!offer accept'); // …immediately after, no gap
+  assert.match(accept, /received/, 'the accept must not be eaten by the bare !offer');
+  assert.deepEqual((await getPlayer(taker.id)).inventory, [ITEM], 'and the gift actually lands');
+});
+
+runOrSkip('offer: a fumbled sub-verb does not swallow the retype', async () => {
+  await say(giver, `!offer @${taker.login} ${ITEM}`);
+  const typo = await say(taker, '!offer acept');
+  assert.match(typo, /pending offer/i, 'a typo with an exchange open points at the response verbs');
+  assert.doesNotMatch(typo, /usage: !offer @user/, 'not the open-a-new-one syntax');
+  assert.match(await say(taker, '!offer accept'), /received/);
+  assert.deepEqual((await getPlayer(taker.id)).inventory, [ITEM]);
+});
+
+runOrSkip('offer: the same sub-verb repeated IS still rate-limited, and says so in the log', async () => {
+  await say(giver, `!offer @${taker.login} ${ITEM}`);
+  assert.match(await say(taker, '!offer accept'), /received/);
+  assert.equal(await say(taker, '!offer accept'), '', 'a second accept is dropped — that is what the cooldown is for');
+  assert.deepEqual(
+    drops.map((d) => `${d.command}:${d.sub}`), ['offer:accept'],
+    'and a dropped command is never silent in the logs',
+  );
+});
+
+runOrSkip('cooldown is per sub-verb only where a command opts in', async () => {
+  await seedCuratedFacts();
+  assert.match(await say(taker, '!fact'), /./, 'first !fact answers');
+  assert.equal(await say(taker, '!fact 2'), '', '!fact does not opt in — the whole command shares one window');
+  assert.deepEqual(drops.map((d) => d.command), ['fact']);
+});
+
+runOrSkip('cooldowns are per user, not global', async () => {
+  await say(giver, `!offer @${taker.login} ${ITEM}`);
+  // The giver just used !offer; the taker's own !offer must be unaffected.
+  assert.match(await say(taker, '!offer'), /Offer:/);
+  assert.deepEqual(drops, [], 'nothing was dropped');
+});

--- a/test/cooldown.test.js
+++ b/test/cooldown.test.js
@@ -26,10 +26,14 @@ const giver = { id: 'u_cd_giver', login: 'nikkibreanne', name: 'NikkiBreAnne' };
 const taker = { id: 'u_cd_taker', login: 'okrafan', name: 'OkraFan' };
 
 const sent = [];
-const drops = []; // what the dispatcher logged when it dropped a command
+const drops = [];   // what the dispatcher logged when it dropped a command
+const unknown = []; // …and when it ignored one it doesn't know
 const logger = {
   info() {}, warn() {}, error() {},
-  debug: (msg, meta) => { if (String(msg).includes('cooldown')) drops.push(meta); },
+  debug: (msg, meta) => {
+    if (String(msg).includes('cooldown')) drops.push(meta);
+    if (String(msg).includes('unknown command')) unknown.push(meta);
+  },
 };
 const sender = { say: (t) => { sent.push(t); return Promise.resolve(); }, action: () => Promise.resolve() };
 
@@ -58,6 +62,7 @@ after(async () => { if (host) await closeFirebase(); });
 beforeEach(async () => {
   if (!host) return;
   drops.length = 0;
+  unknown.length = 0;
   for (const p of ['players', 'usernames', 'trades', 'wallets', 'counters', 'facts']) {
     await database().ref(p).remove().catch(() => {});
   }
@@ -101,6 +106,18 @@ runOrSkip('cooldown is per sub-verb only where a command opts in', async () => {
   assert.match(await say(taker, '!fact'), /./, 'first !fact answers');
   assert.equal(await say(taker, '!fact 2'), '', '!fact does not opt in — the whole command shares one window');
   assert.deepEqual(drops.map((d) => d.command), ['fact']);
+});
+
+runOrSkip('an unknown command stays quiet in chat but leaves a trace in the log', async () => {
+  // `!accept` is what a viewer types when the bot says "Reply: !offer accept".
+  // Answering every stray `!` would be noise (the channel runs other bots), so
+  // silence in CHAT is right — silence in the LOGS is what made this undebuggable.
+  await say(giver, `!offer @${taker.login} ${ITEM}`);
+  assert.equal(await say(taker, '!accept'), '', 'no reply — other bots own their own commands');
+  assert.deepEqual(
+    unknown.map((u) => u.command), ['accept'],
+    'but the bot must record that it saw and ignored it',
+  );
 });
 
 runOrSkip('cooldowns are per user, not global', async () => {


### PR DESCRIPTION
Two distinct ways `!offer accept` could do nothing, both reported as "it didn't
work and there was nothing in the logs". Reproduced against the emulator through
the real dispatcher.

## 1. A typo in the command NAME is completely silent

A typo in the *sub-verb* is handled. A typo in the *command name* — or the
obvious `!accept` — hits `if (!def) return` and vanishes:

| typed | result |
|---|---|
| `!offer accept` · `!gift accept` · `!offer yes` · `!offer ok` · odd spacing/caps | ✅ gift lands |
| `!offer acept` · `!offer accpet` | 💬 replies, naming the right verbs |
| **`!accept`** | 🔇 **silent, nothing logged** |
| `!ofer accept` · `!offert accept` · `offer accept` | 🔇 **silent, nothing logged** |

`!accept` is what a viewer types when the bot itself says *"Reply: !offer
accept"*. Staying quiet in **chat** is still correct — the channel runs other
bots and answering every stray `!` would be noise. Staying quiet in the **logs**
is not: unknown and mod-gated commands are now logged at debug, so next time this
is one grep instead of a guess.

## 2. The cooldown could swallow a legitimate accept

The per-user cooldown was keyed on `(user, command)`, so *any* `!offer …` message
opened a 3-second window in which the next one was dropped — silently:

```
bot   🎁 @okrafan — @Nikki offers you Thornnettle Dirk … Reply: !offer accept
fan   !offer            ← "what am I being given?"   (starts the 3s window)
fan   !offer accept     ← DROPPED. no reply, no log.
```

| sequence | before | after |
|---|---|---|
| `!offer` → `!offer accept` | silence, gift lost | gift lands |
| `!offer acept` → `!offer accept` | silence, gift lost | gift lands |
| `!offer accept` → `!offer accept` | silence | still dropped (correct) |

Fixed by keying the cooldown per **sub-verb** for commands that opt in
(`cooldownPerSubcommand` — `!offer` and `!trade`), which keeps what the cooldown
is for (the same command repeated) while letting a reply to the bot's own prompt
through. Cooldown drops are logged too.

Also: an unrecognised sub-verb used to fall through to "open a new exchange" and
answer with `usage: !offer @user <item>` — useless to someone who mistyped
`accept`. With an exchange pending it now names the response verbs.

**The exchange engine itself was never at fault** — every path in `!offer`
settles correctly, including gifts by bag number, by display name, and to a
recipient with no character (which replies properly).

## `!kennycommands` no longer links the repo

Dropped `source: github.com/nikkibreanne/kennyBot`. No command emits a repo link
now, and the reason is recorded in the file so it doesn't creep back.

## Why no test caught either

Nothing covered dispatcher-level behaviour, because **every existing test
deliberately sidesteps it** and says so in its own comments: the e2e harness
rebuilds the dispatcher per message, and `mute.test.js` uses a fresh user id per
send. New `test/cooldown.test.js` drives **one persistent handler**, like
production, and covers both failing sequences end to end (asserting the item
actually lands in the bag), that a repeated sub-verb is still limited, that a
non-opted-in command still shares one window, and that ignored commands are
logged.

139 offline / 75 emulator / 31 e2e passing.

> **Decided (owner):** `accept` / `decline` stay **sub-verbs**. Bare `!accept` /
> `!decline` are deliberately not registered — the channel runs other bots, and
> claiming names that common risks two bots answering one message. A viewer
> typing `!accept` therefore gets nothing; that is intended, and the debug log
> added here is what keeps it diagnosable. Recorded in the README's decisions
> section so it isn't re-proposed.
