### PR TITLE
feat: !media — play a mapped OBS media source from chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Underneath both:
 - **automated releases** from Conventional Commits (release-please), with `main`
   protected for everyone including admins
 
-Verified by `npm test` (159 offline unit tests), `npm run test:emulator` (75 — RTDB
+Verified by `npm test` (166 offline unit tests), `npm run test:emulator` (75 — RTDB
 rules + client-write rejection, and the stateful command paths), `npm run test:e2e`
 (32 — every registered command driven through the real dispatcher), and
 `npm run synthetic` (full muster→battle→victory run with UI-contract assertions).
@@ -154,7 +154,8 @@ of the replay buffer.
 | `!media <n>` | mod | play the OBS media source mapped to slot `n`. Silent in chat on success — the sound *is* the reply; every failure answers |
 | `!media` | mod | list what's mapped |
 | `!media inputs` | mod | ask OBS which Media Sources exist, spelled exactly as it spells them |
-| `!media set <n> <source>` | mod | map a slot. The source name is the rest of the line, so spaces are fine |
+| `!media set <n> <a> \| <b>` | mod | map a slot to one or more sources. Names are the rest of the line (spaces fine); `\|` separates them, because a GIF and its sound are two sources in OBS and one alert in chat |
+| `!media add <n> <source>` | mod | append a source to an existing slot |
 | `!media scene <n> <scene\|none>` | mod | reveal the source in that scene before playing (for a visual alert); `none` stops revealing it |
 | `!media action <n> <action>` | mod | `restart` (default) · `play` · `pause` · `stop` · `next` · `previous` |
 | `!media clear <n>` | mod | unmap |
@@ -392,24 +393,35 @@ source mapped to slot 3; if that slot names a scene, the source is revealed ther
 first, so a visual alert works the same way a sound does.
 
 ```
-!media inputs                  what OBS actually has, spelled its way
-!media set 3 Airhorn SFX       slot 3 → that source
-!media scene 3 Alerts          reveal it in "Alerts" before playing (visual alerts)
-!media action 3 stop           restart (default) · play · pause · stop · next · previous
-!media 3                       fire it
+!media inputs                        what OBS actually has, spelled its way
+!media set 3 alert-gif | alert-mp3   slot 3 → both, fired together
+!media add 3 extra-sound             append to an existing slot
+!media scene 3 Alerts                reveal them in "Alerts" first (only if hidden)
+!media action 3 stop                 restart (default) · play · pause · stop · next · previous
+!media 3                             fire it
 ```
+
+**One slot, several sources.** OBS keeps a GIF and its sound as separate Media
+Sources, so an alert is normally two of them. A slot fires up to five, and the
+triggers go out in a single batch rather than one await at a time — putting a
+round trip between the picture and the sound is audible. Every scene reveal
+happens before any trigger, for the same reason.
 
 **A successful play says nothing in chat.** The sound is the feedback, and an alert
 that also posts a line is clutter. Every *failure* replies — so silence means OBS
-accepted the request, and if you then heard nothing the problem is on the OBS side
-(source muted, hidden, or its file missing).
+accepted the request. Verified against a real OBS: a name that doesn't exist, a
+scene that doesn't exist, and a slot where only *one* of two names is wrong all
+throw and reach chat with the offending name in the message. The one failure OBS
+cannot report is a **muted or zero-volume source** — that answers success and is
+heard by nobody, so it's the first thing to check when a slot goes quiet.
 
 There is deliberately **no overlay page and no message bus**. That architecture is
 what a hosted alert service has to use, because it cannot reach your OBS — this bot
 can, and a web page plus a transport to reach it would be strictly more moving parts
 than the one request that already works. OBS keeps ownership of compositing, audio
-routing and *Hide source when playback ends*, which is also why nothing here holds a
-"hide it later" timer.
+routing and *Show nothing when playback ends* (`clear_on_media_end`, on by default),
+which is also why nothing here holds a "hide it later" timer — and why a source can
+simply be left visible instead of needing a scene at all.
 
 Slots live in RTDB (`config/media/<n>`) for the same reason the clip mode does:
 these names change whenever a source is renamed in OBS, and re-deploying a container
@@ -420,7 +432,9 @@ from `node scripts/obs-media.mjs` before the bot is even deployed.
 
 Mod-only, and no cooldown: a soundboard's value is landing on the beat, sometimes
 twice. Unlike `!clip`'s local capture — hundreds of MB per trigger, hence its own
-rate limit — a media action costs OBS nothing.
+rate limit — a media action costs OBS nothing. A connection is opened **per
+trigger**; ten fired at once completed in 197ms with none dropped, which is well
+past what a soundboard produces.
 
 **Not yet wired to Twitch events.** Firing on cheers, subs or channel-point
 redemptions needs EventSub topics and broadcaster scopes this bot does not hold

--- a/README.md
+++ b/README.md
@@ -436,6 +436,14 @@ rate limit — a media action costs OBS nothing. A connection is opened **per
 trigger**; ten fired at once completed in 197ms with none dropped, which is well
 past what a soundboard produces.
 
+**Re-firing does not stack, and that is why there is no queue.** A Media Source has
+a single playback instance, so `restart` on a source already playing resets it to
+frame one — measured against a real OBS, the cursor dropped from 470ms to 104ms on
+the second trigger. Ten rapid triggers of one slot are one audible play, not ten.
+Different slots *do* overlap, since they are different sources. A queue would only
+matter if alerts should wait their turn rather than interrupt, which for a mod
+soundboard is the wrong behaviour anyway.
+
 **Not yet wired to Twitch events.** Firing on cheers, subs or channel-point
 redemptions needs EventSub topics and broadcaster scopes this bot does not hold
 today (it subscribes to `stream.online`/`offline` only, and prod runs on a Helix

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Firebase and OBS, and never listens on a port — and ships as a container.
 | Feature | Commands | Notes |
 |---|---|---|
 | **Clips** | `!clip` · `!clipmode` · `!start` | 16:9 + natively-framed 9:16 captured on the streamer's PC over obs-websocket / Aitum |
+| **On-stream media** | `!media` | play a mapped OBS media source from chat — the same connection, pointed at a source instead of the buffer |
 | **Stream timer** | `!timer` | one countdown, heads-up marks, survives a restart |
 | **Reminders** | `!reminder` | schedules are RTDB records, not code — daily / after-live / interval |
 | **To-do board** | `!todo` | chat-controlled, rendered on [/todo/](https://okrafans.com/todo/) |
@@ -52,6 +53,8 @@ Implemented and verified — stream side:
 - **`!clip` capture**: horizontal 16:9 + natively-framed vertical 9:16 saved on the
   streamer's PC over obs-websocket / Aitum, with a runtime-switchable clip mode —
   see [Clip capture](#clip-capture)
+- **`!media`**: play a mapped OBS media source from chat (sounds, alert clips) over
+  that same obs-websocket connection — see [Playing media on stream](#playing-media-on-stream--media)
 - **`!timer`**: one mod-set countdown with heads-up marks, stored as a deadline so
   a restart resumes it
 - **`!reminder`**: scheduled nudges whose schedules are RTDB records, editable from
@@ -82,9 +85,9 @@ Underneath both:
 - **automated releases** from Conventional Commits (release-please), with `main`
   protected for everyone including admins
 
-Verified by `npm test` (139 offline unit tests), `npm run test:emulator` (69 — RTDB
+Verified by `npm test` (159 offline unit tests), `npm run test:emulator` (75 — RTDB
 rules + client-write rejection, and the stateful command paths), `npm run test:e2e`
-(31 — every registered command driven through the real dispatcher), and
+(32 — every registered command driven through the real dispatcher), and
 `npm run synthetic` (full muster→battle→victory run with UI-contract assertions).
 
 **Not yet done:** a full-session local recording (see
@@ -101,6 +104,7 @@ Twitch (chat WSS, Helix, EventSub WSS)  ──►  kennyBot (Node, twurple)  ─
                                                    │
                                                    ▼  obs-websocket, over the tailnet
                                      streamer's OBS + Aitum  ──►  16:9 + 9:16 files on their PC
+                                                                  media sources played on stream
 ```
 
 The bot is outbound-only in both directions: it *dials* Twitch, Firebase and OBS,
@@ -115,17 +119,19 @@ src/
   content/                your own data: classes.js (class→role), items.js (catalog +
                           starter gear), facts.js, reminders.js (default schedules)
   rules/                  PURE, RNG/clock-injected, unit-tested: leveling, rating, loot,
-                          combat, reminders (what's due now)
+                          combat, reminders (what's due now), media (slot parsing/validation)
   db/                     firebase, configStore (live mirror), players, raid, drops, wallet,
-                          market, timer, reminders, todo, facts, lock, tokenStore
+                          market, timer, reminders, media, todo, facts, lock, tokenStore
   twitch/                 auth (RefreshingAuthProvider), liveGate (Helix poll), eventsub (WS),
                           sender (Helix/IRC send + badge), clips (Helix Create Clip)
-  integrations/           obsWebsocket (v5 client + Aitum vendor requests), capture (facade + rate limit)
+  integrations/           obsWebsocket (v5 client + Aitum vendor requests), capture (facade +
+                          rate limit), obsMedia (media actions on the same socket)
   events/                 chat (gate→EXP→raid tick + dispatch), twitchEvents (sub/cheer/raid),
                           dropScheduler · timerScheduler · reminderScheduler
   commands/               one module per command + registry; mod/ subdir for mod commands
 test/                     rules/*.test.js (offline) · firebase-rules.test.js (emulator) · e2e/ (dispatcher)
 scripts/synthetic-chat.js no-stream harness that drives the whole loop
+scripts/obs-media.mjs     list/fire OBS media sources without the bot running
 ```
 
 ## Chat commands
@@ -139,6 +145,19 @@ scripts/synthetic-chat.js no-stream harness that drives the whole loop
 | `!clip` | everyone | capture the last ~60s — 16:9 + 9:16 local files by default; a Twitch clip only if the mode says so |
 | `!clipmode <targets>` | mod | pick which of `!clip`'s three outputs run — `horizontal` · `vertical` · `twitch`, combined freely (see below) |
 | `!start` / `!slate` | mod | set a stream sync point for the clip archiver |
+
+**On-stream media** — the same OBS connection, pointed at a media source instead
+of the replay buffer.
+
+| Command | Who | Effect |
+|---|---|---|
+| `!media <n>` | mod | play the OBS media source mapped to slot `n`. Silent in chat on success — the sound *is* the reply; every failure answers |
+| `!media` | mod | list what's mapped |
+| `!media inputs` | mod | ask OBS which Media Sources exist, spelled exactly as it spells them |
+| `!media set <n> <source>` | mod | map a slot. The source name is the rest of the line, so spaces are fine |
+| `!media scene <n> <scene\|none>` | mod | reveal the source in that scene before playing (for a visual alert); `none` stops revealing it |
+| `!media action <n> <action>` | mod | `restart` (default) · `play` · `pause` · `stop` · `next` · `previous` |
+| `!media clear <n>` | mod | unmap |
 
 **Around the stream**
 
@@ -364,6 +383,50 @@ second place that can disagree with it.
 `!clipmode status` reports the mode *and* whether each half can actually run, and a
 switch to a mode nothing is configured for warns immediately rather than leaving a
 viewer to discover it.
+
+### Playing media on stream — `!media`
+
+The same obs-websocket connection that saves replay buffers can also **play a media
+source**, which is all an on-stream alert actually is. `!media 3` restarts the OBS
+source mapped to slot 3; if that slot names a scene, the source is revealed there
+first, so a visual alert works the same way a sound does.
+
+```
+!media inputs                  what OBS actually has, spelled its way
+!media set 3 Airhorn SFX       slot 3 → that source
+!media scene 3 Alerts          reveal it in "Alerts" before playing (visual alerts)
+!media action 3 stop           restart (default) · play · pause · stop · next · previous
+!media 3                       fire it
+```
+
+**A successful play says nothing in chat.** The sound is the feedback, and an alert
+that also posts a line is clutter. Every *failure* replies — so silence means OBS
+accepted the request, and if you then heard nothing the problem is on the OBS side
+(source muted, hidden, or its file missing).
+
+There is deliberately **no overlay page and no message bus**. That architecture is
+what a hosted alert service has to use, because it cannot reach your OBS — this bot
+can, and a web page plus a transport to reach it would be strictly more moving parts
+than the one request that already works. OBS keeps ownership of compositing, audio
+routing and *Hide source when playback ends*, which is also why nothing here holds a
+"hide it later" timer.
+
+Slots live in RTDB (`config/media/<n>`) for the same reason the clip mode does:
+these names change whenever a source is renamed in OBS, and re-deploying a container
+to rename a sound is not a thing anyone does mid-stream. They ship **empty** — a
+default slot would name a source that exists on no particular machine, and a slot
+pointing at nothing fails live, in front of chat. Map them from `!media inputs`, or
+from `node scripts/obs-media.mjs` before the bot is even deployed.
+
+Mod-only, and no cooldown: a soundboard's value is landing on the beat, sometimes
+twice. Unlike `!clip`'s local capture — hundreds of MB per trigger, hence its own
+rate limit — a media action costs OBS nothing.
+
+**Not yet wired to Twitch events.** Firing on cheers, subs or channel-point
+redemptions needs EventSub topics and broadcaster scopes this bot does not hold
+today (it subscribes to `stream.online`/`offline` only, and prod runs on a Helix
+poll because the broadcaster token isn't the channel owner's). The mechanism comes
+first; the trigger is separate work.
 
 The one point of contact is `!start` (`src/db/clipSync.js`), which writes a per-stream
 sync anchor to RTDB — *data the archiver reads*, not a file handoff, and it works

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -44,6 +44,7 @@ so a mod can change them **while the bot is running**. These are the
 | **Clip mode** — which of `!clip`'s outputs run | `!clipmode horizontal vertical twitch` · `!clipmode local\|all\|off` · `!clipmode status` | `config/clipMode` |
 | **Stream timer** — the one mod countdown | `!timer 10m [label]` · `!timer +5` · `!timer -2m` · `!timer pause` / `resume` · `!timer stop` | `config/timer` |
 | **Reminders** — schedules, text, on/off | `!reminder` · `!reminder at ghosty 08:00 17:00` · `!reminder every hydration 60` · `!reminder off <id>` | `config/reminders/<id>` |
+| **Media slots** — number → OBS media source | `!media inputs` · `!media set 3 <source>` · `!media scene 3 <scene>` · `!media action 3 stop` · `!media clear 3` | `config/media/<n>` |
 | **Live status** (set automatically by Twitch) | _(no command — EventSub / Helix poll set it)_ | `config/live` |
 | **Active season** | `!season start <id>` · `!season rollover <id>` | `config/season/current` |
 | **Active raid / boss / phase** | `!boss set <name>` · `!boss next` · `!raidnight` | `config/raid`, `bosses/...` |
@@ -228,6 +229,43 @@ missing.
 > Clip **length** is not configured here, or anywhere in kennyBot — it comes from
 > OBS's Replay Buffer and Aitum's Backtrack settings on the streamer's PC. See
 > [`clip-architecture.md`](clip-architecture.md).
+
+---
+
+## `!media` — playing an OBS media source from chat
+
+**There is nothing to configure in `config.js`.** Media slots are runtime-only
+records at `config/media/<n>`, mapped from chat with `!media set` — and unlike the
+clip mode they ship **empty**, with no seed at all. A default slot would name an OBS
+source that exists on no particular machine, and a slot pointing at nothing fails
+live, in front of chat.
+
+| Field | Required | What it is |
+|---|---|---|
+| `input` | yes | the OBS **source name**, character for character as OBS spells it |
+| `scene` | no | a scene to reveal that source in *before* playing — this is what makes a visual alert work; omit it for sounds that are always in the active scene |
+| `action` | no | `restart` (default) · `play` · `pause` · `stop` · `next` · `previous` |
+| `label` | no | a human name, so `!media` reads as more than numbers |
+
+Slot numbers run 1–20. `restart` is the default because it plays from the first
+frame whether the source is idle, mid-playback or already **finished** — and
+"finished" is the state an alert sits in almost all the time, where plain `play`
+does nothing at all.
+
+**Getting the names right is the whole job.** They must match OBS exactly, so use
+`!media inputs` (or `node scripts/obs-media.mjs`, which needs only the two `OBS_*`
+env vars and not a running bot) rather than typing them from memory.
+
+Two behaviours worth knowing:
+
+- **A successful play is silent in chat.** The sound is the feedback. Every failure
+  replies — so silence means OBS accepted the request, and if you heard nothing the
+  problem is on the OBS side.
+- **Hiding the source again is OBS's job**, via the Media Source property *Hide
+  source when playback ends*. kennyBot deliberately holds no "hide it later" timer.
+
+Connection comes from the same `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` the
+clip capture uses — one OBS, one place to configure it.
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -242,7 +242,7 @@ live, in front of chat.
 
 | Field | Required | What it is |
 |---|---|---|
-| `input` | yes | the OBS **source name**, character for character as OBS spells it |
+| `inputs` | yes | one or more OBS **source names**, character for character as OBS spells them, fired together. OBS keeps a GIF and its sound as separate sources, so an alert is normally two entries. Max 5 |
 | `scene` | no | a scene to reveal that source in *before* playing — this is what makes a visual alert work; omit it for sounds that are always in the active scene |
 | `action` | no | `restart` (default) · `play` · `pause` · `stop` · `next` · `previous` |
 | `label` | no | a human name, so `!media` reads as more than numbers |
@@ -254,15 +254,22 @@ does nothing at all.
 
 **Getting the names right is the whole job.** They must match OBS exactly, so use
 `!media inputs` (or `node scripts/obs-media.mjs`, which needs only the two `OBS_*`
-env vars and not a running bot) rather than typing them from memory.
+env vars and not a running bot) rather than typing them from memory. Renaming a
+source in OBS silently breaks any slot pointing at it — the next fire replies with
+the missing name, which is the intended failure.
 
 Two behaviours worth knowing:
 
 - **A successful play is silent in chat.** The sound is the feedback. Every failure
   replies — so silence means OBS accepted the request, and if you heard nothing the
   problem is on the OBS side.
-- **Hiding the source again is OBS's job**, via the Media Source property *Hide
-  source when playback ends*. kennyBot deliberately holds no "hide it later" timer.
+- **Hiding the source again is OBS's job**, via the Media Source property *Show
+  nothing when playback ends* (setting key `clear_on_media_end`, **on by default**).
+  kennyBot deliberately holds no "hide it later" timer. Because that default already
+  blanks a finished source, you can leave the scene item permanently visible and skip
+  the `scene` field entirely — which is the recommended setup.
+- **A muted or zero-volume source still reports success.** OBS gives no way to tell,
+  so that is the first thing to check when a slot fires and nobody hears anything.
 
 Connection comes from the same `OBS_WEBSOCKET_URL` / `OBS_WEBSOCKET_PASSWORD` the
 clip capture uses — one OBS, one place to configure it.

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import { buildAuth } from './src/twitch/auth.js';
 import { createSender } from './src/twitch/sender.js';
 import { initClips } from './src/twitch/clips.js';
 import { initCapture, captureReady } from './src/integrations/capture.js';
+import { initMedia } from './src/integrations/obsMedia.js';
 // Read once at boot purely to log what's in force; the live value is RTDB-backed.
 import { activeClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
@@ -212,6 +213,12 @@ async function main() {
   // Local full-quality capture on the streamer's PC (obs-websocket over the
   // tailnet), reached whenever !clip's mode includes the local half.
   initCapture({}, logger);
+
+  // Media actions on that SAME OBS — `!media <n>` plays a mapped source. Separate
+  // init because it is a separate feature with its own failure mode, but it
+  // deliberately resolves the same connection: two ideas of where OBS lives is
+  // one more than can ever be right.
+  initMedia({}, logger);
 
   // What !clip actually does. Default 'local': trigger the streamer's OBS/Aitum
   // capture and post NO Twitch clip — a Twitch clip is capped at the stream

--- a/scripts/obs-media.mjs
+++ b/scripts/obs-media.mjs
@@ -1,0 +1,78 @@
+// scripts/obs-media.mjs — set up `!media` slots without needing the bot running.
+//
+// Slot mapping only works if the OBS source names are EXACT, and typing them from
+// memory is how you get a slot that looks mapped and plays nothing. This asks OBS
+// what it actually has, and lets you fire one to confirm before mapping it.
+//
+//   node scripts/obs-media.mjs                          list Media Sources
+//   node scripts/obs-media.mjs --all                    list every input, with kinds
+//   node scripts/obs-media.mjs --scenes                 list scenes
+//   node scripts/obs-media.mjs --play "Airhorn SFX"     fire one, right now
+//   node scripts/obs-media.mjs --play "GIF" --scene "Alerts" --action restart
+//
+// Reads OBS_WEBSOCKET_URL / OBS_WEBSOCKET_PASSWORD from .env, the same two vars
+// the bot uses — so if this works, `!media` will too, and if it doesn't, the
+// problem is the connection rather than anything in the bot.
+import 'dotenv/config';
+import { withObs, obsConnectionFromEnv } from '../src/integrations/obsWebsocket.js';
+import { mediaSequence } from '../src/integrations/obsMedia.js';
+import { MEDIA_ACTIONS, DEFAULT_ACTION } from '../src/rules/media.js';
+
+const conn = obsConnectionFromEnv();
+if (!conn) {
+  console.error('Need OBS_WEBSOCKET_URL (and usually OBS_WEBSOCKET_PASSWORD) in .env');
+  console.error('e.g. OBS_WEBSOCKET_URL=ws://<obs-host>:4455');
+  process.exit(1);
+}
+
+const arg = (flag) => {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const has = (flag) => process.argv.includes(flag);
+
+const play = arg('--play');
+const scene = arg('--scene') ?? null;
+const action = arg('--action') ?? DEFAULT_ACTION;
+
+if (play && !MEDIA_ACTIONS.includes(action)) {
+  console.error(`--action must be one of: ${MEDIA_ACTIONS.join(', ')}`);
+  process.exit(1);
+}
+
+try {
+  await withObs(conn, async (request) => {
+    if (play) {
+      const res = await mediaSequence(request, { input: play, scene, action });
+      console.log(`▶ ${action} "${play}"${scene ? ` (revealed in "${scene}")` : ''}`);
+      console.log(res.shown ? '  scene item enabled first' : '  no scene handling — source must already be visible');
+      // OBS accepts a media action against a source whose FILE is missing without
+      // complaint, so this says what was sent, not that anything was heard.
+      console.log('  OBS accepted the request. If you heard nothing, check the source in OBS.');
+      return;
+    }
+
+    if (has('--scenes')) {
+      const { scenes = [] } = await request('GetSceneList');
+      console.log(`${scenes.length} scene(s):`);
+      for (const s of scenes) console.log(`  "${s.sceneName}"`);
+      return;
+    }
+
+    // ffmpeg_source IS the OBS "Media Source" kind — the only kind that answers a
+    // media action. --all exists for when a source is not where you expect it.
+    const kind = has('--all') ? null : 'ffmpeg_source';
+    const { inputs = [] } = await request('GetInputList', kind ? { inputKind: kind } : {});
+    if (!inputs.length) {
+      console.log(kind ? 'No Media Sources in OBS. Add one, or re-run with --all.' : 'OBS reports no inputs at all.');
+      return;
+    }
+    console.log(`${inputs.length} ${kind ? 'Media Source' : 'input'}(s) — map with: !media set <n> <name>`);
+    for (const i of inputs) {
+      console.log(has('--all') ? `  "${i.inputName}"  [${i.inputKind}]` : `  "${i.inputName}"`);
+    }
+  });
+} catch (err) {
+  console.error(`OBS: ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/obs-media.mjs
+++ b/scripts/obs-media.mjs
@@ -8,6 +8,7 @@
 //   node scripts/obs-media.mjs --all                    list every input, with kinds
 //   node scripts/obs-media.mjs --scenes                 list scenes
 //   node scripts/obs-media.mjs --play "Airhorn SFX"     fire one, right now
+//   node scripts/obs-media.mjs --play "GIF | Sound"      fire a whole slot together
 //   node scripts/obs-media.mjs --play "GIF" --scene "Alerts" --action restart
 //
 // Reads OBS_WEBSOCKET_URL / OBS_WEBSOCKET_PASSWORD from .env, the same two vars
@@ -16,7 +17,7 @@
 import 'dotenv/config';
 import { withObs, obsConnectionFromEnv } from '../src/integrations/obsWebsocket.js';
 import { mediaSequence } from '../src/integrations/obsMedia.js';
-import { MEDIA_ACTIONS, DEFAULT_ACTION } from '../src/rules/media.js';
+import { MEDIA_ACTIONS, DEFAULT_ACTION, parseInputList } from '../src/rules/media.js';
 
 const conn = obsConnectionFromEnv();
 if (!conn) {
@@ -43,9 +44,16 @@ if (play && !MEDIA_ACTIONS.includes(action)) {
 try {
   await withObs(conn, async (request) => {
     if (play) {
-      const res = await mediaSequence(request, { input: play, scene, action });
-      console.log(`▶ ${action} "${play}"${scene ? ` (revealed in "${scene}")` : ''}`);
-      console.log(res.shown ? '  scene item enabled first' : '  no scene handling — source must already be visible');
+      // Same `|` separator as `!media set`, so what you test here is what you map.
+      const inputs = parseInputList(play);
+      if (!inputs) {
+        console.error('--play needs one or more non-empty source names separated by |');
+        process.exitCode = 1;
+        return;
+      }
+      const res = await mediaSequence(request, { inputs, scene, action });
+      console.log(`▶ ${action} ${inputs.map((i) => `"${i}"`).join(' + ')}${scene ? ` (revealed in "${scene}")` : ''}`);
+      console.log(res.shown ? `  ${res.shown} scene item(s) enabled first` : '  no scene handling — sources must already be visible');
       // OBS accepts a media action against a source whose FILE is missing without
       // complaint, so this says what was sent, not that anything was heard.
       console.log('  OBS accepted the request. If you heard nothing, check the source in OBS.');

--- a/src/commands/mod/media.js
+++ b/src/commands/mod/media.js
@@ -1,0 +1,186 @@
+// !media (mod) — fire a mapped OBS media source from chat.
+//
+//   !media 3                     play slot 3
+//   !media                       list what's mapped
+//   !media inputs                ask OBS which media sources exist
+//   !media set 3 Airhorn         map slot 3 to the OBS input named "Airhorn"
+//   !media scene 3 Alerts        reveal it in the "Alerts" scene before playing
+//   !media scene 3 none          stop revealing it (it's always on screen)
+//   !media action 3 stop         change what "trigger" means for this slot
+//   !media clear 3               unmap
+//
+// This is the manual half of a StreamElements-style alert: the *play* mechanism,
+// driven by a mod typing a number. Wiring it to Twitch events (cheers, subs,
+// redemptions) is a separate piece of work and needs broadcaster scopes this bot
+// does not currently hold — the mechanism has to exist and be trusted first.
+//
+// Mod-only, deliberately. This makes noise over the stream, and a public version
+// is a way for chat to talk over the streamer. Opening it up is a decision to be
+// made once the slot map exists, not a default.
+//
+// Names are OBS's names, character for character. `!media inputs` exists because
+// typing them from memory is how you get a slot that looks mapped and plays
+// nothing — which is indistinguishable, live, from the bot being broken.
+//
+// CONTRACT: a successful play says NOTHING in chat — the sound is the feedback,
+// and an alert that also posts a line is just clutter. EVERY failure replies. So
+// silence means OBS accepted the request; if you then hear nothing, the problem
+// is on the OBS side (source muted, hidden, or its media file missing), not here.
+import { listSlots, getSlot, mapSlot, clearMediaSlot } from '../../db/media.js';
+import { describeSlot, parseSlot, MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT } from '../../rules/media.js';
+import { playMedia, listInputs, mediaReady } from '../../integrations/obsMedia.js';
+
+const ACTIONS = MEDIA_ACTIONS;
+const USAGE = `Usage: !media <1-${MAX_SLOT}> · set <n> <OBS source> · scene <n> <scene|none> · action <n> ${ACTIONS.join('|')} · clear <n> · inputs`;
+
+/** Why a write was refused, in words a mod can act on. */
+function refusal(reason) {
+  switch (reason) {
+    case 'bad-input': return 'that OBS source name is empty or too long';
+    case 'bad-scene': return 'that scene name is empty or too long';
+    case 'bad-action': return `action must be one of: ${ACTIONS.join(', ')}`;
+    case 'bad-label': return 'that label is empty or too long';
+    case 'unmapped': return 'that slot is not mapped yet — set it first';
+    default: return reason;
+  }
+}
+
+export default {
+  names: ['media'],
+  mod: true,
+  // No cooldown, like !clipmode and !timer. A soundboard's whole value is landing
+  // on the beat, sometimes twice — and a window here would also swallow the
+  // map-then-immediately-test workflow. It's mod-only, and unlike !clip's local
+  // capture (hundreds of MB per trigger, hence its own rate limit) a media action
+  // costs OBS nothing. Spam is a conversation to have with a mod, not a lockout.
+  cooldownMs: 0,
+  help: `!media <n> plays a mapped OBS source · set/scene/action/clear/inputs to map them — mod-only`,
+  async run({ args, reply, logger }) {
+    const [first, ...rest] = args;
+    const verb = String(first || '').toLowerCase();
+
+    // ── list ────────────────────────────────────────────────────────────────
+    if (!verb) {
+      const slots = listSlots();
+      if (!slots.length) {
+        reply(`no media slots mapped yet · ${USAGE}`);
+        return;
+      }
+      reply(`🎬 media: ${slots.map(describeSlot).join(' · ')}`);
+      return;
+    }
+
+    // ── inputs (discovery) ──────────────────────────────────────────────────
+    if (verb === 'inputs') {
+      if (!mediaReady()) {
+        reply('no OBS is configured for this bot, so there is nothing to list');
+        return;
+      }
+      // ffmpeg_source IS the OBS "Media Source" kind — the only one that answers
+      // media actions. Listing everything would offer sources that can never play.
+      const res = await listInputs('ffmpeg_source', logger);
+      if (!res.ok) {
+        reply(`could not reach OBS: ${res.reason}`);
+        return;
+      }
+      if (!res.inputs.length) {
+        reply('OBS answered, but it has no Media Sources — add one in OBS first');
+        return;
+      }
+      reply(`🎬 OBS media sources: ${res.inputs.map((i) => `"${i.name}"`).join(' · ')}`);
+      return;
+    }
+
+    // ── set <n> <name…> ─────────────────────────────────────────────────────
+    // The source name is the REST OF THE LINE, not one token: real OBS sources
+    // are called things like "Airhorn SFX".
+    if (verb === 'set') {
+      const n = parseSlot(rest[0]);
+      if (!n) {
+        reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
+        return;
+      }
+      const res = await mapSlot(n, { input: rest.slice(1).join(' ') });
+      if (!res.ok) {
+        reply(refusal(res.reason));
+        return;
+      }
+      reply(`🎬 slot ${describeSlot(res.slot)} — try it with !media ${n}`);
+      return;
+    }
+
+    // ── scene <n> <name…|none> ──────────────────────────────────────────────
+    if (verb === 'scene') {
+      const n = parseSlot(rest[0]);
+      if (!n) {
+        reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
+        return;
+      }
+      const raw = rest.slice(1).join(' ');
+      const res = await mapSlot(n, { scene: /^none$/i.test(raw.trim()) ? null : raw });
+      if (!res.ok) {
+        reply(refusal(res.reason));
+        return;
+      }
+      reply(`🎬 slot ${describeSlot(res.slot)}`);
+      return;
+    }
+
+    // ── action <n> <action> ─────────────────────────────────────────────────
+    if (verb === 'action') {
+      const n = parseSlot(rest[0]);
+      if (!n) {
+        reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
+        return;
+      }
+      const res = await mapSlot(n, { action: String(rest[1] || '').toLowerCase() });
+      if (!res.ok) {
+        reply(refusal(res.reason));
+        return;
+      }
+      reply(`🎬 slot ${describeSlot(res.slot)}`);
+      return;
+    }
+
+    // ── clear <n> ───────────────────────────────────────────────────────────
+    if (verb === 'clear') {
+      const n = parseSlot(rest[0]);
+      if (!n) {
+        reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
+        return;
+      }
+      if (!getSlot(n)) {
+        reply(`slot ${n} was not mapped`);
+        return;
+      }
+      await clearMediaSlot(n);
+      reply(`🎬 slot ${n} cleared`);
+      return;
+    }
+
+    // ── play <n> ────────────────────────────────────────────────────────────
+    const n = parseSlot(verb);
+    if (!n) {
+      reply(USAGE);
+      return;
+    }
+    const slot = getSlot(n);
+    if (!slot) {
+      reply(`slot ${n} is not mapped — !media set ${n} <OBS source name>`);
+      return;
+    }
+    if (!mediaReady()) {
+      reply('no OBS is configured for this bot, so nothing can play');
+      return;
+    }
+
+    const res = await playMedia(slot, logger);
+    if (!res.ok) {
+      // Name the slot AND the reason: "it didn't work" costs a stream's worth of
+      // guessing, and the usual cause (a source renamed in OBS) is in the reason.
+      reply(`🎬 slot ${n} ("${slot.input}") failed: ${res.reason}`);
+      return;
+    }
+    logger.info?.('media slot fired', { slot: n, input: slot.input, action: slot.action || DEFAULT_ACTION });
+  },
+};

--- a/src/commands/mod/media.js
+++ b/src/commands/mod/media.js
@@ -3,8 +3,9 @@
 //   !media 3                     play slot 3
 //   !media                       list what's mapped
 //   !media inputs                ask OBS which media sources exist
-//   !media set 3 Airhorn         map slot 3 to the OBS input named "Airhorn"
-//   !media scene 3 Alerts        reveal it in the "Alerts" scene before playing
+//   !media set 3 GIF | Sound     map slot 3 — one alert, however many OBS sources
+//   !media add 3 Extra Sound     append a source to an existing slot
+//   !media scene 3 Alerts        reveal them in the "Alerts" scene before playing
 //   !media scene 3 none          stop revealing it (it's always on screen)
 //   !media action 3 stop         change what "trigger" means for this slot
 //   !media clear 3               unmap
@@ -26,17 +27,18 @@
 // and an alert that also posts a line is just clutter. EVERY failure replies. So
 // silence means OBS accepted the request; if you then hear nothing, the problem
 // is on the OBS side (source muted, hidden, or its media file missing), not here.
-import { listSlots, getSlot, mapSlot, clearMediaSlot } from '../../db/media.js';
-import { describeSlot, parseSlot, MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT } from '../../rules/media.js';
+import { listSlots, getSlot, mapSlot, addInput, clearMediaSlot } from '../../db/media.js';
+import { describeSlot, parseSlot, slotInputs, MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT, MAX_PARTS, PART_SEPARATOR } from '../../rules/media.js';
 import { playMedia, listInputs, mediaReady } from '../../integrations/obsMedia.js';
 
 const ACTIONS = MEDIA_ACTIONS;
-const USAGE = `Usage: !media <1-${MAX_SLOT}> · set <n> <OBS source> · scene <n> <scene|none> · action <n> ${ACTIONS.join('|')} · clear <n> · inputs`;
+const USAGE = `Usage: !media <1-${MAX_SLOT}> · set <n> <source> ${PART_SEPARATOR} <source> · add <n> <source> · scene <n> <scene|none> · action <n> ${ACTIONS.join('/')} · clear <n> · inputs`;
 
 /** Why a write was refused, in words a mod can act on. */
 function refusal(reason) {
   switch (reason) {
-    case 'bad-input': return 'that OBS source name is empty or too long';
+    case 'bad-input': return `each source name must be non-empty and under 100 chars — separate them with ${PART_SEPARATOR}`;
+    case 'too-many-parts': return `a slot fires at most ${MAX_PARTS} sources`;
     case 'bad-scene': return 'that scene name is empty or too long';
     case 'bad-action': return `action must be one of: ${ACTIONS.join(', ')}`;
     case 'bad-label': return 'that label is empty or too long';
@@ -54,7 +56,7 @@ export default {
   // capture (hundreds of MB per trigger, hence its own rate limit) a media action
   // costs OBS nothing. Spam is a conversation to have with a mod, not a lockout.
   cooldownMs: 0,
-  help: `!media <n> plays a mapped OBS source · set/scene/action/clear/inputs to map them — mod-only`,
+  help: `!media <n> plays the OBS sources mapped to that number · set/add/scene/action/clear/inputs to map them — mod-only`,
   async run({ args, reply, logger }) {
     const [first, ...rest] = args;
     const verb = String(first || '').toLowerCase();
@@ -92,20 +94,37 @@ export default {
     }
 
     // ── set <n> <name…> ─────────────────────────────────────────────────────
-    // The source name is the REST OF THE LINE, not one token: real OBS sources
-    // are called things like "Airhorn SFX".
+    // The source names are the REST OF THE LINE, not one token: real OBS sources
+    // are called things like "Airhorn SFX". `|` separates them, because a GIF and
+    // its sound are two sources in OBS and one alert to everyone watching.
     if (verb === 'set') {
       const n = parseSlot(rest[0]);
       if (!n) {
         reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
         return;
       }
-      const res = await mapSlot(n, { input: rest.slice(1).join(' ') });
+      const res = await mapSlot(n, { inputs: rest.slice(1).join(' ') });
       if (!res.ok) {
         reply(refusal(res.reason));
         return;
       }
       reply(`🎬 slot ${describeSlot(res.slot)} — try it with !media ${n}`);
+      return;
+    }
+
+    // ── add <n> <name…> ─────────────────────────────────────────────────────
+    if (verb === 'add') {
+      const n = parseSlot(rest[0]);
+      if (!n) {
+        reply(`slot must be a number 1-${MAX_SLOT} · ${USAGE}`);
+        return;
+      }
+      const res = await addInput(n, rest.slice(1).join(' '));
+      if (!res.ok) {
+        reply(refusal(res.reason));
+        return;
+      }
+      reply(`🎬 slot ${describeSlot(res.slot)}`);
       return;
     }
 
@@ -178,9 +197,9 @@ export default {
     if (!res.ok) {
       // Name the slot AND the reason: "it didn't work" costs a stream's worth of
       // guessing, and the usual cause (a source renamed in OBS) is in the reason.
-      reply(`🎬 slot ${n} ("${slot.input}") failed: ${res.reason}`);
+      reply(`🎬 slot ${n} (${slotInputs(slot).map((i) => `"${i}"`).join(' + ')}) failed: ${res.reason}`);
       return;
     }
-    logger.info?.('media slot fired', { slot: n, input: slot.input, action: slot.action || DEFAULT_ACTION });
+    logger.info?.('media slot fired', { slot: n, inputs: slotInputs(slot), action: slot.action || DEFAULT_ACTION });
   },
 };

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -31,8 +31,9 @@ import raidnight from './mod/raidnight.js';
 import season from './mod/season.js';
 import timer from './mod/timer.js';
 import reminder from './mod/reminder.js';
+import media from './mod/media.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder, media];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -31,6 +31,10 @@ const mirror = {
   // config/reminders: id → scheduled-nudge record. Evaluated on every reminder
   // tick, so it's mirrored rather than re-read.
   reminders: {},
+  // config/media: slot number → OBS media mapping (`!media`). Mirrored so firing
+  // a slot is a chat-latency operation rather than a chat-latency operation plus
+  // an RTDB read — the point of the feature is that it lands on the beat.
+  media: {},
 };
 
 let started = false;
@@ -63,6 +67,7 @@ export async function startConfigMirror(logger = console) {
   const timerRef = db.ref(PATHS.configTimer());
   const liveSinceRef = db.ref(PATHS.configLiveSince());
   const remindersRef = db.ref(PATHS.reminders());
+  const mediaRef = db.ref(PATHS.mediaSlots());
 
   // Seed drop-scheduler defaults once (never clobber a mod's settings).
   await dropRef.transaction((v) => (v == null ? { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec } : v));
@@ -77,11 +82,12 @@ export async function startConfigMirror(logger = console) {
   timerRef.on('value', (s) => { mirror.timer = s.val() || null; });
   liveSinceRef.on('value', (s) => { mirror.liveSince = s.val() || null; });
   remindersRef.on('value', (s) => { mirror.reminders = s.val() || {}; });
+  mediaRef.on('value', (s) => { mirror.media = s.val() || {}; });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap, liveSinceSnap, remindersSnap] = await Promise.all([
+  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap, liveSinceSnap, remindersSnap, mediaSnap] = await Promise.all([
     liveRef.get(), expRef.get(), mutedRef.get(), clipRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
-    timerRef.get(), liveSinceRef.get(), remindersRef.get(),
+    timerRef.get(), liveSinceRef.get(), remindersRef.get(), mediaRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
@@ -93,6 +99,7 @@ export async function startConfigMirror(logger = console) {
   mirror.timer = timerSnap.val() || null;
   mirror.liveSince = liveSinceSnap.val() || null;
   mirror.reminders = remindersSnap.val() || {};
+  mirror.media = mediaSnap.val() || {};
   logger.info?.('config mirror warm', {
     live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, clipMode: mirror.clipMode,
   });
@@ -185,6 +192,34 @@ export async function setReminderState(id, state) {
   if (cur) mirror.reminders = { ...mirror.reminders, [id]: { ...cur, state } };
   await database().ref(PATHS.reminderState(id)).set(state || null);
   return state;
+}
+
+/** All OBS media slots as `{ "1": {input, scene, action, label}, … }` (`!media`). */
+export function getMediaSlots() {
+  return mirror.media || {};
+}
+
+/**
+ * Merge a patch into one media slot. Mirror first, exactly like patchReminder:
+ * a mod who types `!media set 1 Airhorn` and then `!media 1` in the next breath
+ * must hit the slot they just wrote, not the one RTDB has caught up to.
+ */
+export async function setMediaSlot(n, patch) {
+  const key = String(n);
+  const merged = { ...(mirror.media?.[key] || {}), ...patch };
+  for (const [k, v] of Object.entries(patch)) if (v === null) delete merged[k];
+  mirror.media = { ...(mirror.media || {}), [key]: merged };
+  await database().ref(PATHS.mediaSlot(key)).update(patch);
+  return merged;
+}
+
+/** Remove a media slot entirely. */
+export async function clearMediaSlot(n) {
+  const key = String(n);
+  const next = { ...(mirror.media || {}) };
+  delete next[key];
+  mirror.media = next;
+  await database().ref(PATHS.mediaSlot(key)).remove();
 }
 
 /**

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -101,6 +101,14 @@ export const PATHS = {
   reminders: () => 'config/reminders',
   reminder: (id) => `config/reminders/${id}`,
   reminderState: (id) => `config/reminders/${id}/state`,
+  // MEDIA SLOTS (`!media`): slot number → { input, scene?, action?, label? },
+  // the map from a number a mod types to a media source in OBS. Config, not a
+  // message channel — nothing is ever *sent* through here. It lives in RTDB for
+  // the same reason clipMode does: the names change whenever the streamer
+  // renames a source in OBS, and re-deploying a container to rename a sound is
+  // not a thing anyone does mid-stream.
+  mediaSlots: () => 'config/media',
+  mediaSlot: (n) => `config/media/${n}`,
   configLock: () => 'config/lock',
   // OKRA FACTS (/info/): approved facts are client-read-only; the submission
   // queue + counter are admin-only.

--- a/src/db/media.js
+++ b/src/db/media.js
@@ -9,7 +9,7 @@
 // mapped from `!media inputs`, which asks OBS what it actually has.
 
 import { getMediaSlots, setMediaSlot, clearMediaSlot } from './configStore.js';
-import { sortSlots, validateMapping } from '../rules/media.js';
+import { sortSlots, validateMapping, slotInputs, MAX_PARTS } from '../rules/media.js';
 
 export { getMediaSlots, clearMediaSlot };
 
@@ -18,16 +18,16 @@ export function listSlots() {
   return sortSlots(getMediaSlots());
 }
 
-/** One slot by number, or null. An entry with no `input` is not a slot. */
+/** One slot by number, or null. An entry with no source to fire is not a slot. */
 export function getSlot(n) {
   const slot = getMediaSlots()[String(n)];
-  return slot && slot.input ? { ...slot, n: Number(n) } : null;
+  return slot && slotInputs(slot).length ? { ...slot, n: Number(n) } : null;
 }
 
 /**
  * Map a slot to an OBS input. Creating and re-pointing are the same operation.
  * @param {number} n
- * @param {{input?: string, scene?: string|null, action?: string, label?: string|null}} edit
+ * @param {{inputs?: string[]|string, scene?: string|null, action?: string, label?: string|null}} edit
  * @returns {Promise<{ok:true,slot:object}|{ok:false,reason:string}>}
  */
 export async function mapSlot(n, edit) {
@@ -35,7 +35,22 @@ export async function mapSlot(n, edit) {
   if (!res.ok) return res;
   // Refuse a patch that would leave a slot with no source to play — an entry
   // that exists but can't fire reads as "mapped" in the list and isn't.
-  if (!res.patch.input && !getSlot(n)) return { ok: false, reason: 'unmapped' };
+  if (!res.patch.inputs && !getSlot(n)) return { ok: false, reason: 'unmapped' };
   const slot = await setMediaSlot(n, res.patch);
   return { ok: true, slot: { ...slot, n } };
+}
+
+/**
+ * Append a source to a slot, so a GIF and its sound become one alert without
+ * retyping both names. Writes the WHOLE list rather than pushing a child: RTDB
+ * stores arrays as numeric-keyed objects, and a partial write is how you get a
+ * sparse one that reads back with holes.
+ * @returns {Promise<{ok:true,slot:object}|{ok:false,reason:string}>}
+ */
+export async function addInput(n, name) {
+  const cur = getSlot(n);
+  if (!cur) return { ok: false, reason: 'unmapped' };
+  const next = [...slotInputs(cur), String(name ?? '')];
+  if (next.length > MAX_PARTS) return { ok: false, reason: 'too-many-parts' };
+  return mapSlot(n, { inputs: next });
 }

--- a/src/db/media.js
+++ b/src/db/media.js
@@ -1,0 +1,41 @@
+// MEDIA SLOT persistence for `!media`. The decisions — what a valid slot number
+// is, what a usable OBS name is, which actions exist — are pure and live in
+// src/rules/media.js; this file only reads and writes them.
+//
+// There is no seed file, and that is deliberate. Every other config in this bot
+// ships sensible defaults, but a default slot would name an OBS source that
+// exists on no particular machine, and a slot pointing at nothing fails at the
+// worst possible moment: live, in front of chat. Slots start empty and get
+// mapped from `!media inputs`, which asks OBS what it actually has.
+
+import { getMediaSlots, setMediaSlot, clearMediaSlot } from './configStore.js';
+import { sortSlots, validateMapping } from '../rules/media.js';
+
+export { getMediaSlots, clearMediaSlot };
+
+/** Slots as a number-sorted list, each with its `n`. The order `!media` prints. */
+export function listSlots() {
+  return sortSlots(getMediaSlots());
+}
+
+/** One slot by number, or null. An entry with no `input` is not a slot. */
+export function getSlot(n) {
+  const slot = getMediaSlots()[String(n)];
+  return slot && slot.input ? { ...slot, n: Number(n) } : null;
+}
+
+/**
+ * Map a slot to an OBS input. Creating and re-pointing are the same operation.
+ * @param {number} n
+ * @param {{input?: string, scene?: string|null, action?: string, label?: string|null}} edit
+ * @returns {Promise<{ok:true,slot:object}|{ok:false,reason:string}>}
+ */
+export async function mapSlot(n, edit) {
+  const res = validateMapping(edit);
+  if (!res.ok) return res;
+  // Refuse a patch that would leave a slot with no source to play — an entry
+  // that exists but can't fire reads as "mapped" in the list and isn't.
+  if (!res.patch.input && !getSlot(n)) return { ok: false, reason: 'unmapped' };
+  const slot = await setMediaSlot(n, res.patch);
+  return { ok: true, slot: { ...slot, n } };
+}

--- a/src/integrations/obsMedia.js
+++ b/src/integrations/obsMedia.js
@@ -1,0 +1,179 @@
+// OBS media actions — "play a sound / roll a clip on stream", on the SAME
+// obs-websocket connection the capture path already uses.
+//
+// This is the StreamElements alert mechanism reduced to what it actually is: a
+// media source sitting in a scene, and a request that restarts it. OBS already
+// owns the compositing, the audio routing, and the hide-when-finished behaviour.
+// The bot's entire job is the trigger.
+//
+// Deliberately NOT built: an overlay web page driven by a message channel. That
+// is how a hosted alert service has to do it — it has no access to your OBS — but
+// kennyBot does, and adding a page plus a transport to reach it would be strictly
+// more moving parts than the one request below.
+//
+// A SLOT is the mapping (config/media/<n>): a number a mod types → an OBS input
+// name, an optional scene to reveal it in, and which media action to fire. Numbers
+// because a slot has to be typeable in one second while something is happening.
+//
+// Same contract as capture.js, for the same reason: connect per trigger,
+// deadline-bounded, and every failure RESOLVES with `{ ok:false, reason }` rather
+// than throwing. The streamer's PC may be off — that must never break chat.
+
+import { withObs, obsConnectionFromEnv, websocketAvailable } from './obsWebsocket.js';
+import { DEFAULT_ACTION } from '../rules/media.js';
+
+/**
+ * Protocol encoding only — a mod's word for an action → obs-websocket's enum.
+ * The VOCABULARY (which words exist, which is the default) belongs to
+ * src/rules/media.js, so the validation that rejects a typo can be tested
+ * without a socket. This table is just the wire format.
+ */
+export const OBS_MEDIA_ACTION = {
+  restart: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART',
+  play: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PLAY',
+  pause: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PAUSE',
+  stop: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_STOP',
+  next: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_NEXT',
+  previous: 'OBS_WEBSOCKET_MEDIA_INPUT_ACTION_PREVIOUS',
+};
+
+/** Connection config, or `null` when this deployment has no OBS. */
+let conn = null;
+/** Test seam: when set, stands in for the whole obs-websocket round trip. */
+let fakeTrigger = null;
+
+/**
+ * @param {{ url?: string, password?: string, timeoutMs?: number }} [opts]
+ * @param {any} [logger]
+ */
+export function initMedia(opts = {}, logger = console) {
+  fakeTrigger = null;
+  const env = obsConnectionFromEnv();
+  const url = opts.url ?? env?.url ?? '';
+  if (!url) {
+    conn = null;
+    logger.info?.('media actions disabled (no OBS_WEBSOCKET_URL)');
+    return;
+  }
+  if (!websocketAvailable()) {
+    conn = null;
+    logger.warn?.('media actions disabled — this Node build lacks WebSocket (needs Node 22+)');
+    return;
+  }
+  conn = {
+    url,
+    password: opts.password ?? env?.password ?? '',
+    timeoutMs: opts.timeoutMs ?? env?.timeoutMs ?? 8000,
+  };
+  logger.info?.('media actions ready', { url });
+}
+
+/**
+ * Test seam: `fn({ slot })` replaces the OBS round trip entirely. Pass `null` to
+ * turn media actions off (the "no OBS configured" deployment).
+ */
+export function initMediaWith(fn) {
+  fakeTrigger = fn || null;
+  conn = fn ? { url: 'test://obs', password: '', timeoutMs: 0 } : null;
+}
+
+/** True when an OBS connection is configured. */
+export function mediaReady() {
+  return conn !== null;
+}
+
+/**
+ * The request sequence, split from the socket so it can be unit-tested with a
+ * fake `request` — the same shape as replayBufferSequence, and for the same
+ * reason: every bug worth catching here is an ordering bug.
+ *
+ * Order is load-bearing. The scene item is enabled BEFORE the media action, so
+ * the restart plays into a source that is already on screen. Reversed, the first
+ * frames play to nobody.
+ *
+ * @param {(type: string, data?: object) => Promise<any>} request
+ * @param {{ input: string, scene?: string|null, action?: string }} slot
+ * @returns {Promise<{ played: boolean, shown: boolean }>}
+ */
+export async function mediaSequence(request, slot) {
+  const name = slot?.action || DEFAULT_ACTION;
+  const mediaAction = OBS_MEDIA_ACTION[name];
+  if (!mediaAction) throw new Error(`unknown media action "${name}"`);
+  if (!slot?.input) throw new Error('slot has no OBS input name');
+
+  let shown = false;
+  if (slot.scene) {
+    // SetSceneItemEnabled takes a NUMERIC sceneItemId, not a source name, so the
+    // id has to be looked up first — there is no name-based form of this request.
+    const { sceneItemId } = await request('GetSceneItemId', {
+      sceneName: slot.scene,
+      sourceName: slot.input,
+    });
+    await request('SetSceneItemEnabled', {
+      sceneName: slot.scene,
+      sceneItemId,
+      sceneItemEnabled: true,
+    });
+    shown = true;
+  }
+
+  await request('TriggerMediaInputAction', { inputName: slot.input, mediaAction });
+  return { played: true, shown };
+}
+
+/**
+ * Fire one slot. Never throws.
+ *
+ * NOTE: there is no "and then hide it" step, deliberately. OBS's own Media Source
+ * property — *Hide source when playback ends* — already does that, frame-accurately
+ * and without the bot holding a timer that a restart would lose. Set it there.
+ *
+ * @param {{ input: string, scene?: string|null, action?: string }} slot
+ * @returns {Promise<{ ok: boolean, played?: boolean, shown?: boolean, reason?: string }>}
+ */
+export async function playMedia(slot, logger = console) {
+  if (!conn) return { ok: false, reason: 'not configured' };
+  if (!slot?.input) return { ok: false, reason: 'unmapped' };
+  try {
+    const res = fakeTrigger
+      ? await fakeTrigger({ slot })
+      : await withObs(conn, (request) => mediaSequence(request, slot));
+    logger.info?.('media triggered', {
+      input: slot.input,
+      action: slot.action || DEFAULT_ACTION,
+      scene: slot.scene || null,
+    });
+    return { ok: true, played: true, shown: Boolean(res?.shown) };
+  } catch (err) {
+    // Expected whenever the streamer's PC is off, OBS is closed, or the source
+    // was renamed in OBS but not in the slot map. Log it and tell the mod.
+    logger.warn?.('media trigger failed', { input: slot.input, err: String(err?.message || err) });
+    return { ok: false, reason: String(err?.message || err) };
+  }
+}
+
+/**
+ * Ask OBS what inputs exist. This is what makes the slot map usable: source names
+ * must match OBS EXACTLY, and guessing at them from memory is how you get a slot
+ * that silently does nothing.
+ *
+ * @param {string|null} [kind] restrict to one input kind, e.g. `ffmpeg_source`
+ *   (Media Source). Pass null for everything.
+ * @returns {Promise<{ ok: boolean, inputs?: Array<{name: string, kind: string}>, reason?: string }>}
+ */
+export async function listInputs(kind = null, logger = console) {
+  if (!conn) return { ok: false, reason: 'not configured' };
+  try {
+    const data = await withObs(conn, (request) =>
+      request('GetInputList', kind ? { inputKind: kind } : {}),
+    );
+    const inputs = (data?.inputs || []).map((i) => ({
+      name: i.inputName,
+      kind: i.inputKind,
+    }));
+    return { ok: true, inputs };
+  } catch (err) {
+    logger.warn?.('input list failed', { err: String(err?.message || err) });
+    return { ok: false, reason: String(err?.message || err) };
+  }
+}

--- a/src/integrations/obsMedia.js
+++ b/src/integrations/obsMedia.js
@@ -11,16 +11,18 @@
 // kennyBot does, and adding a page plus a transport to reach it would be strictly
 // more moving parts than the one request below.
 //
-// A SLOT is the mapping (config/media/<n>): a number a mod types → an OBS input
-// name, an optional scene to reveal it in, and which media action to fire. Numbers
-// because a slot has to be typeable in one second while something is happening.
+// A SLOT is the mapping (config/media/<n>): a number a mod types → one or more OBS
+// source names, an optional scene to reveal them in, and which media action to
+// fire. Numbers because a slot has to be typeable in one second while something is
+// happening; a LIST because OBS keeps a GIF and its sound as separate sources, so
+// one alert is normally two of them.
 //
 // Same contract as capture.js, for the same reason: connect per trigger,
 // deadline-bounded, and every failure RESOLVES with `{ ok:false, reason }` rather
 // than throwing. The streamer's PC may be off — that must never break chat.
 
 import { withObs, obsConnectionFromEnv, websocketAvailable } from './obsWebsocket.js';
-import { DEFAULT_ACTION } from '../rules/media.js';
+import { DEFAULT_ACTION, slotInputs } from '../rules/media.js';
 
 /**
  * Protocol encoding only — a mod's word for an action → obs-websocket's enum.
@@ -87,38 +89,50 @@ export function mediaReady() {
  * fake `request` — the same shape as replayBufferSequence, and for the same
  * reason: every bug worth catching here is an ordering bug.
  *
- * Order is load-bearing. The scene item is enabled BEFORE the media action, so
- * the restart plays into a source that is already on screen. Reversed, the first
- * frames play to nobody.
+ * A slot fires ONE OR MORE sources, because OBS keeps a GIF and its sound as
+ * separate Media Sources and an alert is both of them.
+ *
+ * Order is load-bearing, twice over:
+ *   1. every scene item is revealed BEFORE any media action, so a restart never
+ *      plays into a source that is still hidden;
+ *   2. the triggers themselves go out TOGETHER rather than one-await-at-a-time —
+ *      serialising them puts a full round trip between the picture and the sound,
+ *      which over a tailnet is audible as a flam.
  *
  * @param {(type: string, data?: object) => Promise<any>} request
- * @param {{ input: string, scene?: string|null, action?: string }} slot
- * @returns {Promise<{ played: boolean, shown: boolean }>}
+ * @param {{ inputs?: string[], input?: string, scene?: string|null, action?: string }} slot
+ * @returns {Promise<{ played: number, shown: number }>}
  */
 export async function mediaSequence(request, slot) {
   const name = slot?.action || DEFAULT_ACTION;
   const mediaAction = OBS_MEDIA_ACTION[name];
   if (!mediaAction) throw new Error(`unknown media action "${name}"`);
-  if (!slot?.input) throw new Error('slot has no OBS input name');
+  const inputs = slotInputs(slot);
+  if (!inputs.length) throw new Error('slot has no OBS input name');
 
-  let shown = false;
+  let shown = 0;
   if (slot.scene) {
     // SetSceneItemEnabled takes a NUMERIC sceneItemId, not a source name, so the
     // id has to be looked up first — there is no name-based form of this request.
-    const { sceneItemId } = await request('GetSceneItemId', {
-      sceneName: slot.scene,
-      sourceName: slot.input,
-    });
-    await request('SetSceneItemEnabled', {
-      sceneName: slot.scene,
-      sceneItemId,
-      sceneItemEnabled: true,
-    });
-    shown = true;
+    // Sequential so a failure names the source that is missing from the scene.
+    for (const input of inputs) {
+      const { sceneItemId } = await request('GetSceneItemId', {
+        sceneName: slot.scene,
+        sourceName: input,
+      });
+      await request('SetSceneItemEnabled', {
+        sceneName: slot.scene,
+        sceneItemId,
+        sceneItemEnabled: true,
+      });
+      shown += 1;
+    }
   }
 
-  await request('TriggerMediaInputAction', { inputName: slot.input, mediaAction });
-  return { played: true, shown };
+  await Promise.all(
+    inputs.map((input) => request('TriggerMediaInputAction', { inputName: input, mediaAction })),
+  );
+  return { played: inputs.length, shown };
 }
 
 /**
@@ -128,26 +142,27 @@ export async function mediaSequence(request, slot) {
  * property — *Hide source when playback ends* — already does that, frame-accurately
  * and without the bot holding a timer that a restart would lose. Set it there.
  *
- * @param {{ input: string, scene?: string|null, action?: string }} slot
- * @returns {Promise<{ ok: boolean, played?: boolean, shown?: boolean, reason?: string }>}
+ * @param {{ inputs?: string[], input?: string, scene?: string|null, action?: string }} slot
+ * @returns {Promise<{ ok: boolean, played?: number, shown?: number, reason?: string }>}
  */
 export async function playMedia(slot, logger = console) {
   if (!conn) return { ok: false, reason: 'not configured' };
-  if (!slot?.input) return { ok: false, reason: 'unmapped' };
+  const inputs = slotInputs(slot);
+  if (!inputs.length) return { ok: false, reason: 'unmapped' };
   try {
     const res = fakeTrigger
       ? await fakeTrigger({ slot })
       : await withObs(conn, (request) => mediaSequence(request, slot));
     logger.info?.('media triggered', {
-      input: slot.input,
+      inputs,
       action: slot.action || DEFAULT_ACTION,
       scene: slot.scene || null,
     });
-    return { ok: true, played: true, shown: Boolean(res?.shown) };
+    return { ok: true, played: res?.played ?? inputs.length, shown: res?.shown ?? 0 };
   } catch (err) {
-    // Expected whenever the streamer's PC is off, OBS is closed, or the source
-    // was renamed in OBS but not in the slot map. Log it and tell the mod.
-    logger.warn?.('media trigger failed', { input: slot.input, err: String(err?.message || err) });
+    // Expected whenever the streamer's PC is off, OBS is closed, or a source was
+    // renamed in OBS but not in the slot map. Log it and tell the mod.
+    logger.warn?.('media trigger failed', { inputs, err: String(err?.message || err) });
     return { ok: false, reason: String(err?.message || err) };
   }
 }

--- a/src/integrations/obsWebsocket.js
+++ b/src/integrations/obsWebsocket.js
@@ -34,6 +34,26 @@ export function websocketAvailable() {
 }
 
 /**
+ * Where OBS is and how to authenticate — `null` when the deployment has no OBS.
+ *
+ * Shared because there are now TWO consumers of one connection (capture.js saves
+ * replay buffers; obsMedia.js fires media actions) and they must never disagree
+ * about which machine that is. This resolves the TOPOLOGY only; what each feature
+ * does with the socket stays that feature's own config.
+ *
+ * @returns {{ url: string, password: string, timeoutMs: number } | null}
+ */
+export function obsConnectionFromEnv(env = process.env) {
+  const url = env.OBS_WEBSOCKET_URL ?? '';
+  if (!url) return null;
+  return {
+    url,
+    password: env.OBS_WEBSOCKET_PASSWORD ?? '',
+    timeoutMs: Number(env.OBS_TIMEOUT_MS || 8000),
+  };
+}
+
+/**
  * Open a session, run `fn(request)`, and always close. `request(type, data)`
  * resolves with responseData or rejects with the OBS failure comment.
  *

--- a/src/rules/media.js
+++ b/src/rules/media.js
@@ -1,0 +1,126 @@
+// MEDIA SLOTS — the pure half of `!media`: the vocabulary, the parsing, and the
+// validation that decides whether a mapping is worth writing.
+//
+// Pure on purpose, like every other src/rules module: no config import, no RTDB,
+// no OBS. That's what lets the whole of it run in the offline suite, and it's
+// where every rule that has bitten us in chat gets a test.
+//
+// A SLOT is `{ input, scene?, action?, label? }`:
+//   input   the OBS source name, character for character as OBS spells it
+//   scene   optional — a scene to reveal that source in before playing it
+//   action  what "trigger" means for this slot (default: restart)
+//   label   optional human name, so `!media` reads as more than numbers
+
+/** The actions a mod can name. Encoded to obs-websocket's enum in obsMedia.js. */
+export const MEDIA_ACTIONS = ['restart', 'play', 'pause', 'stop', 'next', 'previous'];
+
+/**
+ * The alert-shaped default. `restart` plays from the first frame whether the
+ * source is idle, mid-playback or already finished — `play` does nothing at all
+ * on a source that has ended, which is exactly the state an alert is usually in.
+ */
+export const DEFAULT_ACTION = 'restart';
+
+/** Highest slot number — bounded so a fat-fingered `!media set 99999` can't sprawl. */
+export const MAX_SLOT = 20;
+
+/** A sanity bound on OBS names, not an OBS limit. */
+export const MAX_NAME_LEN = 100;
+
+/** True when `a` is an action a mod may name. */
+export function isAction(a) {
+  return MEDIA_ACTIONS.includes(String(a || '').toLowerCase());
+}
+
+/**
+ * Parse a slot number from chat.
+ *
+ * Strict digits only: `parseInt` would turn "1.5" into 1 and "2x" into 2, quietly
+ * mapping a slot the mod did not name. Refusing is the only safe reading.
+ *
+ * @returns {number|null} 1..MAX_SLOT, or null
+ */
+export function parseSlot(raw) {
+  const s = String(raw ?? '').trim();
+  if (!/^\d{1,3}$/.test(s)) return null;
+  const n = Number(s);
+  return n >= 1 && n <= MAX_SLOT ? n : null;
+}
+
+/**
+ * Collapse whitespace in an OBS name and bound its length.
+ * @returns {string|null} null when empty or too long
+ */
+export function cleanName(raw) {
+  const name = String(raw ?? '').replace(/\s+/g, ' ').trim();
+  if (!name) return null;
+  return name.length > MAX_NAME_LEN ? null : name;
+}
+
+/**
+ * Validate a mapping edit and return the exact patch to persist.
+ *
+ * `scene: null` explicitly CLEARS the scene, which is different from omitting it
+ * (leave as-is) — so the caller distinguishes "stop revealing this" from "don't
+ * touch that field". Same three-state contract the reminder edits use.
+ *
+ * @param {{input?: string, scene?: string|null, action?: string, label?: string|null}} edit
+ * @returns {{ok: true, patch: object} | {ok: false, reason: string}}
+ */
+export function validateMapping(edit = {}) {
+  const patch = {};
+
+  if (edit.input !== undefined) {
+    const input = cleanName(edit.input);
+    if (!input) return { ok: false, reason: 'bad-input' };
+    patch.input = input;
+  }
+
+  if (edit.scene !== undefined) {
+    if (edit.scene === null) {
+      patch.scene = null;
+    } else {
+      const scene = cleanName(edit.scene);
+      if (!scene) return { ok: false, reason: 'bad-scene' };
+      patch.scene = scene;
+    }
+  }
+
+  if (edit.action !== undefined) {
+    const action = String(edit.action || '').toLowerCase();
+    if (!isAction(action)) return { ok: false, reason: 'bad-action' };
+    patch.action = action;
+  }
+
+  if (edit.label !== undefined) {
+    patch.label = edit.label === null ? null : cleanName(edit.label);
+    if (edit.label !== null && !patch.label) return { ok: false, reason: 'bad-label' };
+  }
+
+  return { ok: true, patch };
+}
+
+/**
+ * Slot records → a number-sorted list. RTDB hands back STRING keys, so a plain
+ * sort puts slot 10 between 1 and 2.
+ * @param {Record<string, object>} slots
+ */
+export function sortSlots(slots = {}) {
+  return Object.entries(slots)
+    .filter(([, slot]) => slot && typeof slot === 'object' && slot.input)
+    .map(([n, slot]) => ({ ...slot, n: Number(n) }))
+    .sort((a, b) => a.n - b.n);
+}
+
+/** One-liner for chat: `3 airhorn → "Airhorn SFX" in "Alerts" (stop)`. */
+export function describeSlot(slot) {
+  const bits = [String(slot.n)];
+  if (slot.label) bits.push(slot.label);
+  bits.push(`→ "${slot.input}"`);
+  if (slot.scene) bits.push(`in "${slot.scene}"`);
+  // The default is the overwhelmingly common case; printing it on every line
+  // would bury the one slot that differs.
+  const action = slot.action || DEFAULT_ACTION;
+  if (action !== DEFAULT_ACTION) bits.push(`(${action})`);
+  return bits.join(' ');
+}

--- a/src/rules/media.js
+++ b/src/rules/media.js
@@ -5,8 +5,9 @@
 // no OBS. That's what lets the whole of it run in the offline suite, and it's
 // where every rule that has bitten us in chat gets a test.
 //
-// A SLOT is `{ input, scene?, action?, label? }`:
-//   input   the OBS source name, character for character as OBS spells it
+// A SLOT is `{ inputs, scene?, action?, label? }`:
+//   inputs  one or more OBS source names, fired together — OBS keeps a GIF and
+//           its sound as separate sources, so one alert is usually two of them
 //   scene   optional — a scene to reveal that source in before playing it
 //   action  what "trigger" means for this slot (default: restart)
 //   label   optional human name, so `!media` reads as more than numbers
@@ -27,9 +28,47 @@ export const MAX_SLOT = 20;
 /** A sanity bound on OBS names, not an OBS limit. */
 export const MAX_NAME_LEN = 100;
 
+/**
+ * How many sources one slot may fire. A slot exists to make ONE alert out of the
+ * pieces OBS keeps separate — a GIF and its sound — not to be a scene switcher.
+ */
+export const MAX_PARTS = 5;
+
+/** What separates source names in `!media set 1 A | B`. OBS names contain spaces. */
+export const PART_SEPARATOR = '|';
+
 /** True when `a` is an action a mod may name. */
 export function isAction(a) {
   return MEDIA_ACTIONS.includes(String(a || '').toLowerCase());
+}
+
+/**
+ * The OBS sources a slot fires, in order, normalised from every shape the record
+ * can legitimately have:
+ *   - `inputs: ["A", "B"]`      the current form
+ *   - `inputs: {0:"A", 1:"B"}`  the same thing after an RTDB round trip, which
+ *                               stores arrays as numeric-keyed objects
+ *   - `input: "A"`              a single-source slot
+ * Normalising here means nothing downstream has to know which it got.
+ * @returns {string[]}
+ */
+export function slotInputs(slot) {
+  const raw = slot?.inputs ?? slot?.input;
+  if (!raw) return [];
+  const list = Array.isArray(raw) ? raw : typeof raw === 'object' ? Object.values(raw) : [raw];
+  return list.map((s) => String(s ?? '').trim()).filter(Boolean);
+}
+
+/**
+ * Split `A | B` into source names. All-or-nothing: one empty part rejects the
+ * whole line, because a slot that silently drops half an alert is worse than one
+ * that refuses to be created.
+ * @returns {string[]|null}
+ */
+export function parseInputList(raw) {
+  const parts = String(raw ?? '').split(PART_SEPARATOR).map(cleanName);
+  if (!parts.length || parts.some((p) => !p)) return null;
+  return parts;
 }
 
 /**
@@ -70,10 +109,11 @@ export function cleanName(raw) {
 export function validateMapping(edit = {}) {
   const patch = {};
 
-  if (edit.input !== undefined) {
-    const input = cleanName(edit.input);
-    if (!input) return { ok: false, reason: 'bad-input' };
-    patch.input = input;
+  if (edit.inputs !== undefined) {
+    const list = Array.isArray(edit.inputs) ? edit.inputs.map(cleanName) : parseInputList(edit.inputs);
+    if (!list || !list.length || list.some((p) => !p)) return { ok: false, reason: 'bad-input' };
+    if (list.length > MAX_PARTS) return { ok: false, reason: 'too-many-parts' };
+    patch.inputs = list;
   }
 
   if (edit.scene !== undefined) {
@@ -107,16 +147,16 @@ export function validateMapping(edit = {}) {
  */
 export function sortSlots(slots = {}) {
   return Object.entries(slots)
-    .filter(([, slot]) => slot && typeof slot === 'object' && slot.input)
+    .filter(([, slot]) => slot && typeof slot === 'object' && slotInputs(slot).length)
     .map(([n, slot]) => ({ ...slot, n: Number(n) }))
     .sort((a, b) => a.n - b.n);
 }
 
-/** One-liner for chat: `3 airhorn → "Airhorn SFX" in "Alerts" (stop)`. */
+/** One-liner for chat: `3 airhorn → "Airhorn GIF" + "Airhorn SFX" (stop)`. */
 export function describeSlot(slot) {
   const bits = [String(slot.n)];
   if (slot.label) bits.push(slot.label);
-  bits.push(`→ "${slot.input}"`);
+  bits.push(`→ ${slotInputs(slot).map((i) => `"${i}"`).join(' + ')}`);
   if (slot.scene) bits.push(`in "${slot.scene}"`);
   // The default is the overwhelmingly common case; printing it on every line
   // would bury the one slot that differs.

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -19,6 +19,7 @@ import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 import { initMediaWith } from '../../src/integrations/obsMedia.js';
 import { clearMediaSlot, listSlots } from '../../src/db/media.js';
+import { slotInputs } from '../../src/rules/media.js';
 import { defaultBoss } from '../../src/content/bosses.js';
 import { until } from './harness.js';
 
@@ -439,35 +440,49 @@ export const SCENARIOS = [
 
         // Source names are the rest of the line — real OBS sources have spaces.
         assert.match(await bot.send(mod, '!media set 1 Airhorn SFX'), /"Airhorn SFX"/);
-        assert.equal((await database().ref('config/media/1').get()).val().input, 'Airhorn SFX', 'persisted');
+        assert.deepEqual((await database().ref('config/media/1').get()).val().inputs, ['Airhorn SFX'], 'persisted');
 
         // Firing is silent in chat by contract; the slot reaching OBS is the proof.
         assert.equal(await bot.send(mod, '!media 1'), '', 'a successful play says nothing');
         assert.equal(fired.length, 1);
-        assert.equal(fired[0].input, 'Airhorn SFX');
+        assert.deepEqual(slotInputs(fired[0]), ['Airhorn SFX']);
         assert.equal(fired[0].action ?? 'restart', 'restart', 'the alert-shaped default');
+
+        // A GIF and its sound are two sources in OBS and ONE alert in chat.
+        assert.match(await bot.send(mod, '!media set 2 Alert GIF | Alert SFX'), /"Alert GIF" \+ "Alert SFX"/);
+        await bot.send(mod, '!media 2');
+        assert.deepEqual(slotInputs(fired[1]), ['Alert GIF', 'Alert SFX'], 'both fired from one number');
+
+        // …and `add` grows a slot without retyping what is already there.
+        assert.match(await bot.send(mod, '!media add 2 Third Thing'), /\+ "Third Thing"/);
+        assert.deepEqual(listSlots().find((x) => x.n === 2).inputs, ['Alert GIF', 'Alert SFX', 'Third Thing']);
+
+        // Half an alert is worse than none: one empty part rejects the whole line.
+        assert.match(await bot.send(mod, '!media set 3 Good | '), /separate them with/);
+        assert.equal(listSlots().some((x) => x.n === 3), false, 'nothing was created');
 
         // Mapping a scene and an action edits the same slot rather than replacing it.
         assert.match(await bot.send(mod, '!media scene 1 Alerts'), /in "Alerts"/);
         assert.match(await bot.send(mod, '!media action 1 stop'), /\(stop\)/);
         await bot.send(mod, '!media 1');
-        assert.equal(fired[1].input, 'Airhorn SFX', 'input survived both edits');
-        assert.equal(fired[1].scene, 'Alerts');
-        assert.equal(fired[1].action, 'stop');
+        // fired[2] — only three plays have happened; the edits in between don't fire.
+        assert.deepEqual(slotInputs(fired[2]), ['Airhorn SFX'], 'input survived both edits');
+        assert.equal(fired[2].scene, 'Alerts');
+        assert.equal(fired[2].action, 'stop');
 
         // A typo'd action must not write a slot that throws at play time.
         assert.match(await bot.send(mod, '!media action 1 restrat'), /action must be one of/);
-        assert.equal(listSlots()[0].action, 'stop', 'the bad edit changed nothing');
+        assert.equal(listSlots().find((x) => x.n === 1).action, 'stop', 'the bad edit changed nothing');
 
         assert.match(await bot.send(mod, '!media scene 1 none'), /"Airhorn SFX"/);
-        assert.equal(listSlots()[0].scene ?? null, null, 'scene cleared, slot kept');
+        assert.equal(listSlots().find((x) => x.n === 1).scene ?? null, null, 'scene cleared, slot kept');
 
         assert.match(await bot.send(mod, '!media'), /Airhorn SFX/);
         assert.match(await bot.send(mod, '!media clear 1'), /cleared/i);
-        assert.equal(listSlots().length, 0);
+        assert.equal(listSlots().some((x) => x.n === 1), false);
       } finally {
         // Scenarios share one emulator DB — leave no slots behind.
-        await clearMediaSlot(1);
+        for (const n of [1, 2, 3]) await clearMediaSlot(n);
         initMediaWith(null);
       }
     },

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -17,6 +17,8 @@ import { seedReminders, listReminders } from '../../src/db/reminders.js';
 import { getRaidPointer, getConfig, setLive, setClipMode } from '../../src/db/configStore.js';
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
+import { initMediaWith } from '../../src/integrations/obsMedia.js';
+import { clearMediaSlot, listSlots } from '../../src/db/media.js';
 import { defaultBoss } from '../../src/content/bosses.js';
 import { until } from './harness.js';
 
@@ -420,6 +422,53 @@ export const SCENARIOS = [
         assert.equal((await database().ref('config/timer').get()).exists(), false, 'cleared from RTDB');
       } finally {
         await bot.send(mod, '!timer stop'); // never leak a timer into the next scenario
+      }
+    },
+  },
+  {
+    command: 'media', title: 'a mod maps an OBS source to a number and fires it',
+    run: async ({ bot, u }) => {
+      const mod = u('e2e_media', { login: 'nikki', name: 'Nikki', mod: true });
+      const fired = [];
+      // Stands in for the whole obs-websocket round trip — what matters here is
+      // that the SLOT the command resolved is the one handed to OBS.
+      initMediaWith(async ({ slot }) => { fired.push(slot); return { played: true, shown: Boolean(slot.scene) }; });
+      try {
+        assert.match(await bot.send(mod, '!media'), /no media slots mapped/i);
+        assert.match(await bot.send(mod, '!media 1'), /slot 1 is not mapped/i);
+
+        // Source names are the rest of the line — real OBS sources have spaces.
+        assert.match(await bot.send(mod, '!media set 1 Airhorn SFX'), /"Airhorn SFX"/);
+        assert.equal((await database().ref('config/media/1').get()).val().input, 'Airhorn SFX', 'persisted');
+
+        // Firing is silent in chat by contract; the slot reaching OBS is the proof.
+        assert.equal(await bot.send(mod, '!media 1'), '', 'a successful play says nothing');
+        assert.equal(fired.length, 1);
+        assert.equal(fired[0].input, 'Airhorn SFX');
+        assert.equal(fired[0].action ?? 'restart', 'restart', 'the alert-shaped default');
+
+        // Mapping a scene and an action edits the same slot rather than replacing it.
+        assert.match(await bot.send(mod, '!media scene 1 Alerts'), /in "Alerts"/);
+        assert.match(await bot.send(mod, '!media action 1 stop'), /\(stop\)/);
+        await bot.send(mod, '!media 1');
+        assert.equal(fired[1].input, 'Airhorn SFX', 'input survived both edits');
+        assert.equal(fired[1].scene, 'Alerts');
+        assert.equal(fired[1].action, 'stop');
+
+        // A typo'd action must not write a slot that throws at play time.
+        assert.match(await bot.send(mod, '!media action 1 restrat'), /action must be one of/);
+        assert.equal(listSlots()[0].action, 'stop', 'the bad edit changed nothing');
+
+        assert.match(await bot.send(mod, '!media scene 1 none'), /"Airhorn SFX"/);
+        assert.equal(listSlots()[0].scene ?? null, null, 'scene cleared, slot kept');
+
+        assert.match(await bot.send(mod, '!media'), /Airhorn SFX/);
+        assert.match(await bot.send(mod, '!media clear 1'), /cleared/i);
+        assert.equal(listSlots().length, 0);
+      } finally {
+        // Scenarios share one emulator DB — leave no slots behind.
+        await clearMediaSlot(1);
+        initMediaWith(null);
       }
     },
   },

--- a/test/rules/media.test.js
+++ b/test/rules/media.test.js
@@ -1,0 +1,194 @@
+// MEDIA SLOTS (`!media`) — the offline half: slot parsing, mapping validation,
+// and the obs-websocket request sequence that plays one.
+//
+// The sequence is tested with a fake `request` rather than a socket, the same way
+// replayBufferSequence is, because every bug worth catching here is an ORDERING
+// bug: reveal the source, then play it. A socket would only obscure that.
+//
+// The stateful half — slots persisted to RTDB, the mirror being readable in the
+// same breath as the write, and every reply `!media` gives — is covered by the
+// e2e scenario in test/e2e/scenarios.js, which drives the real dispatcher.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSlot, cleanName, validateMapping, sortSlots, describeSlot, isAction,
+  MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT, MAX_NAME_LEN,
+} from '../../src/rules/media.js';
+import { mediaSequence, OBS_MEDIA_ACTION } from '../../src/integrations/obsMedia.js';
+
+/** Records every request in order, so the sequence itself can be asserted. */
+function fakeObs({ sceneItemId = 7, fail = null } = {}) {
+  const calls = [];
+  return {
+    calls,
+    request: async (type, data) => {
+      calls.push({ type, data });
+      if (fail === type) throw new Error(`OBS rejected ${type}`);
+      if (type === 'GetSceneItemId') return { sceneItemId };
+      return {};
+    },
+  };
+}
+
+// ── slot numbers ──────────────────────────────────────────────────────────────
+
+test('parseSlot accepts whole numbers in range', () => {
+  assert.equal(parseSlot('1'), 1);
+  assert.equal(parseSlot(String(MAX_SLOT)), MAX_SLOT);
+  assert.equal(parseSlot(' 3 '), 3, 'chat leaves whitespace everywhere');
+});
+
+test('parseSlot refuses what parseInt would silently accept', () => {
+  // These are the whole reason parseSlot exists: parseInt('1.5') is 1 and
+  // parseInt('2x') is 2, either of which maps a slot the mod never named.
+  assert.equal(parseSlot('1.5'), null);
+  assert.equal(parseSlot('2x'), null);
+  assert.equal(parseSlot('-1'), null);
+  assert.equal(parseSlot(''), null);
+  assert.equal(parseSlot(undefined), null);
+});
+
+test('parseSlot bounds the map', () => {
+  assert.equal(parseSlot('0'), null, 'slots are 1-based, as typed');
+  assert.equal(parseSlot(String(MAX_SLOT + 1)), null);
+  assert.equal(parseSlot('99999'), null);
+});
+
+// ── OBS names ─────────────────────────────────────────────────────────────────
+
+test('cleanName collapses whitespace but keeps the name OBS knows', () => {
+  assert.equal(cleanName('  Airhorn   SFX '), 'Airhorn SFX');
+  assert.equal(cleanName('Alert'), 'Alert');
+});
+
+test('cleanName refuses empty and over-long names', () => {
+  assert.equal(cleanName('   '), null);
+  assert.equal(cleanName(''), null);
+  assert.equal(cleanName('x'.repeat(MAX_NAME_LEN)), 'x'.repeat(MAX_NAME_LEN));
+  assert.equal(cleanName('x'.repeat(MAX_NAME_LEN + 1)), null);
+});
+
+// ── mapping validation ────────────────────────────────────────────────────────
+
+test('validateMapping builds the patch to persist', () => {
+  const res = validateMapping({ input: ' Airhorn ', scene: 'Alerts', action: 'stop' });
+  assert.deepEqual(res, { ok: true, patch: { input: 'Airhorn', scene: 'Alerts', action: 'stop' } });
+});
+
+test('validateMapping distinguishes "clear the scene" from "leave it alone"', () => {
+  // Three states, and the difference matters: omitting scene must not wipe one a
+  // mod already set, and `null` must actually wipe it.
+  assert.deepEqual(validateMapping({ action: 'play' }).patch, { action: 'play' }, 'scene untouched');
+  assert.deepEqual(validateMapping({ scene: null }).patch, { scene: null }, 'scene cleared');
+});
+
+test('validateMapping refuses a typo rather than writing a dead slot', () => {
+  assert.deepEqual(validateMapping({ action: 'restrat' }), { ok: false, reason: 'bad-action' });
+  assert.deepEqual(validateMapping({ input: '   ' }), { ok: false, reason: 'bad-input' });
+  assert.deepEqual(validateMapping({ scene: '' }), { ok: false, reason: 'bad-scene' });
+});
+
+test('validateMapping lowercases the action a mod shouted', () => {
+  assert.equal(validateMapping({ action: 'RESTART' }).patch.action, 'restart');
+});
+
+test('every named action has a wire encoding', () => {
+  // The vocabulary (rules) and the protocol table (integration) are separate
+  // files; a word in one and not the other is a slot that validates and then
+  // throws at play time.
+  for (const name of MEDIA_ACTIONS) {
+    assert.ok(OBS_MEDIA_ACTION[name], `no obs-websocket enum for "${name}"`);
+  }
+  assert.equal(Object.keys(OBS_MEDIA_ACTION).length, MEDIA_ACTIONS.length, 'and no extras');
+  assert.ok(isAction(DEFAULT_ACTION), 'the default must itself be valid');
+});
+
+// ── listing ───────────────────────────────────────────────────────────────────
+
+test('sortSlots orders numerically, not by RTDB string key', () => {
+  const slots = { 10: { input: 'J' }, 2: { input: 'B' }, 1: { input: 'A' } };
+  assert.deepEqual(sortSlots(slots).map((s) => s.n), [1, 2, 10]);
+});
+
+test('sortSlots drops entries that could never play', () => {
+  const slots = { 1: { input: 'A' }, 2: { label: 'no input' }, 3: null };
+  assert.deepEqual(sortSlots(slots).map((s) => s.n), [1]);
+});
+
+test('describeSlot prints the non-default action and hides the default', () => {
+  assert.equal(describeSlot({ n: 3, input: 'Airhorn' }), '3 → "Airhorn"');
+  assert.equal(describeSlot({ n: 3, input: 'Airhorn', action: DEFAULT_ACTION }), '3 → "Airhorn"');
+  assert.equal(describeSlot({ n: 3, input: 'Airhorn', action: 'stop' }), '3 → "Airhorn" (stop)');
+  assert.equal(
+    describeSlot({ n: 1, label: 'airhorn', input: 'Airhorn SFX', scene: 'Alerts' }),
+    '1 airhorn → "Airhorn SFX" in "Alerts"',
+  );
+});
+
+// ── the request sequence ──────────────────────────────────────────────────────
+
+test('a slot with no scene is one request', async () => {
+  const obs = fakeObs();
+  const res = await mediaSequence(obs.request, { input: 'Airhorn' });
+
+  assert.deepEqual(res, { played: true, shown: false });
+  assert.deepEqual(obs.calls, [{
+    type: 'TriggerMediaInputAction',
+    data: { inputName: 'Airhorn', mediaAction: OBS_MEDIA_ACTION.restart },
+  }]);
+});
+
+test('a slot with a scene reveals the source BEFORE playing it', async () => {
+  const obs = fakeObs({ sceneItemId: 42 });
+  const res = await mediaSequence(obs.request, { input: 'Airhorn', scene: 'Alerts' });
+
+  assert.deepEqual(res, { played: true, shown: true });
+  // Order is the assertion. Reversed, the first frames play to a hidden source.
+  assert.deepEqual(obs.calls.map((c) => c.type), [
+    'GetSceneItemId', 'SetSceneItemEnabled', 'TriggerMediaInputAction',
+  ]);
+  assert.deepEqual(obs.calls[0].data, { sceneName: 'Alerts', sourceName: 'Airhorn' });
+  assert.deepEqual(obs.calls[1].data, { sceneName: 'Alerts', sceneItemId: 42, sceneItemEnabled: true });
+});
+
+test('the scene item id comes from OBS, never from the slot', async () => {
+  // SetSceneItemEnabled takes a numeric id with no name-based form, so the id
+  // MUST be whatever GetSceneItemId just answered — a remembered one goes stale
+  // the moment a source is reordered in the scene.
+  const obs = fakeObs({ sceneItemId: 99 });
+  await mediaSequence(obs.request, { input: 'GIF', scene: 'Alerts' });
+  assert.equal(obs.calls[1].data.sceneItemId, 99);
+});
+
+test('the slot chooses the action', async () => {
+  const obs = fakeObs();
+  await mediaSequence(obs.request, { input: 'Music Bed', action: 'stop' });
+  assert.equal(obs.calls[0].data.mediaAction, OBS_MEDIA_ACTION.stop);
+});
+
+test('an unknown action throws instead of reaching OBS', async () => {
+  const obs = fakeObs();
+  await assert.rejects(
+    () => mediaSequence(obs.request, { input: 'Airhorn', action: 'explode' }),
+    /unknown media action "explode"/,
+  );
+  assert.equal(obs.calls.length, 0, 'nothing was sent');
+});
+
+test('a slot with no input throws instead of reaching OBS', async () => {
+  const obs = fakeObs();
+  await assert.rejects(() => mediaSequence(obs.request, {}), /no OBS input name/);
+  assert.equal(obs.calls.length, 0);
+});
+
+test('a missing source surfaces the OBS failure rather than playing blind', async () => {
+  // Renaming a source in OBS without updating the slot is the expected failure
+  // in real use. It must fail at the lookup, not fall through to a trigger that
+  // does nothing and reports success.
+  const obs = fakeObs({ fail: 'GetSceneItemId' });
+  await assert.rejects(
+    () => mediaSequence(obs.request, { input: 'Gone', scene: 'Alerts' }),
+    /OBS rejected GetSceneItemId/,
+  );
+  assert.deepEqual(obs.calls.map((c) => c.type), ['GetSceneItemId']);
+});

--- a/test/rules/media.test.js
+++ b/test/rules/media.test.js
@@ -12,7 +12,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   parseSlot, cleanName, validateMapping, sortSlots, describeSlot, isAction,
-  MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT, MAX_NAME_LEN,
+  slotInputs, parseInputList,
+  MEDIA_ACTIONS, DEFAULT_ACTION, MAX_SLOT, MAX_NAME_LEN, MAX_PARTS,
 } from '../../src/rules/media.js';
 import { mediaSequence, OBS_MEDIA_ACTION } from '../../src/integrations/obsMedia.js';
 
@@ -71,8 +72,8 @@ test('cleanName refuses empty and over-long names', () => {
 // ── mapping validation ────────────────────────────────────────────────────────
 
 test('validateMapping builds the patch to persist', () => {
-  const res = validateMapping({ input: ' Airhorn ', scene: 'Alerts', action: 'stop' });
-  assert.deepEqual(res, { ok: true, patch: { input: 'Airhorn', scene: 'Alerts', action: 'stop' } });
+  const res = validateMapping({ inputs: ' Airhorn ', scene: 'Alerts', action: 'stop' });
+  assert.deepEqual(res, { ok: true, patch: { inputs: ['Airhorn'], scene: 'Alerts', action: 'stop' } });
 });
 
 test('validateMapping distinguishes "clear the scene" from "leave it alone"', () => {
@@ -84,7 +85,7 @@ test('validateMapping distinguishes "clear the scene" from "leave it alone"', ()
 
 test('validateMapping refuses a typo rather than writing a dead slot', () => {
   assert.deepEqual(validateMapping({ action: 'restrat' }), { ok: false, reason: 'bad-action' });
-  assert.deepEqual(validateMapping({ input: '   ' }), { ok: false, reason: 'bad-input' });
+  assert.deepEqual(validateMapping({ inputs: '   ' }), { ok: false, reason: 'bad-input' });
   assert.deepEqual(validateMapping({ scene: '' }), { ok: false, reason: 'bad-scene' });
 });
 
@@ -106,22 +107,60 @@ test('every named action has a wire encoding', () => {
 // ── listing ───────────────────────────────────────────────────────────────────
 
 test('sortSlots orders numerically, not by RTDB string key', () => {
-  const slots = { 10: { input: 'J' }, 2: { input: 'B' }, 1: { input: 'A' } };
+  const slots = { 10: { inputs: ['J'] }, 2: { inputs: ['B'] }, 1: { inputs: ['A'] } };
   assert.deepEqual(sortSlots(slots).map((s) => s.n), [1, 2, 10]);
 });
 
 test('sortSlots drops entries that could never play', () => {
-  const slots = { 1: { input: 'A' }, 2: { label: 'no input' }, 3: null };
+  const slots = { 1: { inputs: ['A'] }, 2: { label: 'no input' }, 3: null, 4: { inputs: [] } };
   assert.deepEqual(sortSlots(slots).map((s) => s.n), [1]);
 });
 
 test('describeSlot prints the non-default action and hides the default', () => {
-  assert.equal(describeSlot({ n: 3, input: 'Airhorn' }), '3 → "Airhorn"');
-  assert.equal(describeSlot({ n: 3, input: 'Airhorn', action: DEFAULT_ACTION }), '3 → "Airhorn"');
-  assert.equal(describeSlot({ n: 3, input: 'Airhorn', action: 'stop' }), '3 → "Airhorn" (stop)');
+  assert.equal(describeSlot({ n: 3, inputs: ['Airhorn'] }), '3 → "Airhorn"');
+  assert.equal(describeSlot({ n: 3, inputs: ['Airhorn'], action: DEFAULT_ACTION }), '3 → "Airhorn"');
+  assert.equal(describeSlot({ n: 3, inputs: ['Airhorn'], action: 'stop' }), '3 → "Airhorn" (stop)');
   assert.equal(
-    describeSlot({ n: 1, label: 'airhorn', input: 'Airhorn SFX', scene: 'Alerts' }),
+    describeSlot({ n: 1, label: 'airhorn', inputs: ['Airhorn SFX'], scene: 'Alerts' }),
     '1 airhorn → "Airhorn SFX" in "Alerts"',
+  );
+});
+
+// ── multi-source slots ────────────────────────────────────────────────────────
+
+test('a slot holds several sources, because OBS splits a GIF from its sound', () => {
+  const res = validateMapping({ inputs: 'glasses-raise-gif | bruh-mp3' });
+  assert.deepEqual(res.patch.inputs, ['glasses-raise-gif', 'bruh-mp3']);
+});
+
+test('parseInputList rejects the whole line if any part is empty', () => {
+  // Half an alert is worse than a refusal: the missing half is silent, and
+  // silence is exactly what a working alert looks like when its sound is muted.
+  assert.equal(parseInputList('A | | B'), null);
+  assert.equal(parseInputList('A |'), null);
+  assert.equal(parseInputList(''), null);
+  assert.deepEqual(parseInputList('  A  |  B  '), ['A', 'B']);
+});
+
+test('a slot is bounded — it is one alert, not a scene switcher', () => {
+  const many = Array.from({ length: MAX_PARTS + 1 }, (_, i) => `s${i}`).join(' | ');
+  assert.deepEqual(validateMapping({ inputs: many }), { ok: false, reason: 'too-many-parts' });
+});
+
+test('slotInputs normalises every shape the record can come back as', () => {
+  assert.deepEqual(slotInputs({ inputs: ['A', 'B'] }), ['A', 'B']);
+  // RTDB stores arrays as numeric-keyed objects — same slot, different shape.
+  assert.deepEqual(slotInputs({ inputs: { 0: 'A', 1: 'B' } }), ['A', 'B']);
+  // A single-source slot.
+  assert.deepEqual(slotInputs({ input: 'A' }), ['A']);
+  assert.deepEqual(slotInputs({}), []);
+  assert.deepEqual(slotInputs(null), []);
+});
+
+test('describeSlot joins the parts so chat sees one alert, not two slots', () => {
+  assert.equal(
+    describeSlot({ n: 2, label: 'bruh', inputs: ['glasses-raise-gif', 'bruh-mp3'] }),
+    '2 bruh → "glasses-raise-gif" + "bruh-mp3"',
   );
 });
 
@@ -129,9 +168,9 @@ test('describeSlot prints the non-default action and hides the default', () => {
 
 test('a slot with no scene is one request', async () => {
   const obs = fakeObs();
-  const res = await mediaSequence(obs.request, { input: 'Airhorn' });
+  const res = await mediaSequence(obs.request, { inputs: ['Airhorn'] });
 
-  assert.deepEqual(res, { played: true, shown: false });
+  assert.deepEqual(res, { played: 1, shown: 0 });
   assert.deepEqual(obs.calls, [{
     type: 'TriggerMediaInputAction',
     data: { inputName: 'Airhorn', mediaAction: OBS_MEDIA_ACTION.restart },
@@ -140,9 +179,9 @@ test('a slot with no scene is one request', async () => {
 
 test('a slot with a scene reveals the source BEFORE playing it', async () => {
   const obs = fakeObs({ sceneItemId: 42 });
-  const res = await mediaSequence(obs.request, { input: 'Airhorn', scene: 'Alerts' });
+  const res = await mediaSequence(obs.request, { inputs: ['Airhorn'], scene: 'Alerts' });
 
-  assert.deepEqual(res, { played: true, shown: true });
+  assert.deepEqual(res, { played: 1, shown: 1 });
   // Order is the assertion. Reversed, the first frames play to a hidden source.
   assert.deepEqual(obs.calls.map((c) => c.type), [
     'GetSceneItemId', 'SetSceneItemEnabled', 'TriggerMediaInputAction',
@@ -151,25 +190,54 @@ test('a slot with a scene reveals the source BEFORE playing it', async () => {
   assert.deepEqual(obs.calls[1].data, { sceneName: 'Alerts', sceneItemId: 42, sceneItemEnabled: true });
 });
 
+test('a two-source slot triggers both, and reveals both first', async () => {
+  const obs = fakeObs({ sceneItemId: 5 });
+  const res = await mediaSequence(obs.request, {
+    inputs: ['glasses-raise-gif', 'bruh-mp3'], scene: 'Scene',
+  });
+
+  assert.deepEqual(res, { played: 2, shown: 2 });
+  // EVERY reveal precedes EVERY trigger — otherwise the sound leads the picture
+  // by however long the second reveal takes.
+  assert.deepEqual(obs.calls.map((c) => c.type), [
+    'GetSceneItemId', 'SetSceneItemEnabled',
+    'GetSceneItemId', 'SetSceneItemEnabled',
+    'TriggerMediaInputAction', 'TriggerMediaInputAction',
+  ]);
+  assert.deepEqual(
+    obs.calls.filter((c) => c.type === 'TriggerMediaInputAction').map((c) => c.data.inputName),
+    ['glasses-raise-gif', 'bruh-mp3'],
+  );
+});
+
+test('a two-source slot with no scene is just the two triggers', async () => {
+  // The setup we actually recommend: sources left visible, clear_on_media_end
+  // doing the hiding, so nothing needs revealing at all.
+  const obs = fakeObs();
+  const res = await mediaSequence(obs.request, { inputs: ['gif', 'mp3'] });
+  assert.deepEqual(res, { played: 2, shown: 0 });
+  assert.deepEqual(obs.calls.map((c) => c.type), ['TriggerMediaInputAction', 'TriggerMediaInputAction']);
+});
+
 test('the scene item id comes from OBS, never from the slot', async () => {
   // SetSceneItemEnabled takes a numeric id with no name-based form, so the id
   // MUST be whatever GetSceneItemId just answered — a remembered one goes stale
   // the moment a source is reordered in the scene.
   const obs = fakeObs({ sceneItemId: 99 });
-  await mediaSequence(obs.request, { input: 'GIF', scene: 'Alerts' });
+  await mediaSequence(obs.request, { inputs: ['GIF'], scene: 'Alerts' });
   assert.equal(obs.calls[1].data.sceneItemId, 99);
 });
 
 test('the slot chooses the action', async () => {
   const obs = fakeObs();
-  await mediaSequence(obs.request, { input: 'Music Bed', action: 'stop' });
+  await mediaSequence(obs.request, { inputs: ['Music Bed'], action: 'stop' });
   assert.equal(obs.calls[0].data.mediaAction, OBS_MEDIA_ACTION.stop);
 });
 
 test('an unknown action throws instead of reaching OBS', async () => {
   const obs = fakeObs();
   await assert.rejects(
-    () => mediaSequence(obs.request, { input: 'Airhorn', action: 'explode' }),
+    () => mediaSequence(obs.request, { inputs: ['Airhorn'], action: 'explode' }),
     /unknown media action "explode"/,
   );
   assert.equal(obs.calls.length, 0, 'nothing was sent');
@@ -187,7 +255,7 @@ test('a missing source surfaces the OBS failure rather than playing blind', asyn
   // does nothing and reports success.
   const obs = fakeObs({ fail: 'GetSceneItemId' });
   await assert.rejects(
-    () => mediaSequence(obs.request, { input: 'Gone', scene: 'Alerts' }),
+    () => mediaSequence(obs.request, { inputs: ['Gone'], scene: 'Alerts' }),
     /OBS rejected GetSceneItemId/,
   );
   assert.deepEqual(obs.calls.map((c) => c.type), ['GetSceneItemId']);


### PR DESCRIPTION
Plays OBS media sources from chat — the mechanism behind a StreamElements-style
alert, driven by kennyBot instead of a hosted service.

```
!media inputs                        what OBS actually has, spelled its way
!media set 3 alert-gif | alert-mp3   slot 3 → both, fired together
!media add 3 extra-sound             append to an existing slot
!media scene 3 Alerts                reveal them first (only needed if hidden)
!media action 3 stop                 restart (default) · play · pause · stop · next · previous
!media 3                             fire it
```

Mod-only. Rides the **same obs-websocket connection** the clip capture already
uses — `obsConnectionFromEnv()` is now shared, because two ideas about where OBS
lives is one more than can ever be right.

## Verified against a real OBS, on a live stream

Not fakes. Run against OBS 4 Media Sources deep while broadcasting:

| Check | Result |
|---|---|
| Two-source slot (GIF + MP3) fires together | both `ENDED` → `PLAYING`, cursors advancing, 45ms |
| Audio reaches **viewers** | confirmed on a second device |
| Transparent webm keeps its alpha through the encoder | confirmed on stream |
| Non-mod viewer types `!media 1` | ignored silently, as designed |
| Source name doesn't exist | throws; chat gets the offending name |
| One good + one bad name | throws, naming the bad one |
| Bad scene name | throws |
| **Muted source** | **reports success** — the one failure OBS cannot report |
| 10 concurrent triggers (10 separate connections) | 10/10 ok, 197ms total, ~100ms each |
| Re-trigger a playing source | cursor 470ms → 104ms: restarts, does not stack |

Plus `npm test` **166** · `npm run test:emulator` **75** · `npm run test:e2e` **32**
(the coverage test enforces one scenario per registered command).

## Design decisions

**A slot fires several sources.** OBS keeps a GIF and its sound as separate Media
Sources, so one alert is normally two of them. Max 5. The triggers go out in a
single batch rather than one await at a time, and every scene reveal precedes
every trigger — a round trip between the picture and the sound is audible.

**No overlay page and no message bus.** That architecture is what a hosted alert
service *has* to use — it cannot reach your OBS. This bot can, so a page plus a
transport to reach it is strictly more moving parts than the request that already
works. OBS keeps compositing, audio routing, and *Show nothing when playback ends*
(`clear_on_media_end`, on by default) — which is also why nothing here holds a
hide-it-later timer, and why a source can be left permanently visible with no
`scene` field at all. That default is what the rig confirmed.

**No queue.** OBS already serialises per source: re-firing restarts rather than
stacks. A queue would only matter if alerts should wait their turn instead of
interrupting, which is the wrong behaviour for a soundboard.

**`restart` is the default action, not `play`.** An alert spends nearly all its
life in the *finished* state, where `play` does nothing at all.

**A successful play is silent in chat; every failure replies.** The sound is the
feedback. Silence means OBS accepted it — with the one documented exception above.

**Slots ship empty — no seed.** A default slot would name a source that exists on
no particular machine, and a slot pointing at nothing fails live, in front of
chat. `!media inputs` and `scripts/obs-media.mjs` ask OBS for the real names.

**No cooldown**, like `!clipmode` and `!timer`. A soundboard's value is landing on
the beat. Unlike `!clip`'s local capture — hundreds of MB per trigger, hence its
own rate limit — a media action costs OBS nothing.

## Layering

| File | Job |
|---|---|
| `src/rules/media.js` | pure: slot parsing, mapping validation, action vocabulary |
| `src/integrations/obsMedia.js` | wire encoding + the request sequence |
| `src/db/media.js` | persistence at `config/media/<n>` |
| `src/commands/mod/media.js` | the chat surface |
| `scripts/obs-media.mjs` | list/fire/inspect sources with no bot running |

`slotInputs()` normalises the three shapes a record can arrive in: a list, the
numeric-keyed object RTDB turns a list into, and a single `input` string. Writes
always replace the whole list, so RTDB can never hand back a sparse one.

Slots live in RTDB for the same reason the clip mode does: names change whenever a
source is renamed in OBS, and re-deploying a container to rename a sound is not a
thing anyone does mid-stream. This is **config storage**, not a message channel.

## Not in this PR

- **Twitch event triggers.** Explicitly out of scope — command-level triggers only
  for now, by the owner's decision.
- **The okrafans commands page.** It gets published when this graduates off `dev`.
