### PR TITLE
feat: !obs — drive scenes, sources, filters and audio from chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Firebase and OBS, and never listens on a port — and ships as a container.
 |---|---|---|
 | **Clips** | `!clip` · `!clipmode` · `!start` | 16:9 + natively-framed 9:16 captured on the streamer's PC over obs-websocket / Aitum |
 | **On-stream media** | `!media` | play a mapped OBS media source from chat — the same connection, pointed at a source instead of the buffer |
+| **OBS control** | `!obs` | scenes, source visibility, filters, audio mute and stream stats, from chat |
 | **Stream timer** | `!timer` | one countdown, heads-up marks, survives a restart |
 | **Reminders** | `!reminder` | schedules are RTDB records, not code — daily / after-live / interval |
 | **To-do board** | `!todo` | chat-controlled, rendered on [/todo/](https://okrafans.com/todo/) |
@@ -85,9 +86,9 @@ Underneath both:
 - **automated releases** from Conventional Commits (release-please), with `main`
   protected for everyone including admins
 
-Verified by `npm test` (166 offline unit tests), `npm run test:emulator` (75 — RTDB
+Verified by `npm test` (182 offline unit tests), `npm run test:emulator` (75 — RTDB
 rules + client-write rejection, and the stateful command paths), `npm run test:e2e`
-(32 — every registered command driven through the real dispatcher), and
+(33 — every registered command driven through the real dispatcher), and
 `npm run synthetic` (full muster→battle→victory run with UI-contract assertions).
 
 **Not yet done:** a full-session local recording (see
@@ -125,7 +126,8 @@ src/
   twitch/                 auth (RefreshingAuthProvider), liveGate (Helix poll), eventsub (WS),
                           sender (Helix/IRC send + badge), clips (Helix Create Clip)
   integrations/           obsWebsocket (v5 client + Aitum vendor requests), capture (facade +
-                          rate limit), obsMedia (media actions on the same socket)
+                          rate limit), obsMedia (media actions), obsControl (scenes,
+                          sources, filters, audio) — all on the same socket
   events/                 chat (gate→EXP→raid tick + dispatch), twitchEvents (sub/cheer/raid),
                           dropScheduler · timerScheduler · reminderScheduler
   commands/               one module per command + registry; mod/ subdir for mod commands
@@ -159,6 +161,13 @@ of the replay buffer.
 | `!media scene <n> <scene\|none>` | mod | reveal the source in that scene before playing (for a visual alert); `none` stops revealing it |
 | `!media action <n> <action>` | mod | `restart` (default) · `play` · `pause` · `stop` · `next` · `previous` |
 | `!media clear <n>` | mod | unmap |
+| `!obs` | mod | what's live: current scene, fps, skipped frames |
+| `!obs scenes` · `!obs scene <name>` | mod | list scenes · cut to one |
+| `!obs sources [scene]` | mod | what's in a scene, and what's visible |
+| `!obs show\|hide\|toggle <source>` | mod | flip a source's visibility in the live scene |
+| `!obs filters <source>` · `!obs filter on\|off <source> \| <filter>` | mod | list a source's filters · switch one |
+| `!obs audio` · `!obs mute\|unmute <input>` | mod | audio inputs with mute state and level · mute one. **Not** `!mute`, which silences the bot |
+| `!obs stats` | mod | dropped frames as a rate, CPU, free disk — for when chat says it's buffering |
 
 **Around the stream**
 
@@ -449,6 +458,39 @@ redemptions needs EventSub topics and broadcaster scopes this bot does not hold
 today (it subscribes to `stream.online`/`offline` only, and prod runs on a Helix
 poll because the broadcaster token isn't the channel owner's). The mechanism comes
 first; the trigger is separate work.
+
+### Driving OBS from chat — `!obs`
+
+The rest of the obs-websocket surface, on that same connection: scenes, source
+visibility, filters, audio, and the stream-health numbers.
+
+```
+!obs                          current scene, fps, skipped frames
+!obs scenes                   list · !obs scene Starting Soon   cut to one
+!obs sources                  what's in the live scene, and what's visible
+!obs show|hide|toggle <src>   flip a source
+!obs filters <source>         list · !obs filter off cam | Chroma Key
+!obs audio                    inputs with mute state and level
+!obs mute|unmute <input>      OBS audio — NOT !mute, which silences the bot
+!obs stats                    dropped frames as a RATE, CPU, free disk
+```
+
+One command with sub-verbs rather than eight top-level names: `!obs` alone is the
+discoverable index, and it keeps eight words out of a chat namespace shared with
+other bots. `!obs mute` sits here precisely *because* `!mute` already exists and
+means something entirely different — two mutes at top level is a mistake waiting
+for a stressful moment.
+
+Deliberately thin: each verb is one or two obs-websocket requests with no policy
+on top, and `!obs scene` accepts any scene name rather than an allowlist. This
+exists to learn what OBS exposes; a verb that proves worth keeping can earn its
+own command and its own guard rails then. Errors are OBS's own text, passed
+through — when a name is wrong, OBS says which one, and that beats anything we
+would write.
+
+`!obs stats` reports skipped frames as a **percentage**, because a raw count means
+nothing without the total: "312 dropped" reads as alarming and is fine out of two
+million.
 
 The one point of contact is `!start` (`src/db/clipSync.js`), which writes a per-stream
 sync anchor to RTDB — *data the archiver reads*, not a file handoff, and it works

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import { createSender } from './src/twitch/sender.js';
 import { initClips } from './src/twitch/clips.js';
 import { initCapture, captureReady } from './src/integrations/capture.js';
 import { initMedia } from './src/integrations/obsMedia.js';
+import { initObsControl } from './src/integrations/obsControl.js';
 // Read once at boot purely to log what's in force; the live value is RTDB-backed.
 import { activeClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
@@ -219,6 +220,9 @@ async function main() {
   // deliberately resolves the same connection: two ideas of where OBS lives is
   // one more than can ever be right.
   initMedia({}, logger);
+
+  // Scenes / source visibility / filters / audio on that same OBS (`!obs`).
+  initObsControl({}, logger);
 
   // What !clip actually does. Default 'local': trigger the streamer's OBS/Aitum
   // capture and post NO Twitch clip — a Twitch clip is capped at the stream

--- a/src/commands/mod/obs.js
+++ b/src/commands/mod/obs.js
@@ -1,0 +1,201 @@
+// !obs (mod) — drive OBS from chat: scenes, source visibility, filters, audio.
+//
+//   !obs                          what's live right now
+//   !obs scenes                   list scenes
+//   !obs scene Starting Soon      cut to one
+//   !obs sources [scene]          what's in a scene, and what's visible
+//   !obs show|hide|toggle <src>   flip a source's visibility (current scene)
+//   !obs filters <source>         list a source's filters
+//   !obs filter on|off <src> | <filter>
+//   !obs audio                    audio inputs, mute state and level
+//   !obs mute|unmute <input>      OBS audio mute — NOT the bot's !mute
+//   !obs stats                    dropped frames, CPU, disk
+//
+// One command with sub-verbs rather than eight top-level names: these are for
+// LEARNING what OBS exposes, and `!obs` on its own is the discoverable index of
+// that. It also keeps eight words out of a chat namespace shared with other bots.
+//
+// `!obs mute` is under this command precisely BECAUSE `!mute` already exists and
+// means something entirely different — silencing the bot's own chat output. Two
+// mutes at top level is a mistake waiting for a stressful moment.
+//
+// Deliberately thin: each verb is one or two obs-websocket requests with no policy
+// on top, and `scene` accepts any scene name rather than an allowlist. That is the
+// owner's call for an experiment — if a verb proves worth keeping, it can earn its
+// own command and its own guard rails then.
+import {
+  listScenes, setScene, listSources, setSourceVisible,
+  listFilters, setFilter, listAudio, setMute, getStats, obsControlReady,
+} from '../../integrations/obsControl.js';
+
+const USAGE =
+  'Usage: !obs scenes · scene <name> · sources [scene] · show|hide|toggle <source> · ' +
+  'filters <source> · filter on|off <source> | <filter> · audio · mute|unmute <input> · stats';
+
+/** Chat-sized list: OBS can hold far more scenes than a message can carry. */
+function joinCapped(items, max = 12) {
+  const shown = items.slice(0, max);
+  const extra = items.length - shown.length;
+  return shown.join(' · ') + (extra > 0 ? ` …+${extra} more` : '');
+}
+
+export default {
+  names: ['obs'],
+  mod: true,
+  cooldownMs: 0,
+  help: '!obs scene|sources|show|hide|filters|filter|audio|mute|stats — drive OBS from chat, mod-only',
+  async run({ args, reply }) {
+    if (!obsControlReady()) {
+      reply('no OBS is configured for this bot');
+      return;
+    }
+    const [first, ...rest] = args;
+    const verb = String(first || '').toLowerCase();
+    const arg = rest.join(' ').trim();
+
+    // ── status ──────────────────────────────────────────────────────────────
+    if (!verb) {
+      const [sc, st] = await Promise.all([listScenes(), getStats()]);
+      if (!sc.ok) {
+        reply(`could not reach OBS: ${sc.reason}`);
+        return;
+      }
+      const health = st.ok
+        ? ` · ${st.data.fps.toFixed(0)}fps, ${st.data.outputSkipped}/${st.data.outputTotal} frames skipped`
+        : '';
+      reply(`🎛️ scene "${sc.data.current}" (${sc.data.names.length} scenes)${health} · ${USAGE}`);
+      return;
+    }
+
+    // ── scenes ──────────────────────────────────────────────────────────────
+    if (verb === 'scenes') {
+      const res = await listScenes();
+      if (!res.ok) {
+        reply(`could not reach OBS: ${res.reason}`);
+        return;
+      }
+      const named = res.data.names.map((n) => (n === res.data.current ? `▶ ${n}` : n));
+      reply(`🎛️ scenes: ${joinCapped(named)}`);
+      return;
+    }
+
+    if (verb === 'scene') {
+      if (!arg) {
+        reply(`name a scene · ${USAGE}`);
+        return;
+      }
+      const res = await setScene(arg);
+      // OBS's own error names the scene it couldn't find, which is exactly the
+      // information a mod needs — pass it through rather than rewriting it.
+      reply(res.ok ? `🎛️ switched to "${arg}"` : `couldn't switch: ${res.reason}`);
+      return;
+    }
+
+    // ── sources ─────────────────────────────────────────────────────────────
+    if (verb === 'sources') {
+      const res = await listSources(arg || null);
+      if (!res.ok) {
+        reply(`could not list sources: ${res.reason}`);
+        return;
+      }
+      const named = res.data.items.map((i) => `${i.visible ? '👁' : '🚫'} ${i.name}`);
+      reply(`🎛️ "${res.data.scene}": ${joinCapped(named)}`);
+      return;
+    }
+
+    if (verb === 'show' || verb === 'hide' || verb === 'toggle') {
+      if (!arg) {
+        reply(`name a source · ${USAGE}`);
+        return;
+      }
+      const res = await setSourceVisible(arg, verb);
+      reply(res.ok
+        ? `🎛️ "${arg}" is now ${res.data.visible ? 'visible' : 'hidden'} in "${res.data.scene}"`
+        : `couldn't ${verb} it: ${res.reason}`);
+      return;
+    }
+
+    // ── filters ─────────────────────────────────────────────────────────────
+    if (verb === 'filters') {
+      if (!arg) {
+        reply(`name a source · ${USAGE}`);
+        return;
+      }
+      const res = await listFilters(arg);
+      if (!res.ok) {
+        reply(`could not list filters: ${res.reason}`);
+        return;
+      }
+      if (!res.data.filters.length) {
+        reply(`🎛️ "${arg}" has no filters`);
+        return;
+      }
+      reply(`🎛️ "${arg}": ${joinCapped(res.data.filters.map((f) => `${f.enabled ? '✅' : '⬜'} ${f.name}`))}`);
+      return;
+    }
+
+    if (verb === 'filter') {
+      // `source | filter` — both are OBS names and both can contain spaces, so a
+      // separator is the only unambiguous split. Same `|` as `!media set`.
+      const state = String(rest[0] || '').toLowerCase();
+      const [sourceName, filterName] = rest.slice(1).join(' ').split('|').map((s) => s.trim());
+      if ((state !== 'on' && state !== 'off') || !sourceName || !filterName) {
+        reply(`Usage: !obs filter on|off <source> | <filter>`);
+        return;
+      }
+      const res = await setFilter(sourceName, filterName, state === 'on');
+      reply(res.ok
+        ? `🎛️ "${filterName}" on "${sourceName}" is now ${state}`
+        : `couldn't set it: ${res.reason}`);
+      return;
+    }
+
+    // ── audio ───────────────────────────────────────────────────────────────
+    if (verb === 'audio') {
+      const res = await listAudio();
+      if (!res.ok) {
+        reply(`could not list audio: ${res.reason}`);
+        return;
+      }
+      const named = res.data.inputs.map((i) => `${i.muted ? '🔇' : '🔊'} ${i.name} ${i.db.toFixed(0)}dB`);
+      reply(named.length ? `🎛️ audio: ${joinCapped(named)}` : '🎛️ OBS reports no audio inputs');
+      return;
+    }
+
+    if (verb === 'mute' || verb === 'unmute') {
+      if (!arg) {
+        reply(`name an OBS audio input · ${USAGE}`);
+        return;
+      }
+      const res = await setMute(arg, verb);
+      reply(res.ok
+        ? `🎛️ "${arg}" is now ${res.data.muted ? 'muted 🔇' : 'unmuted 🔊'}`
+        : `couldn't ${verb} it: ${res.reason}`);
+      return;
+    }
+
+    // ── stats ───────────────────────────────────────────────────────────────
+    if (verb === 'stats') {
+      const res = await getStats();
+      if (!res.ok) {
+        reply(`could not reach OBS: ${res.reason}`);
+        return;
+      }
+      const d = res.data;
+      // Dropped frames matter as a RATE, not a count — "312 dropped" means
+      // nothing without knowing it's 312 out of two million.
+      const pct = (a, b) => (b > 0 ? `${((a / b) * 100).toFixed(2)}%` : 'n/a');
+      const stream = d.streaming
+        ? ` · dropped ${d.streamSkipped}/${d.streamTotal} (${pct(d.streamSkipped, d.streamTotal)})`
+        : ' · not streaming';
+      reply(
+        `🎛️ ${d.fps.toFixed(0)}fps · CPU ${d.cpu.toFixed(1)}% · ` +
+        `render skip ${pct(d.renderSkipped, d.renderTotal)} · ` +
+        `encode skip ${pct(d.outputSkipped, d.outputTotal)}${stream} · ${d.diskGb.toFixed(1)}GB free`,
+      );
+      return;
+    }
+
+    reply(USAGE);
+  },
+};

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -32,8 +32,9 @@ import season from './mod/season.js';
 import timer from './mod/timer.js';
 import reminder from './mod/reminder.js';
 import media from './mod/media.js';
+import obs from './mod/obs.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder, media];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder, media, obs];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/integrations/obsControl.js
+++ b/src/integrations/obsControl.js
@@ -1,0 +1,230 @@
+// OBS scene / source / filter / audio control — everything at the obs-websocket
+// seam that ISN'T playing a media source (that's obsMedia.js).
+//
+// Same connection, same contract as capture.js and obsMedia.js: connect per
+// call, deadline-bounded, and every failure RESOLVES with `{ ok:false, reason }`
+// rather than throwing. OBS being closed must never break chat.
+//
+// This exists to LEARN what OBS can do from chat, so it is deliberately broad and
+// deliberately thin: each operation is one or two requests with no policy on top.
+// The only gate is that `!obs` is mod-only. If one of these turns out to be worth
+// keeping, it can grow its own command and its own guard rails then.
+//
+// Connection state is resolved here rather than shared with obsMedia, which is a
+// little duplication in exchange for the media path — the one that is verified
+// against a real rig and already merged — being impossible to destabilise from
+// here. Both read the same env, so they cannot disagree about where OBS is.
+
+import { withObs, obsConnectionFromEnv, websocketAvailable } from './obsWebsocket.js';
+
+/** Connection config, or `null` when this deployment has no OBS. */
+let conn = null;
+/** Test seam: when set, stands in for `request` — see initObsControlWith. */
+let fakeRequest = null;
+
+/** @param {{url?: string, password?: string, timeoutMs?: number}} [opts] */
+export function initObsControl(opts = {}, logger = console) {
+  fakeRequest = null;
+  const env = obsConnectionFromEnv();
+  const url = opts.url ?? env?.url ?? '';
+  if (!url || !websocketAvailable()) {
+    conn = null;
+    logger.info?.('obs control disabled (no OBS_WEBSOCKET_URL)');
+    return;
+  }
+  conn = {
+    url,
+    password: opts.password ?? env?.password ?? '',
+    timeoutMs: opts.timeoutMs ?? env?.timeoutMs ?? 8000,
+  };
+  logger.info?.('obs control ready', { url });
+}
+
+/**
+ * Test seam. `fn(requestType, requestData)` replaces the obs-websocket request
+ * function itself — NOT each operation — so tests assert the actual protocol
+ * calls rather than a mock of our own design. Pass null to disable.
+ */
+export function initObsControlWith(fn) {
+  fakeRequest = fn || null;
+  conn = fn ? { url: 'test://obs', password: '', timeoutMs: 0 } : null;
+}
+
+/** True when an OBS connection is configured. */
+export function obsControlReady() {
+  return conn !== null;
+}
+
+/**
+ * Run `fn(request)` against OBS. Never throws — the caller gets a reason it can
+ * put in chat, which for this feature is usually OBS's own error text and is
+ * more useful than anything we would write.
+ * @returns {Promise<{ok: true, data: any} | {ok: false, reason: string}>}
+ */
+async function run(fn) {
+  if (!conn) return { ok: false, reason: 'no OBS is configured for this bot' };
+  try {
+    return { ok: true, data: fakeRequest ? await fn(fakeRequest) : await withObs(conn, fn) };
+  } catch (err) {
+    return { ok: false, reason: String(err?.message || err) };
+  }
+}
+
+// ── scenes ───────────────────────────────────────────────────────────────────
+
+/** Every scene, plus which one is live. */
+export function listScenes() {
+  return run(async (request) => {
+    const { scenes = [], currentProgramSceneName } = await request('GetSceneList');
+    // OBS returns scenes in REVERSE UI order (index 0 is the bottom of the list).
+    // Reversing makes chat's list read like the panel the streamer is looking at.
+    return {
+      current: currentProgramSceneName,
+      names: scenes.map((s) => s.sceneName).reverse(),
+    };
+  });
+}
+
+/** Cut to a scene by exact name. */
+export function setScene(sceneName) {
+  return run(async (request) => {
+    await request('SetCurrentProgramScene', { sceneName });
+    return { sceneName };
+  });
+}
+
+// ── sources (scene items) ────────────────────────────────────────────────────
+
+/** The current program scene's name — the default target for source commands. */
+async function currentScene(request) {
+  const { currentProgramSceneName } = await request('GetSceneList');
+  return currentProgramSceneName;
+}
+
+/** Every source in a scene, with whether it is currently visible. */
+export function listSources(sceneName = null) {
+  return run(async (request) => {
+    const scene = sceneName || (await currentScene(request));
+    const { sceneItems = [] } = await request('GetSceneItemList', { sceneName: scene });
+    return {
+      scene,
+      // Reversed for the same reason as scenes: OBS's list is bottom-up.
+      items: sceneItems
+        .map((i) => ({ name: i.sourceName, id: i.sceneItemId, visible: i.sceneItemEnabled }))
+        .reverse(),
+    };
+  });
+}
+
+/**
+ * Show, hide, or flip a source's visibility.
+ * @param {'show'|'hide'|'toggle'} mode
+ */
+export function setSourceVisible(sourceName, mode, sceneName = null) {
+  return run(async (request) => {
+    const scene = sceneName || (await currentScene(request));
+    // SetSceneItemEnabled takes a numeric id; there is no name-based form.
+    const { sceneItemId } = await request('GetSceneItemId', { sceneName: scene, sourceName });
+    let enabled;
+    if (mode === 'toggle') {
+      const cur = await request('GetSceneItemEnabled', { sceneName: scene, sceneItemId });
+      enabled = !cur.sceneItemEnabled;
+    } else {
+      enabled = mode === 'show';
+    }
+    await request('SetSceneItemEnabled', { sceneName: scene, sceneItemId, sceneItemEnabled: enabled });
+    return { scene, sourceName, visible: enabled };
+  });
+}
+
+// ── filters ──────────────────────────────────────────────────────────────────
+
+/** Every filter on a source, in OBS's own order, with enabled state. */
+export function listFilters(sourceName) {
+  return run(async (request) => {
+    const { filters = [] } = await request('GetSourceFilterList', { sourceName });
+    return {
+      sourceName,
+      filters: filters.map((f) => ({ name: f.filterName, kind: f.filterKind, enabled: f.filterEnabled })),
+    };
+  });
+}
+
+/** Turn one filter on or off. */
+export function setFilter(sourceName, filterName, enabled) {
+  return run(async (request) => {
+    await request('SetSourceFilterEnabled', { sourceName, filterName, filterEnabled: enabled });
+    return { sourceName, filterName, enabled };
+  });
+}
+
+// ── audio ────────────────────────────────────────────────────────────────────
+
+/**
+ * Inputs that actually have audio, with mute state and level.
+ *
+ * OBS has no "list audio inputs" request, so this asks every input for its mute
+ * state and keeps the ones that answer — a source with no audio track errors,
+ * and that error IS the filter. Costs one round trip per input, on a single
+ * connection, which is fine for a command a mod types occasionally.
+ */
+export function listAudio() {
+  return run(async (request) => {
+    const { inputs = [] } = await request('GetInputList');
+    const out = [];
+    for (const { inputName } of inputs) {
+      try {
+        const { inputMuted } = await request('GetInputMute', { inputName });
+        const { inputVolumeDb } = await request('GetInputVolume', { inputName });
+        out.push({ name: inputName, muted: inputMuted, db: inputVolumeDb });
+      } catch {
+        /* no audio track on this input — not an error, just not audio */
+      }
+    }
+    return { inputs: out };
+  });
+}
+
+/**
+ * Mute, unmute, or flip an audio input.
+ * @param {'mute'|'unmute'|'toggle'} mode
+ */
+export function setMute(inputName, mode) {
+  return run(async (request) => {
+    let muted;
+    if (mode === 'toggle') {
+      const { inputMuted } = await request('GetInputMute', { inputName });
+      muted = !inputMuted;
+    } else {
+      muted = mode === 'mute';
+    }
+    await request('SetInputMute', { inputName, inputMuted: muted });
+    return { inputName, muted };
+  });
+}
+
+// ── health ───────────────────────────────────────────────────────────────────
+
+/**
+ * The numbers that say whether the STREAM is healthy, not whether OBS is up.
+ * Dropped frames and encoder lag are what a mod needs when chat says "it's
+ * buffering" and the streamer can't see it.
+ */
+export function getStats() {
+  return run(async (request) => {
+    const s = await request('GetStats');
+    const out = await request('GetStreamStatus').catch(() => null);
+    return {
+      cpu: s.cpuUsage,
+      fps: s.activeFps,
+      renderSkipped: s.renderSkippedFrames,
+      renderTotal: s.renderTotalFrames,
+      outputSkipped: s.outputSkippedFrames,
+      outputTotal: s.outputTotalFrames,
+      diskGb: s.availableDiskSpace / 1024,
+      streaming: out?.outputActive ?? null,
+      streamSkipped: out?.outputSkippedFrames ?? null,
+      streamTotal: out?.outputTotalFrames ?? null,
+    };
+  });
+}

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -18,6 +18,7 @@ import { getRaidPointer, getConfig, setLive, setClipMode } from '../../src/db/co
 import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 import { initMediaWith } from '../../src/integrations/obsMedia.js';
+import { initObsControlWith } from '../../src/integrations/obsControl.js';
 import { clearMediaSlot, listSlots } from '../../src/db/media.js';
 import { slotInputs } from '../../src/rules/media.js';
 import { defaultBoss } from '../../src/content/bosses.js';
@@ -484,6 +485,61 @@ export const SCENARIOS = [
         // Scenarios share one emulator DB — leave no slots behind.
         for (const n of [1, 2, 3]) await clearMediaSlot(n);
         initMediaWith(null);
+      }
+    },
+  },
+  {
+    command: 'obs', title: 'a mod drives scenes, sources, filters and audio from chat',
+    run: async ({ bot, u }) => {
+      const mod = u('e2e_obs', { login: 'nikki', name: 'Nikki', mod: true });
+      const calls = [];
+      // The seam is the obs-websocket `request` itself, so what's asserted is the
+      // protocol call OBS would actually receive — not a mock of our own shape.
+      initObsControlWith(async (type, data) => {
+        calls.push({ type, data });
+        switch (type) {
+          case 'GetSceneList':
+            return { currentProgramSceneName: 'Live', scenes: [{ sceneName: 'BRB' }, { sceneName: 'Live' }] };
+          case 'GetSceneItemList':
+            return { sceneItems: [{ sourceName: 'overlay', sceneItemId: 2, sceneItemEnabled: false }] };
+          case 'GetSceneItemId': return { sceneItemId: 2 };
+          case 'GetSourceFilterList':
+            return { filters: [{ filterName: 'Chroma Key', filterKind: 'chroma_key_filter_v2', filterEnabled: true }] };
+          case 'GetInputList': return { inputs: [{ inputName: 'Mic' }] };
+          case 'GetInputMute': return { inputMuted: false };
+          case 'GetInputVolume': return { inputVolumeDb: -6 };
+          case 'GetStats':
+            return { cpuUsage: 9, activeFps: 60, renderSkippedFrames: 0, renderTotalFrames: 100,
+                     outputSkippedFrames: 0, outputTotalFrames: 100, availableDiskSpace: 10240 };
+          case 'GetStreamStatus': return { outputActive: false };
+          default: return {};
+        }
+      });
+      try {
+        assert.match(await bot.send(mod, '!obs scenes'), /Live/);
+        assert.match(await bot.send(mod, '!obs scene BRB'), /switched to "BRB"/);
+        assert.equal(calls.at(-1).data.sceneName, 'BRB', 'the scene name reached OBS unchanged');
+
+        assert.match(await bot.send(mod, '!obs sources'), /overlay/);
+        assert.match(await bot.send(mod, '!obs show overlay'), /now visible/);
+        assert.equal(calls.at(-1).type, 'SetSceneItemEnabled');
+        assert.equal(calls.at(-1).data.sceneItemEnabled, true);
+
+        assert.match(await bot.send(mod, '!obs filters cam'), /Chroma Key/);
+        // Source and filter are both OBS names and both may contain spaces, so
+        // `|` is the only unambiguous split — same separator as !media set.
+        assert.match(await bot.send(mod, '!obs filter off cam | Chroma Key'), /is now off/);
+        assert.deepEqual(calls.at(-1).data, { sourceName: 'cam', filterName: 'Chroma Key', filterEnabled: false });
+        assert.match(await bot.send(mod, '!obs filter off cam'), /Usage: !obs filter/, 'needs both names');
+
+        assert.match(await bot.send(mod, '!obs audio'), /Mic/);
+        assert.match(await bot.send(mod, '!obs mute Mic'), /muted/);
+        assert.equal(calls.at(-1).data.inputMuted, true);
+
+        assert.match(await bot.send(mod, '!obs stats'), /60fps/);
+        assert.match(await bot.send(mod, '!obs nonsense'), /Usage: !obs/);
+      } finally {
+        initObsControlWith(null);
       }
     },
   },

--- a/test/rules/obs.test.js
+++ b/test/rules/obs.test.js
@@ -1,0 +1,206 @@
+// !obs — the obs-websocket request sequences behind scene switching, source
+// visibility, filters and audio.
+//
+// Driven through a fake `request` rather than a socket (initObsControlWith), so
+// what's asserted is the ACTUAL protocol call OBS would receive. Every bug worth
+// catching at this layer is either "wrong request" or "wrong order".
+//
+// The chat surface itself is covered by the e2e scenario in test/e2e/scenarios.js.
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initObsControlWith, obsControlReady,
+  listScenes, setScene, listSources, setSourceVisible,
+  listFilters, setFilter, listAudio, setMute, getStats,
+} from '../../src/integrations/obsControl.js';
+
+/** Records every request and answers with a small fake OBS. */
+function fakeObs(overrides = {}) {
+  const calls = [];
+  const answers = {
+    GetSceneList: { currentProgramSceneName: 'Live', scenes: [{ sceneName: 'BRB' }, { sceneName: 'Live' }] },
+    GetSceneItemList: { sceneItems: [
+      { sourceName: 'cam', sceneItemId: 1, sceneItemEnabled: true },
+      { sourceName: 'overlay', sceneItemId: 2, sceneItemEnabled: false },
+    ] },
+    GetSceneItemId: { sceneItemId: 7 },
+    GetSceneItemEnabled: { sceneItemEnabled: true },
+    SetSceneItemEnabled: {},
+    SetCurrentProgramScene: {},
+    GetSourceFilterList: { filters: [{ filterName: 'Chroma Key', filterKind: 'chroma_key_filter_v2', filterEnabled: true }] },
+    SetSourceFilterEnabled: {},
+    GetInputList: { inputs: [{ inputName: 'Mic' }, { inputName: 'Image' }] },
+    GetInputMute: { inputMuted: false },
+    GetInputVolume: { inputVolumeDb: -6 },
+    SetInputMute: {},
+    GetStats: {
+      cpuUsage: 12.5, activeFps: 60, renderSkippedFrames: 3, renderTotalFrames: 1000,
+      outputSkippedFrames: 0, outputTotalFrames: 900, availableDiskSpace: 51200,
+    },
+    GetStreamStatus: { outputActive: true, outputSkippedFrames: 5, outputTotalFrames: 900 },
+    ...overrides,
+  };
+  const request = async (type, data) => {
+    calls.push({ type, data });
+    const a = answers[type];
+    if (a instanceof Error) throw a;
+    if (typeof a === 'function') return a(data);
+    if (a === undefined) throw new Error(`fake OBS has no answer for ${type}`);
+    return a;
+  };
+  return { calls, request, types: () => calls.map((c) => c.type) };
+}
+
+let obs;
+beforeEach(() => {
+  obs = fakeObs();
+  initObsControlWith(obs.request);
+});
+after(() => initObsControlWith(null));
+
+// ── wiring ────────────────────────────────────────────────────────────────────
+
+test('the test seam stands in for a configured OBS, and null means none', () => {
+  assert.equal(obsControlReady(), true);
+  initObsControlWith(null);
+  assert.equal(obsControlReady(), false);
+});
+
+test('with no OBS configured every operation resolves rather than throwing', async () => {
+  initObsControlWith(null);
+  const res = await setScene('Live');
+  assert.deepEqual(res, { ok: false, reason: 'no OBS is configured for this bot' });
+});
+
+// ── scenes ────────────────────────────────────────────────────────────────────
+
+test('scenes come back in the order OBS shows them, not the order it sends them', async () => {
+  // OBS returns index 0 as the BOTTOM of its scene list; chat should read like
+  // the panel the streamer is looking at.
+  const res = await listScenes();
+  assert.deepEqual(res.data.names, ['Live', 'BRB']);
+  assert.equal(res.data.current, 'Live');
+});
+
+test('switching a scene sends the name unchanged', async () => {
+  const res = await setScene('Starting Soon');
+  assert.ok(res.ok);
+  assert.deepEqual(obs.calls[0], { type: 'SetCurrentProgramScene', data: { sceneName: 'Starting Soon' } });
+});
+
+test("a scene OBS doesn't have surfaces OBS's own error", async () => {
+  initObsControlWith(fakeObs({ SetCurrentProgramScene: new Error('No source was found by the name of `Nope`') }).request);
+  const res = await setScene('Nope');
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /No source was found/);
+});
+
+// ── sources ───────────────────────────────────────────────────────────────────
+
+test('listing sources defaults to the scene that is live', async () => {
+  const res = await listSources();
+  assert.equal(res.data.scene, 'Live');
+  assert.deepEqual(obs.types(), ['GetSceneList', 'GetSceneItemList']);
+  assert.equal(obs.calls[1].data.sceneName, 'Live');
+  // Reversed like scenes, so the top of the chat list is the top of OBS's list.
+  assert.deepEqual(res.data.items.map((i) => i.name), ['overlay', 'cam']);
+  assert.deepEqual(res.data.items.map((i) => i.visible), [false, true]);
+});
+
+test('an explicit scene skips the lookup of the current one', async () => {
+  await listSources('BRB');
+  assert.deepEqual(obs.types(), ['GetSceneItemList']);
+});
+
+test('show and hide set visibility directly, by numeric id', async () => {
+  const res = await setSourceVisible('overlay', 'show');
+  assert.equal(res.data.visible, true);
+  assert.deepEqual(obs.types(), ['GetSceneList', 'GetSceneItemId', 'SetSceneItemEnabled']);
+  // The id must come from OBS — there is no name-based form of this request, and
+  // a remembered id goes stale the moment a source is reordered.
+  assert.deepEqual(obs.calls[2].data, { sceneName: 'Live', sceneItemId: 7, sceneItemEnabled: true });
+
+  obs = fakeObs();
+  initObsControlWith(obs.request);
+  assert.equal((await setSourceVisible('overlay', 'hide')).data.visible, false);
+  assert.equal(obs.calls[2].data.sceneItemEnabled, false);
+});
+
+test('toggle reads the current state first and inverts it', async () => {
+  const res = await setSourceVisible('cam', 'toggle');   // fake says enabled: true
+  assert.equal(res.data.visible, false);
+  assert.deepEqual(obs.types(), [
+    'GetSceneList', 'GetSceneItemId', 'GetSceneItemEnabled', 'SetSceneItemEnabled',
+  ]);
+  assert.equal(obs.calls[3].data.sceneItemEnabled, false);
+});
+
+// ── filters ───────────────────────────────────────────────────────────────────
+
+test('filters come back with their enabled state', async () => {
+  const res = await listFilters('cam');
+  assert.deepEqual(res.data.filters, [
+    { name: 'Chroma Key', kind: 'chroma_key_filter_v2', enabled: true },
+  ]);
+});
+
+test('setting a filter names both the source and the filter', async () => {
+  await setFilter('cam', 'Chroma Key', false);
+  assert.deepEqual(obs.calls[0].data, {
+    sourceName: 'cam', filterName: 'Chroma Key', filterEnabled: false,
+  });
+});
+
+// ── audio ─────────────────────────────────────────────────────────────────────
+
+test('listing audio keeps only the inputs that HAVE audio', async () => {
+  // OBS has no "list audio inputs" request: an input with no audio track errors
+  // on GetInputMute, and that error is the filter. An image source must not
+  // appear in a list a mod is about to mute.
+  const o = fakeObs({
+    GetInputMute: (d) => {
+      if (d.inputName === 'Image') throw new Error('no audio track');
+      return { inputMuted: true };
+    },
+  });
+  initObsControlWith(o.request);
+  const res = await listAudio();
+  assert.deepEqual(res.data.inputs, [{ name: 'Mic', muted: true, db: -6 }]);
+});
+
+test('mute and unmute set the state directly', async () => {
+  await setMute('Mic', 'mute');
+  assert.deepEqual(obs.calls[0], { type: 'SetInputMute', data: { inputName: 'Mic', inputMuted: true } });
+
+  obs = fakeObs();
+  initObsControlWith(obs.request);
+  await setMute('Mic', 'unmute');
+  assert.equal(obs.calls[0].data.inputMuted, false);
+});
+
+test('audio toggle reads first, like the visibility toggle', async () => {
+  const res = await setMute('Mic', 'toggle');    // fake says muted: false
+  assert.equal(res.data.muted, true);
+  assert.deepEqual(obs.types(), ['GetInputMute', 'SetInputMute']);
+});
+
+// ── stats ─────────────────────────────────────────────────────────────────────
+
+test('stats carry the stream numbers, not just the app ones', async () => {
+  const res = await getStats();
+  assert.equal(res.data.fps, 60);
+  assert.equal(res.data.streaming, true);
+  assert.equal(res.data.streamSkipped, 5);
+  assert.equal(res.data.diskGb, 50);
+});
+
+test('stats still work when nothing is streaming', async () => {
+  // GetStreamStatus is allowed to fail — OBS health is still worth reporting when
+  // the stream is down, which is exactly when someone is asking.
+  const o = fakeObs({ GetStreamStatus: new Error('not streaming') });
+  initObsControlWith(o.request);
+  const res = await getStats();
+  assert.ok(res.ok);
+  assert.equal(res.data.streaming, null);
+  assert.equal(res.data.fps, 60);
+});


