### PR TITLE
ci: move the release actions to Node 24 and silence a false-positive lint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       # docker-container driver — required to attach the SBOM/provenance attestations below.
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,14 @@
 #
 # Both paths call the same reusable docker-publish.yml, so the image is built
 # identically however the release was cut.
+#
+# DEFERRED (owner, 2026-08-10): a `workflow_dispatch` DRY RUN — build the image
+# but pass `push: false` — so a Dockerfile or build-pipeline change can be
+# exercised without cutting a release. Today neither path is reachable from a PR
+# (docker-publish.yml is workflow_call-only; this one needs a pushed v* tag), so
+# a change like the setup-buildx major bump is first exercised BY the release it
+# could break. Deliberately not built yet: it adds a manually-triggerable job
+# with `packages: write` in scope, and the current risk is judged acceptable.
 name: publish
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       tag: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# check=skip=SecretsUsedInArgOrEnv
+#
+# ^ BuildKit's secret-in-ENV lint matches on the NAME, and `TOKEN_STORE_DIR` is a
+# directory path (/data), not a credential — a false positive. Skipped so the
+# build log stays clean enough that a real warning is noticeable. The tradeoff is
+# that the rule is off for this whole file, which is acceptable only because no
+# secret is ever baked in here: every credential is runtime-injected (see the
+# README's environment contract), and the image ships none.
+#
 # kennyBot runtime image (IMPLEMENTATION §C). Multi-stage, slim, non-root.
 # Outbound-only — the bot listens on nothing, so there is no EXPOSE / -p.
 #


### PR DESCRIPTION
The three warnings on the release job. Short answer: **two are worth fixing, one
is a false positive worth silencing.**

## 1 & 2 — Node 20 deprecation (worth fixing)

Nothing is broken today: GitHub force-runs both actions on Node 24 already. But
the deprecation ends in a **hard failure**, and it lands on the *release* path —
which fails at the worst possible moment and blocks publishing an image. Better
bumped deliberately now than under a deadline.

Both are safe for how this repo uses them, checked rather than assumed:

| action | bump | why it's safe here |
|---|---|---|
| `googleapis/release-please-action` | v4 → **v5** | v5.0.0's *only* breaking change is the node24 upgrade. Verified in the v5 `action.yml` that `config-file` / `manifest-file` still exist, and in its source that it still emits `release_created`, `tag_name` (kept explicitly for back-compat) and `version` — the three outputs `release.yml` reads. |
| `docker/setup-buildx-action` | v3 → **v4** | v4.0.0 is node24 + *"remove deprecated inputs/outputs"*. We invoke it with **no inputs at all**, so that half can't affect us. |

Dependabot would have proposed these eventually (github-actions, monthly), but a
*major* bump needs the compatibility check above either way.

## 3 — `SecretsUsedInArgOrEnv` (false positive)

`ENV TOKEN_STORE_DIR=/data` is a **directory path, not a credential** — the rule
matches on the name containing "TOKEN". Silenced with a check directive so the
build log stays clean enough that a real warning gets noticed.

The tradeoff is recorded in the Dockerfile: the rule is now off for the whole
file. That's acceptable only because nothing secret is ever baked into this image
— every credential is runtime-injected (README environment contract). The
alternative, renaming the env var, would break any deployment that sets it, for a
cosmetic lint.

## Verified

Docker on the dev machine was upgraded mid-review (buildx v0.36), so the
Dockerfile change is now checked rather than argued:

```
main's Dockerfile      → Check complete, 1 warning has been found!
                         SecretsUsedInArgOrEnv … (ENV "TOKEN_STORE_DIR") line 29
this branch            → Check complete, no warnings found.
branch w/ BOGUS rule   → Check complete, 1 warning has been found!   ← warning RETURNS
```

That last line is the one that matters: with a deliberately wrong rule name the
warning comes back, so the directive is being **honoured for that specific rule**
rather than linting being switched off wholesale.

The image also still builds and its runtime contract is intact:

```
user=node  TOKEN_STORE_DIR=/data  NODE_ENV=production
drwxr-xr-x 2 node node /data
```

## Still unverified: the two action bumps

Those can't be exercised on a PR. `docker-publish.yml` is `workflow_call`-only
and `publish.yml` triggers solely on a pushed `v*` tag, so the first real run of
`release-please@v5` and `setup-buildx@v4` is **the next release**. The
compatibility review above (inputs, outputs, and the fact that buildx is invoked
with no inputs) is what stands in for a test run.

That gap is pre-existing. **Deferred by the owner** rather than built here, and
recorded as a note in `publish.yml` — where the dry-run would live — so the
reason the release path can't be exercised from a PR is discoverable at the
point someone next hits it, instead of being rediscovered from scratch.

The `ci / test` check here passes, but note it only proves the Node suite still
runs; it does not touch either changed workflow.

