### PR TITLE
ci: run the merge gate on dev as well as main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
-# Continuous integration — the merge gate for `main`.
+# Continuous integration — the merge gate for `main` and `dev`.
 #
 # Runs the full test suite (unit + Firebase-rules emulator + end-to-end command
-# dispatch) on every pull request into main and every push to main. Branch
-# protection on `main` requires this workflow's `test` check to pass before a PR
-# can merge, so a change that breaks any command can't land.
+# dispatch) on every pull request into those branches and every push to them.
+# Branch protection requires this workflow's `test` check to pass before a PR can
+# merge, so a change that breaks any command can't land.
+#
+# `dev` MUST be listed here. A protected branch whose required check never
+# triggers is a branch nothing can ever merge into — the PR sits at "no checks
+# reported" forever. That is not hypothetical: a PR stacked on a feature branch
+# hit exactly this and had to be rebased onto main to get any CI at all.
 #
 # `publish.yml` reuses this exact job via `workflow_call`, so a release tag can't
 # build an image that skipped the suite — one source of truth for "the tests".
@@ -11,9 +16,9 @@ name: ci
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
   workflow_call: {} # let publish.yml run this same job before building the image
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,11 @@ name: pr-title
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-    branches: [main]
+    # `dev` too: it is protected with this same required check, and a required
+    # check that never runs blocks every PR into that branch permanently. It also
+    # keeps the titles conventional all the way down, so the eventual dev → main
+    # PR is assembled from commits release-please can already read.
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ name: release
 
 on:
   push:
+    # main ONLY — deliberately not `dev`. An integration branch that cut a release
+    # on every push would tag and publish half-finished work; dev reaches the world
+    # by merging into main, which is what triggers this.
     branches: [main]
 
 permissions: {} # nothing by default; each job asks for exactly what it needs


### PR DESCRIPTION
Prerequisite for standing up a protected `dev` integration branch.

`dev` will carry the same required status checks as `main` (`test`, `pr-title`).
Both of those workflows were scoped to `branches: [main]`, so a PR into `dev`
would have triggered **neither** — and a protected branch whose required checks
never run can never be merged into. The PR just sits at "no checks reported".

That failure mode already bit this repo once: PR #54 was stacked on a feature
branch, got no CI at all, and had to be rebased onto main to become mergeable.

## Changes

- `ci.yml` — `pull_request` and `push` now include `dev`.
- `pr-title.yml` — `pull_request` now includes `dev`, so titles stay
  conventional all the way down and the eventual `dev` → `main` PR is built
  from commits release-please can already parse.
- `release.yml` — **unchanged behaviour**, comment only: it stays `main`-only,
  now stating why. An integration branch that released on every push would tag
  and publish half-finished work.

## Verification

All three workflow files parse, and the resolved triggers are what's intended:

    ci.yml       on= {"pull_request":{"branches":["main","dev"]},"push":{"branches":["main","dev"]},"workflow_call":{}}
    pr-title.yml on= {"pull_request":{"types":[...],"branches":["main","dev"]}}
    release.yml  on= {"push":{"branches":["main"]}}

This PR is itself the check — it targets `main`, so `test` and `pr-title` run
here as usual. `dev`'s protection is applied only after this lands, so the
required checks exist before anything depends on them.