### PR DESCRIPTION
The rest of the obs-websocket surface, on the same connection `!media` and the
clip capture already use.

```
!obs                          current scene, fps, skipped frames
!obs scenes                   list · !obs scene Starting Soon   cut to one
!obs sources [scene]          what's in a scene, and what's visible
!obs show|hide|toggle <src>   flip a source in the live scene
!obs filters <source>         list · !obs filter off cam | Chroma Key
!obs audio                    inputs with mute state and level
!obs mute|unmute <input>      OBS audio — NOT !mute, which silences the bot
!obs stats                    dropped frames as a RATE, CPU, free disk
```

Mod-only. Built to **learn what OBS exposes from chat**, so it is deliberately
broad and deliberately thin.

## Decisions

**One command with sub-verbs, not eight top-level names.** `!obs` alone is the
discoverable index of what's available, and it keeps eight words out of a chat
namespace shared with other bots.

**`!obs mute` rather than `!mute`** — precisely because `!mute` already exists and
means something entirely different: silencing the *bot's* chat output. Two mutes
at top level is a mistake waiting for a stressful moment. Checked the registry
for collisions before naming anything.

**`!obs scene` takes any scene name, no allowlist** — the owner's call, for an
experiment. Unrestricted is better for learning; a guard rail can come later if a
verb proves worth keeping.

**Errors are OBS's own text, passed through.** When a name is wrong, OBS names it,
and that beats anything we would write.

**Stats report skipped frames as a percentage.** A raw count is meaningless
without the total — "312 dropped" reads as alarming and is fine out of two
million. `GetStreamStatus` is allowed to fail so stats still work when nothing is
streaming, which is exactly when someone is asking.

**Scenes and sources are reversed on the way out.** OBS returns index 0 as the
*bottom* of its list; reversing makes chat read like the panel the streamer is
looking at.

**Audio inputs are discovered by asking.** OBS has no "list audio inputs" request,
so `!obs audio` asks every input for its mute state and keeps the ones that answer
— an input with no audio track errors, and that error *is* the filter. An image
source must not appear in a list a mod is about to mute.

**Connection state is resolved in `obsControl.js` rather than shared with
`obsMedia.js`** — a little duplication, in exchange for the merged, rig-verified
media path being impossible to destabilise from an experiment. Both read the same
env, so they cannot disagree about where OBS is.

## Verification

`npm test` **182** (16 new) · `npm run test:emulator` **75** · `npm run test:e2e`
**33** (new `!obs` scenario; the coverage test enforces one per command).

The test seam is the obs-websocket `request` function itself, not each operation,
so tests assert the protocol calls OBS would actually receive rather than a mock
of our own design. That covers the two bug classes at this layer: wrong request,
and wrong order (both toggles read current state before inverting).

Every read-only operation was then run against a **real OBS** and returned sane
data — scenes, 8 scene items with visibility, 8 audio inputs with real dB levels,
live stats (30fps, 192GB free), and an empty filter list. Nothing was mutated on
that rig.

## Live verification (added after testing)

Exercised in `#scasplte2` chat against the real rig: scene switching (including a
scene name containing spaces and a question mark), source show/hide/toggle, filter
listing and on/off, audio listing and mute, and stats. Reported working by the
owner. This PR was opened before that test; from now on the live run comes first.
