### PR TITLE
feat: !song — Spotify now playing, in chat and on an OBS overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Firebase and OBS, and never listens on a port — and ships as a container.
 | Feature | Commands | Notes |
 |---|---|---|
 | **Clips** | `!clip` · `!clipmode` · `!start` | 16:9 + natively-framed 9:16 captured on the streamer's PC over obs-websocket / Aitum |
+| **Now playing** | `!song` | reads Spotify (account-scoped, so the bot needn't be on that machine) + an OBS text overlay |
 | **On-stream media** | `!media` | play a mapped OBS media source from chat — the same connection, pointed at a source instead of the buffer |
 | **OBS control** | `!obs` | scenes, source visibility, filters, audio mute and stream stats, from chat |
 | **Stream timer** | `!timer` | one countdown, heads-up marks, survives a restart |
@@ -86,7 +87,7 @@ Underneath both:
 - **automated releases** from Conventional Commits (release-please), with `main`
   protected for everyone including admins
 
-Verified by `npm test` (182 offline unit tests), `npm run test:emulator` (75 — RTDB
+Verified by `npm test` (196 offline unit tests), `npm run test:emulator` (75 — RTDB
 rules + client-write rejection, and the stateful command paths), `npm run test:e2e`
 (33 — every registered command driven through the real dispatcher), and
 `npm run synthetic` (full muster→battle→victory run with UI-contract assertions).
@@ -120,16 +121,19 @@ src/
   content/                your own data: classes.js (class→role), items.js (catalog +
                           starter gear), facts.js, reminders.js (default schedules)
   rules/                  PURE, RNG/clock-injected, unit-tested: leveling, rating, loot,
-                          combat, reminders (what's due now), media (slot parsing/validation)
+                          combat, reminders (what's due now), media (slot parsing/validation),
+                          spotify (now-playing formatting)
   db/                     firebase, configStore (live mirror), players, raid, drops, wallet,
                           market, timer, reminders, media, todo, facts, lock, tokenStore
   twitch/                 auth (RefreshingAuthProvider), liveGate (Helix poll), eventsub (WS),
                           sender (Helix/IRC send + badge), clips (Helix Create Clip)
   integrations/           obsWebsocket (v5 client + Aitum vendor requests), capture (facade +
                           rate limit), obsMedia (media actions), obsControl (scenes,
-                          sources, filters, audio) — all on the same socket
+                          sources, filters, audio), spotify (now playing, token
+                          refresh) — the OBS three all on the same socket
   events/                 chat (gate→EXP→raid tick + dispatch), twitchEvents (sub/cheer/raid),
-                          dropScheduler · timerScheduler · reminderScheduler
+                          dropScheduler · timerScheduler · reminderScheduler ·
+                          spotifyScheduler (writes the now-playing overlay)
   commands/               one module per command + registry; mod/ subdir for mod commands
 test/                     rules/*.test.js (offline) · firebase-rules.test.js (emulator) · e2e/ (dispatcher)
 scripts/synthetic-chat.js no-stream harness that drives the whole loop
@@ -168,6 +172,12 @@ of the replay buffer.
 | `!obs filters <source>` · `!obs filter on\|off <source> \| <filter>` | mod | list a source's filters · switch one |
 | `!obs audio` · `!obs mute\|unmute <input>` | mod | audio inputs with mute state and level · mute one. **Not** `!mute`, which silences the bot |
 | `!obs stats` | mod | dropped frames as a rate, CPU, free disk — for when chat says it's buffering |
+
+**Now playing**
+
+| Command | Who | Effect |
+|---|---|---|
+| `!song` / `!nowplaying` / `!np` | everyone | what's playing on the streamer's Spotify — track, artists, position, and a link |
 
 **Around the stream**
 
@@ -491,6 +501,46 @@ would write.
 `!obs stats` reports skipped frames as a **percentage**, because a raw count means
 nothing without the total: "312 dropped" reads as alarming and is fine out of two
 million.
+
+### Now playing — `!song` and the OBS overlay
+
+`!song` answers what the streamer's Spotify is playing. The Web API is
+**account-scoped, not device-scoped**, so this reads that account's playback on any
+device — the bot does not need to run on the machine Spotify is on, and nothing is
+installed there. You can only ever read your *own* account; there is no endpoint
+for "what is user X playing".
+
+**Setup** (once):
+
+1. Register an app at [developer.spotify.com](https://developer.spotify.com/dashboard);
+   put the client id + secret in `.env` as `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET`.
+2. Add the redirect URI **`http://127.0.0.1:8888/callback`** to the app and save it.
+   Spotify explicitly rejects `localhost` — it must be the loopback IP literal.
+3. `node scripts/get-spotify-token.mjs` — approve in the browser. The refresh token
+   is written to the token store, and printed for `SPOTIFY_REFRESH_TOKEN`.
+
+Only `user-read-currently-playing` is requested. Podcast episodes may additionally
+need `user-read-playback-state`; set `SPOTIFY_SCOPES` and re-run the script.
+
+**The overlay.** Set `SPOTIFY_OVERLAY_SOURCE` to the name of an OBS text source and
+kennyBot keeps it current. `node scripts/obs-overlay-setup.mjs` creates one and adds
+it to every scene — deliberately **one source shown in several scenes**, not a copy
+per scene, so a single write updates them all and they cannot drift.
+
+It **writes only when the line changes**: a text source rewritten every poll
+re-renders in OBS for nothing. And it **clears** when playback stops or pauses,
+rather than freezing the last track — a stale song title is worse than none,
+because viewers believe it.
+
+`config.spotify` holds the poll interval, the cache window, and the overlay prefix
+(`Now Playing: `). The prefix is applied only to a non-empty line, so a pause
+leaves an empty source rather than a bare label.
+
+Spotify's payload has more shapes than "a song is playing", and each one reaches
+chat: nothing playing (a **204 with an empty body** — parsing it would throw),
+paused (still populated, `is_playing:false`), an **episode** (no `artists` field at
+all), an ad, and a local file with no URL. All five are covered in
+`test/rules/spotify.test.js` and were exercised against a real account.
 
 The one point of contact is `!start` (`src/db/clipSync.js`), which writes a per-stream
 sync anchor to RTDB — *data the archiver reads*, not a file handoff, and it works

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -336,6 +336,21 @@ restart can't make the bot repeat a "1 minute left" it already posted.
 | `tickMs` | `1000` (1 s) | Countdown resolution. Each tick reads memory only — RTDB is touched just when the timer actually fires. | Higher = a "time's up" that can land that much late. Little reason to change. |
 | `maxLabelLen` | `60` | Longest timer label; longer ones are clipped with `…`. | Keeps a pasted paragraph out of every heads-up line. |
 
+## `spotify` — now playing (`!song` + the overlay)
+
+| Key | Default | What it controls |
+|---|---|---|
+| `cacheMs` | `5_000` | How long one Spotify answer is reused. `!song` is a pile-on command and the answer can't meaningfully change in a couple of seconds — twenty viewers asking at once must be one request, not twenty. |
+| `overlayPollMs` | `10_000` | How often the overlay re-checks. The write is skipped unless the line changed, so this is how quickly a track change appears on stream, not a write rate. |
+| `overlayPrefix` | `'Now Playing: '` | Prepended to the overlay only — never to the chat reply, and never to an empty line. |
+
+Environment: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, optionally
+`SPOTIFY_REFRESH_TOKEN` (otherwise the token store is used), and
+`SPOTIFY_OVERLAY_SOURCE` — the OBS text source to write. Unset means no overlay and
+no polling at all.
+
+---
+
 ---
 
 ## `lock` — single-instance lease

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ import { initClips } from './src/twitch/clips.js';
 import { initCapture, captureReady } from './src/integrations/capture.js';
 import { initMedia } from './src/integrations/obsMedia.js';
 import { initObsControl } from './src/integrations/obsControl.js';
+import { initSpotify } from './src/integrations/spotify.js';
+import { startSpotifyOverlay } from './src/events/spotifyScheduler.js';
 // Read once at boot purely to log what's in force; the live value is RTDB-backed.
 import { activeClipMode } from './src/commands/clip.js';
 import { startLivePoll } from './src/twitch/liveGate.js';
@@ -223,6 +225,10 @@ async function main() {
 
   // Scenes / source visibility / filters / audio on that same OBS (`!obs`).
   initObsControl({}, logger);
+  // Spotify "now playing" (`!song`). Account-scoped, so it reads whatever the
+  // streamer's Spotify is playing on ANY device — the bot does not need to be on
+  // the same machine, and nothing is installed there.
+  await initSpotify({}, logger);
 
   // What !clip actually does. Default 'local': trigger the streamer's OBS/Aitum
   // capture and post NO Twitch clip — a Twitch clip is capped at the stream
@@ -307,6 +313,10 @@ async function main() {
   // so this only supplies the clock and the channel — which is also what makes a
   // reminder channel-specific without any per-channel branch in the code.
   shutdownHooks.push(startReminderScheduler({ send, channel, logger }));
+
+  // Now-playing overlay: writes the current track into an OBS text source named
+  // by SPOTIFY_OVERLAY_SOURCE. No source name → no polling at all.
+  shutdownHooks.push(startSpotifyOverlay({ logger }));
 
   // ── Live gate: Helix poll (always) + EventSub (when broadcaster auth fits) ──
   const setLiveBound = (live, source) => {

--- a/scripts/get-spotify-token.mjs
+++ b/scripts/get-spotify-token.mjs
@@ -1,0 +1,115 @@
+// One-off helper: obtain the Spotify refresh token `!song` needs.
+//
+// NOT part of the running bot — kennyBot is outbound-only. This briefly listens on
+// 127.0.0.1 purely to catch the OAuth redirect, then exits. Exactly the same shape
+// as scripts/get-token.mjs does for Twitch.
+//
+// Prereqs:
+//   1. SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET in .env (from
+//      https://developer.spotify.com/dashboard → your app → Settings).
+//   2. Add the redirect URI to that app and SAVE it. It must be the loopback IP
+//      literal — Spotify explicitly rejects `localhost`:
+//        http://127.0.0.1:8888/callback
+//   3. Be logged into Spotify as the account whose music should be shown.
+//
+// Run:
+//   node scripts/get-spotify-token.mjs
+//
+// The token is written straight into the token store (TOKEN_STORE_DIR, default
+// ./.tokens) as token-spotify.json, so nothing needs pasting into .env. It is
+// also printed, for a deployment that prefers SPOTIFY_REFRESH_TOKEN.
+import 'dotenv/config';
+import http from 'node:http';
+import { TokenStore } from '../src/db/tokenStore.js';
+
+const clientId = process.env.SPOTIFY_CLIENT_ID;
+const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+// Spotify permits http ONLY for a loopback address given as an IP literal.
+const redirectUri = process.env.SPOTIFY_REDIRECT_URI || 'http://127.0.0.1:8888/callback';
+// Everything !song needs and nothing more. Podcasts additionally need
+// user-read-playback-state; add it here if you want episodes named.
+const scopes = (process.env.SPOTIFY_SCOPES || 'user-read-currently-playing').split(/\s+/).filter(Boolean);
+
+if (!clientId || !clientSecret) {
+  console.error('Missing SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET (set them in .env).');
+  process.exit(1);
+}
+
+const url = new URL(redirectUri);
+const state = Math.random().toString(36).slice(2);
+
+const authUrl =
+  'https://accounts.spotify.com/authorize?' +
+  new URLSearchParams({
+    client_id: clientId,
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    scope: scopes.join(' '),
+    state,
+    // Force the consent screen so re-running this after a scope change actually
+    // re-prompts instead of silently handing back the old grant.
+    show_dialog: 'true',
+  });
+
+console.log('\n1. Open this in a browser signed in as the Spotify account to show:\n');
+console.log(`   ${authUrl}\n`);
+console.log(`2. Approve. Waiting for the redirect on ${redirectUri} …\n`);
+
+const server = http.createServer(async (req, res) => {
+  const got = new URL(req.url, `http://${req.headers.host}`);
+  if (got.pathname !== url.pathname) {
+    res.writeHead(404).end('not the redirect path');
+    return;
+  }
+  const code = got.searchParams.get('code');
+  const err = got.searchParams.get('error');
+  if (err || !code) {
+    res.writeHead(400).end(`Spotify returned: ${err || 'no code'}`);
+    console.error(`\n✗ ${err || 'no code in redirect'}`);
+    server.close();
+    process.exitCode = 1;
+    return;
+  }
+  if (got.searchParams.get('state') !== state) {
+    res.writeHead(400).end('state mismatch');
+    console.error('\n✗ state mismatch — start over');
+    server.close();
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const r = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+      },
+      body: new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: redirectUri }),
+    });
+    const json = await r.json();
+    if (!r.ok) throw new Error(`${r.status} ${JSON.stringify(json)}`);
+
+    const store = new TokenStore(process.env.TOKEN_STORE_DIR || './.tokens');
+    await store.save('spotify', {
+      refreshToken: json.refresh_token,
+      scope: (json.scope || '').split(' ').filter(Boolean),
+      obtainmentTimestamp: Date.now(),
+    });
+
+    res.writeHead(200, { 'content-type': 'text/html' })
+      .end('<h2>kennyBot: Spotify connected.</h2><p>You can close this tab.</p>');
+    console.log('✓ stored in the token store as token-spotify.json');
+    console.log('  scopes:', json.scope);
+    console.log('\n  (optional, for a deployment without the token file:)');
+    console.log(`  SPOTIFY_REFRESH_TOKEN=${json.refresh_token}\n`);
+  } catch (e) {
+    res.writeHead(500).end('token exchange failed');
+    console.error(`\n✗ token exchange failed: ${e.message}`);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+  }
+});
+
+server.listen(Number(url.port || 80), url.hostname);

--- a/scripts/obs-overlay-setup.mjs
+++ b/scripts/obs-overlay-setup.mjs
@@ -1,0 +1,96 @@
+// Create the now-playing text source in OBS and add it to every scene.
+//
+// Separate from the bot on purpose: creating and positioning sources is SETUP, and
+// a bot that invents sources in your scene collection at boot is a bot you stop
+// trusting. Run this once; after that kennyBot only ever writes the source's text.
+//
+//   node scripts/obs-overlay-setup.mjs                    create + add to all scenes
+//   node scripts/obs-overlay-setup.mjs --name "Now Playing"
+//   node scripts/obs-overlay-setup.mjs --scenes "Scene,BRB"   only these
+//   node scripts/obs-overlay-setup.mjs --remove           undo it everywhere
+//
+// ONE source shown in several scenes, not a copy per scene: in OBS a source can
+// appear in many scenes as separate scene items, and they all render the same
+// underlying text. So kennyBot writes once and every scene updates. Copies would
+// need a write each and would drift.
+import 'dotenv/config';
+import { withObs, obsConnectionFromEnv } from '../src/integrations/obsWebsocket.js';
+
+const conn = obsConnectionFromEnv();
+if (!conn) {
+  console.error('Need OBS_WEBSOCKET_URL (and usually OBS_WEBSOCKET_PASSWORD) in .env');
+  process.exit(1);
+}
+
+const arg = (f) => {
+  const i = process.argv.indexOf(f);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+};
+const NAME = arg('--name') || process.env.SPOTIFY_OVERLAY_SOURCE || 'Now Playing';
+const REMOVE = process.argv.includes('--remove');
+const ONLY = arg('--scenes')?.split(',').map((s) => s.trim()).filter(Boolean);
+
+await withObs(conn, async (rq) => {
+  const { scenes } = await rq('GetSceneList');
+  const names = scenes.map((s) => s.sceneName).reverse();
+  const targets = ONLY ? names.filter((n) => ONLY.includes(n)) : names;
+  if (!targets.length) {
+    console.error(`No matching scenes. OBS has: ${names.join(', ')}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (REMOVE) {
+    // Removing the INPUT removes every scene item referencing it, in one call.
+    await rq('RemoveInput', { inputName: NAME });
+    console.log(`removed "${NAME}" from all scenes`);
+    return;
+  }
+
+  // Which text kind this OBS build has: GDI+ on Windows, FreeType elsewhere. Ask
+  // rather than assume — the wrong kind fails with an unhelpful error.
+  const { inputKinds } = await rq('GetInputKindList');
+  const kind = ['text_gdiplus_v3', 'text_gdiplus_v2', 'text_ft2_source_v2']
+    .find((k) => inputKinds.includes(k));
+  if (!kind) {
+    console.error(`No text source kind available. OBS offers: ${inputKinds.join(', ')}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const exists = (await rq('GetInputList')).inputs.some((i) => i.inputName === NAME);
+  const [first, ...rest] = targets;
+
+  if (!exists) {
+    await rq('CreateInput', {
+      sceneName: first,
+      inputName: NAME,
+      inputKind: kind,
+      inputSettings: {
+        text: '',
+        // A readable default; restyle it in OBS afterwards, this only has to be
+        // visible enough to find and drag.
+        font: { face: 'Segoe UI', size: 36, style: 'Bold' },
+        color: 0xffffffff,
+        outline: true,
+      },
+    });
+    console.log(`created "${NAME}" [${kind}] in "${first}"`);
+  } else {
+    console.log(`"${NAME}" already exists — adding it to any scene that lacks it`);
+    rest.unshift(first);
+  }
+
+  for (const sceneName of rest) {
+    const { sceneItems } = await rq('GetSceneItemList', { sceneName });
+    if (sceneItems.some((i) => i.sourceName === NAME)) {
+      console.log(`  "${sceneName}": already there`);
+      continue;
+    }
+    await rq('CreateSceneItem', { sceneName, sourceName: NAME, sceneItemEnabled: true });
+    console.log(`  "${sceneName}": added`);
+  }
+
+  console.log(`\nNow set this in .env so kennyBot writes to it:\n  SPOTIFY_OVERLAY_SOURCE=${NAME}`);
+  console.log('Then position and restyle it in OBS — it is one source, so every scene follows.');
+});

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -18,6 +18,7 @@ import duel from './duel.js';
 import trade from './trade.js';
 import offer from './offer.js';
 import clip from './clip.js';
+import song from './song.js';
 import start from './start.js';
 import market from './mod/market.js';
 import todo from './mod/todo.js';
@@ -34,7 +35,7 @@ import reminder from './mod/reminder.js';
 import media from './mod/media.js';
 import obs from './mod/obs.js';
 
-const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder, media, obs];
+const defs = [create, char, bag, equip, unequip, grab, raid, top, fact, kennycommands, points, daily, bet, duel, trade, offer, clip, song, start, exp, clipmode, mute, drop, drops, boss, raidnight, season, market, todo, timer, reminder, media, obs];
 
 /** @type {Map<string, typeof defs[number]>} */
 const byName = new Map();

--- a/src/commands/song.js
+++ b/src/commands/song.js
@@ -1,0 +1,35 @@
+// !song / !nowplaying / !np — what the streamer's Spotify is playing.
+//
+// Public: it is read-only, it names music rather than anything about the rig, and
+// "what's this song?" is the single most common question a music stream gets.
+//
+// The per-user cooldown is the usual gate, but the real protection is the cache in
+// the integration — twenty viewers asking at once is ONE Spotify request, and the
+// answer cannot meaningfully change in the couple of seconds between them.
+//
+// Every not-playing case is a real sentence rather than silence, because the
+// states are genuinely different and viewers can tell: paused is not stopped, and
+// an ad is not a song. Those distinctions live in src/rules/spotify.js.
+import { currentlyPlaying, spotifyReady } from '../integrations/spotify.js';
+import { readNowPlaying, chatLine } from '../rules/spotify.js';
+
+export default {
+  names: ['song', 'nowplaying', 'np'],
+  mod: false,
+  cooldownMs: 10_000,
+  help: '!song — what is playing on Spotify right now',
+  async run({ reply, logger }) {
+    if (!spotifyReady()) {
+      reply('🎧 Spotify isn\'t connected for this bot');
+      return;
+    }
+    const res = await currentlyPlaying(logger);
+    if (!res.ok) {
+      // Spotify's own words, not ours — "rate limited, retry in 3s" tells a viewer
+      // something useful, where "something went wrong" tells them nothing.
+      reply(`🎧 couldn't reach Spotify: ${res.reason}`);
+      return;
+    }
+    reply(chatLine(readNowPlaying(res.payload)));
+  },
+};

--- a/src/config.js
+++ b/src/config.js
@@ -205,6 +205,22 @@ export const config = {
     defaultMode: 'horizontal,vertical',
   },
 
+  // ── Spotify "now playing" (`!song` + the OBS overlay) ────────────────────
+  spotify: {
+    // How long one Spotify answer is reused. `!song` is a pile-on command, and
+    // the answer cannot meaningfully change in a couple of seconds — twenty
+    // viewers asking at once must be ONE request, not twenty.
+    cacheMs: 5_000,
+    // How often the overlay re-checks. The write itself is skipped unless the
+    // line changed, so this is the latency of a track change appearing on
+    // stream, not a write rate.
+    overlayPollMs: 10_000,
+    // Prepended to the on-stream overlay, never to the chat reply. Applied only
+    // when something is actually playing — an empty line stays empty so the
+    // source collapses instead of showing a lone label.
+    overlayPrefix: 'Now Playing: ',
+  },
+
   // ── Single-instance lease (IMPLEMENTATION §E/§J) ─────────────────────────
   lock: {
     heartbeatMs: 15_000,

--- a/src/events/spotifyScheduler.js
+++ b/src/events/spotifyScheduler.js
@@ -1,0 +1,85 @@
+// NOW-PLAYING OVERLAY — keeps an OBS text source showing the current track.
+//
+// Polls Spotify and writes the line into a text source over the same
+// obs-websocket connection everything else uses. The source is named by
+// SPOTIFY_OVERLAY_SOURCE; unset means no overlay and no polling at all.
+//
+// WRITES ONLY ON CHANGE. A text source rewritten every ten seconds with identical
+// content is pure churn — and in OBS a settings write is not free, it re-renders
+// the source. So the last written value is held in memory and compared first.
+//
+// Memory, not the database, on purpose: this is a cache of what OBS was last told,
+// not state worth surviving a restart. After a restart the first poll writes
+// whatever is playing, which is correct by construction.
+//
+// An empty line (nothing playing, paused, an ad) CLEARS the overlay rather than
+// leaving the last song frozen on screen — a stale track name is worse than none,
+// because viewers believe it.
+
+import { withObs, obsConnectionFromEnv } from '../integrations/obsWebsocket.js';
+import { currentlyPlaying, spotifyReady } from '../integrations/spotify.js';
+import { readNowPlaying, overlayLine } from '../rules/spotify.js';
+import { config } from '../config.js';
+
+/**
+ * @param {{ sourceName?: string, logger?: any, intervalMs?: number }} deps
+ * @returns {() => void} stop
+ */
+export function startSpotifyOverlay({ sourceName, logger = console, intervalMs } = {}) {
+  const source = sourceName ?? process.env.SPOTIFY_OVERLAY_SOURCE ?? '';
+  const every = intervalMs ?? config.spotify.overlayPollMs;
+
+  if (!source) {
+    logger.info?.('spotify overlay disabled (no SPOTIFY_OVERLAY_SOURCE)');
+    return () => {};
+  }
+  if (!spotifyReady()) {
+    logger.info?.('spotify overlay disabled (spotify not connected)');
+    return () => {};
+  }
+  if (!obsConnectionFromEnv()) {
+    logger.info?.('spotify overlay disabled (no OBS_WEBSOCKET_URL)');
+    return () => {};
+  }
+
+  let lastWritten = null;
+  let stopped = false;
+  let running = false;
+
+  async function tick() {
+    // A slow poll must never overlap the next one — Spotify and OBS are both
+    // network hops, and two writes racing would fight over the same source.
+    if (stopped || running) return;
+    running = true;
+    try {
+      const res = await currentlyPlaying(logger);
+      if (!res.ok) return; // already logged; keep whatever is on screen
+      const line = overlayLine(readNowPlaying(res.payload), { prefix: config.spotify.overlayPrefix });
+      if (line === lastWritten) return;
+
+      await withObs(obsConnectionFromEnv(), (request) =>
+        request('SetInputSettings', { inputName: source, inputSettings: { text: line }, overlay: true }),
+      );
+      lastWritten = line;
+      logger.info?.('spotify overlay updated', { source, text: line || '(cleared)' });
+    } catch (err) {
+      // OBS closed, PC asleep, source renamed — all expected, none fatal. Reset
+      // so the next successful poll rewrites rather than believing OBS still
+      // shows what we last sent it.
+      lastWritten = null;
+      logger.warn?.('spotify overlay update failed', { source, err: String(err?.message || err) });
+    } finally {
+      running = false;
+    }
+  }
+
+  logger.info?.('spotify overlay started', { source, everyMs: every });
+  const timer = setInterval(tick, every);
+  timer.unref?.();
+  tick();
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/src/integrations/spotify.js
+++ b/src/integrations/spotify.js
@@ -1,0 +1,155 @@
+// Spotify "now playing" — reads what the STREAMER'S ACCOUNT is playing.
+//
+// The Web API is account-scoped, not device-scoped: this returns whatever that
+// Spotify account is playing on any device — desktop, phone, web. So the bot does
+// NOT need to run on the machine Spotify is on, and nothing is installed there.
+// That is the whole reason this is an API integration rather than a local scrape.
+//
+// You can only ever read your OWN account. There is no endpoint for "what is user
+// X playing"; anyone else's playback would require them to authorise this app.
+//
+// Auth is the same shape as the Twitch bot token: a refresh token obtained once,
+// interactively, by scripts/get-spotify-token.mjs, then persisted through the same
+// TokenStore. The bot stays outbound-only — the only thing that ever listened on a
+// port is that one-off script.
+//
+// Failure is never fatal. Spotify being down, the token being revoked, or the
+// account being in a private session all resolve to `{ ok:false, reason }`, and
+// chat gets a sentence instead of silence.
+
+import { TokenStore } from '../db/tokenStore.js';
+import { config } from '../config.js';
+
+const TOKEN_URL = 'https://accounts.spotify.com/api/token';
+const NOW_PLAYING_URL =
+  'https://api.spotify.com/v1/me/player/currently-playing?additional_types=track,episode';
+
+/** The TokenStore key. Not a Twitch user id — just a stable filename. */
+const STORE_KEY = 'spotify';
+
+let cfg = null;         // { clientId, clientSecret, store }
+let access = null;      // { token, expiresAt }
+let refreshToken = null;
+let cache = null;       // { at, payload } — see currentlyPlaying
+/** Test seam: stands in for the whole HTTP round trip. */
+let fakeFetch = null;
+
+/**
+ * @param {{clientId?: string, clientSecret?: string, refreshToken?: string, storeDir?: string}} [opts]
+ */
+export async function initSpotify(opts = {}, logger = console) {
+  fakeFetch = null;
+  access = null;
+  cache = null;
+  const clientId = opts.clientId ?? process.env.SPOTIFY_CLIENT_ID ?? '';
+  const clientSecret = opts.clientSecret ?? process.env.SPOTIFY_CLIENT_SECRET ?? '';
+  if (!clientId || !clientSecret) {
+    cfg = null;
+    logger.info?.('spotify disabled (no SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET)');
+    return;
+  }
+
+  const store = new TokenStore(opts.storeDir ?? process.env.TOKEN_STORE_DIR ?? './.tokens');
+  // A stored token wins over the env one: Spotify MAY hand back a new refresh
+  // token on any refresh, and the stored copy is the one that has been rotated.
+  const saved = await store.load(STORE_KEY).catch(() => null);
+  refreshToken = saved?.refreshToken || opts.refreshToken || process.env.SPOTIFY_REFRESH_TOKEN || '';
+  if (!refreshToken) {
+    cfg = null;
+    logger.warn?.('spotify disabled — no refresh token. Run: node scripts/get-spotify-token.mjs');
+    return;
+  }
+
+  cfg = { clientId, clientSecret, store };
+  logger.info?.('spotify ready', { source: saved?.refreshToken ? 'token store' : 'env' });
+}
+
+/** Test seam: `fn(url, init)` replaces fetch. Pass null to disable Spotify. */
+export function initSpotifyWith(fn) {
+  fakeFetch = fn || null;
+  cfg = fn ? { clientId: 'test', clientSecret: 'test', store: null } : null;
+  refreshToken = fn ? 'test-refresh' : null;
+  access = null;
+  cache = null;
+}
+
+/** True when Spotify is configured and has a refresh token. */
+export function spotifyReady() {
+  return cfg !== null;
+}
+
+const http = (url, init) => (fakeFetch ? fakeFetch(url, init) : fetch(url, init));
+
+/**
+ * Exchange the refresh token for an access token, reusing the live one until it
+ * is nearly expired. Spotify's access tokens last an hour.
+ */
+async function accessToken() {
+  if (access && access.expiresAt > Date.now() + 30_000) return access.token;
+
+  const res = await http(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      // Client credentials go in the Basic header, not the body — Spotify accepts
+      // both, but the header form keeps the secret out of any body logging.
+      authorization: `Basic ${Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64')}`,
+    },
+    body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`token refresh failed (${res.status})${body ? `: ${body.slice(0, 120)}` : ''}`);
+  }
+  const json = await res.json();
+  access = { token: json.access_token, expiresAt: Date.now() + (json.expires_in ?? 3600) * 1000 };
+
+  // Spotify MAY rotate the refresh token. Persisting it is the difference between
+  // this surviving a restart and silently needing the interactive login again.
+  if (json.refresh_token && json.refresh_token !== refreshToken) {
+    refreshToken = json.refresh_token;
+    await cfg.store?.save(STORE_KEY, { refreshToken, obtainmentTimestamp: Date.now() }).catch(() => {});
+  }
+  return access.token;
+}
+
+/**
+ * What the account is playing right now. Never throws.
+ *
+ * Cached briefly: `!song` is the kind of command chat piles onto, and the answer
+ * cannot meaningfully change in a couple of seconds. The overlay poller shares
+ * this cache, so a viewer asking mid-poll costs nothing.
+ *
+ * @returns {Promise<{ok: true, payload: object|null} | {ok: false, reason: string}>}
+ */
+export async function currentlyPlaying(logger = console, now = Date.now()) {
+  if (!cfg) return { ok: false, reason: 'not configured' };
+  if (cache && now - cache.at < config.spotify.cacheMs) return { ok: true, payload: cache.payload };
+
+  try {
+    const token = await accessToken();
+    const res = await http(NOW_PLAYING_URL, { headers: { authorization: `Bearer ${token}` } });
+
+    // 204 is Spotify's "nothing is playing" — not an error, and the body is empty
+    // so parsing it would throw. A private session looks identical from here.
+    if (res.status === 204) {
+      cache = { at: now, payload: null };
+      return { ok: true, payload: null };
+    }
+    if (res.status === 429) {
+      const retry = res.headers?.get?.('retry-after');
+      return { ok: false, reason: `rate limited${retry ? `, retry in ${retry}s` : ''}` };
+    }
+    if (!res.ok) return { ok: false, reason: `spotify said ${res.status}` };
+
+    // 200 with an empty body happens too — belt and braces, since a throw here
+    // would surface as a broken command rather than "nothing playing".
+    const text = await res.text();
+    const payload = text ? JSON.parse(text) : null;
+    cache = { at: now, payload };
+    return { ok: true, payload };
+  } catch (err) {
+    logger.warn?.('spotify lookup failed', { err: String(err?.message || err) });
+    return { ok: false, reason: String(err?.message || err) };
+  }
+}

--- a/src/rules/spotify.js
+++ b/src/rules/spotify.js
@@ -1,0 +1,141 @@
+// NOW PLAYING — the pure half of `!song`: turning Spotify's payload into the one
+// line chat sees, and the shorter one the on-stream overlay shows.
+//
+// Pure like every other src/rules module: no HTTP, no config, no OBS. Spotify's
+// response has more shapes than "a song is playing" suggests, and each of them is
+// a line someone reads on stream — so they get tested rather than assumed:
+//
+//   nothing playing   · 204 or an empty body, when Spotify is closed
+//   paused            · is_playing:false, but `item` is still populated
+//   a podcast         · currently_playing_type "episode" — `artists` does not exist
+//   an advert         · type "ad", with item null on free accounts
+//   a local file      · a real track with no external_urls
+//
+// The one that bites is `artists` being absent on episodes: reading
+// `item.artists[0]` throws mid-command and the reply never arrives.
+
+/** Longest track/artist text before it gets clipped, so one line stays one line. */
+export const MAX_TITLE_LEN = 120;
+
+/** `1:23` / `1:02:03` — mm:ss unless it's over an hour. */
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return '0:00';
+  const total = Math.floor(ms / 1000);
+  const s = total % 60;
+  const m = Math.floor(total / 60) % 60;
+  const h = Math.floor(total / 3600);
+  const mm = h ? String(m).padStart(2, '0') : String(m);
+  return `${h ? `${h}:` : ''}${mm}:${String(s).padStart(2, '0')}`;
+}
+
+/** Clip to a sane length without cutting mid-word where avoidable. */
+export function clip(text, max = MAX_TITLE_LEN) {
+  const t = String(text ?? '').replace(/\s+/g, ' ').trim();
+  if (t.length <= max) return t;
+  const cut = t.slice(0, max - 1);
+  const space = cut.lastIndexOf(' ');
+  return `${space > max * 0.6 ? cut.slice(0, space) : cut}…`;
+}
+
+/** "A, B & C" — Spotify hands back every credited artist, which can be a lot. */
+export function joinArtists(artists = []) {
+  const names = artists.map((a) => a?.name).filter(Boolean);
+  if (!names.length) return '';
+  if (names.length === 1) return names[0];
+  return `${names.slice(0, -1).join(', ')} & ${names.at(-1)}`;
+}
+
+/**
+ * Normalise a currently-playing payload into everything the callers need.
+ *
+ * @param {object|null} payload the parsed body, or null for 204 / empty
+ * @returns {{
+ *   kind: 'track'|'episode'|'ad'|'nothing',
+ *   playing: boolean, title: string, subtitle: string,
+ *   url: string|null, progressMs: number|null, durationMs: number|null,
+ * }}
+ */
+export function readNowPlaying(payload) {
+  const none = {
+    kind: 'nothing', playing: false, title: '', subtitle: '',
+    url: null, progressMs: null, durationMs: null,
+  };
+  if (!payload || typeof payload !== 'object') return none;
+
+  const type = payload.currently_playing_type;
+  const item = payload.item;
+
+  // An advert has no item on a free account. It is still "something is happening",
+  // and saying so is better than claiming nothing is playing.
+  if (type === 'ad') return { ...none, kind: 'ad' };
+  if (!item) return none;
+
+  const playing = Boolean(payload.is_playing);
+  const progressMs = Number.isFinite(payload.progress_ms) ? payload.progress_ms : null;
+  const durationMs = Number.isFinite(item.duration_ms) ? item.duration_ms : null;
+  // A local file has no Spotify URL — the field is absent, not empty.
+  const url = item.external_urls?.spotify || null;
+
+  if (type === 'episode' || item.show) {
+    return {
+      kind: 'episode', playing, url, progressMs, durationMs,
+      title: clip(item.name || ''),
+      subtitle: clip(item.show?.name || ''),
+    };
+  }
+
+  return {
+    kind: 'track', playing, url, progressMs, durationMs,
+    title: clip(item.name || ''),
+    subtitle: clip(joinArtists(item.artists)),
+  };
+}
+
+/**
+ * The chat reply for `!song`. Says what is true rather than guessing: paused is
+ * not the same as nothing playing, and a listener asking during an ad deserves
+ * to know that's what they're hearing.
+ */
+export function chatLine(np) {
+  switch (np.kind) {
+    case 'nothing':
+      return '🎧 nothing is playing right now';
+    case 'ad':
+      return '🎧 Spotify is playing an ad right now';
+    case 'episode': {
+      const where = np.progressMs != null && np.durationMs
+        ? ` (${formatDuration(np.progressMs)}/${formatDuration(np.durationMs)})`
+        : '';
+      const state = np.playing ? '' : ' — paused';
+      return `🎙️ ${np.subtitle ? `${np.subtitle}: ` : ''}${np.title}${where}${state}`;
+    }
+    default: {
+      const where = np.progressMs != null && np.durationMs
+        ? ` (${formatDuration(np.progressMs)}/${formatDuration(np.durationMs)})`
+        : '';
+      const state = np.playing ? '' : ' — paused';
+      const link = np.url ? ` ${np.url}` : '';
+      return `🎧 ${np.subtitle ? `${np.subtitle} — ` : ''}${np.title}${where}${state}${link}`;
+    }
+  }
+}
+
+/**
+ * The on-stream overlay line. No link (unclickable on a video), no timestamp (it
+ * would rewrite the source every poll and still be wrong between polls), and no
+ * emoji — the OBS text source has its own styling.
+ *
+ * Returns '' for anything not worth showing, which the scheduler treats as
+ * "clear the overlay" rather than "leave the last song up forever".
+ *
+ * `prefix` is passed in rather than read from config, because this module is pure
+ * — the caller owns the setting. It is applied ONLY to a non-empty line: a bare
+ * "Now Playing:" over a black box, with nothing after it, is worse than nothing.
+ */
+export function overlayLine(np, { prefix = '' } = {}) {
+  if (np.kind === 'nothing' || np.kind === 'ad') return '';
+  if (!np.playing) return '';
+  const title = clip(np.title, 60);
+  const sub = clip(np.subtitle, 60);
+  return `${prefix}${sub ? `${sub} — ${title}` : title}`;
+}

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -19,6 +19,7 @@ import { initClipsWith } from '../../src/twitch/clips.js';
 import { initCaptureWith } from '../../src/integrations/capture.js';
 import { initMediaWith } from '../../src/integrations/obsMedia.js';
 import { initObsControlWith } from '../../src/integrations/obsControl.js';
+import { initSpotifyWith } from '../../src/integrations/spotify.js';
 import { clearMediaSlot, listSlots } from '../../src/db/media.js';
 import { slotInputs } from '../../src/rules/media.js';
 import { defaultBoss } from '../../src/content/bosses.js';
@@ -540,6 +541,68 @@ export const SCENARIOS = [
         assert.match(await bot.send(mod, '!obs nonsense'), /Usage: !obs/);
       } finally {
         initObsControlWith(null);
+      }
+    },
+  },
+  {
+    command: 'song', title: 'a viewer asks what is playing on Spotify',
+    run: async ({ bot, u }) => {
+      const viewer = u('e2e_song', { login: 'carl', name: 'Carl' });
+      const other = u('e2e_song2', { login: 'dee', name: 'Dee' });   // !song is per-user cooldowned
+      let calls = 0;
+      // The seam is fetch itself, so the real token refresh + request path runs.
+      const spotify = (body, status = 200) => async (url) => {
+        if (String(url).includes('/api/token')) {
+          return { ok: true, status: 200, json: async () => ({ access_token: 'tok', expires_in: 3600 }) };
+        }
+        calls += 1;
+        return {
+          ok: status < 400, status,
+          headers: { get: () => null },
+          text: async () => (body == null ? '' : JSON.stringify(body)),
+        };
+      };
+
+      try {
+        initSpotifyWith(spotify({
+          is_playing: true, progress_ms: 83000, currently_playing_type: 'track',
+          item: {
+            name: 'Bohemian Rhapsody', duration_ms: 354000,
+            artists: [{ name: 'Queen' }],
+            external_urls: { spotify: 'https://open.spotify.com/track/abc' },
+          },
+        }));
+        const reply = await bot.send(viewer, '!song');
+        assert.match(reply, /Queen — Bohemian Rhapsody/);
+        assert.match(reply, /1:23\/5:54/);
+        assert.equal(calls, 1);
+
+        // A second viewer inside the cache window must not cost a second request:
+        // !song is exactly the command chat piles onto.
+        assert.match(await bot.send(other, '!song'), /Bohemian Rhapsody/);
+        assert.equal(calls, 1, 'served from cache');
+
+        // 204 is Spotify's "nothing playing" and has an EMPTY body — parsing it
+        // would throw and the viewer would get silence.
+        initSpotifyWith(spotify(null, 204));
+        assert.match(await bot.send(viewer, '!song'), /nothing is playing/);
+
+        // An episode carries no `artists`; reading it naively throws mid-command.
+        initSpotifyWith(spotify({
+          is_playing: true, currently_playing_type: 'episode',
+          item: { name: 'Episode 12', duration_ms: 3600000, show: { name: 'Some Podcast' } },
+        }));
+        assert.match(await bot.send(viewer, '!song'), /Some Podcast: Episode 12/);
+
+        // A failure answers with Spotify's own status rather than going quiet.
+        initSpotifyWith(spotify({}, 503));
+        assert.match(await bot.send(viewer, '!song'), /couldn't reach Spotify.*503/);
+
+        // Not connected at all is its own sentence, not an error.
+        initSpotifyWith(null);
+        assert.match(await bot.send(viewer, '!song'), /isn't connected/);
+      } finally {
+        initSpotifyWith(null);
       }
     },
   },

--- a/test/rules/spotify.test.js
+++ b/test/rules/spotify.test.js
@@ -1,0 +1,147 @@
+// NOW PLAYING — reading Spotify's payload and turning it into the line chat sees.
+//
+// Spotify's currently-playing response has more shapes than "a song is playing",
+// and every one of them ends up on stream, so each gets a test. The one that
+// actually breaks things is an EPISODE: it has no `artists`, so the obvious
+// `item.artists[0].name` throws mid-command and the viewer gets nothing at all.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  readNowPlaying, chatLine, overlayLine, formatDuration, clip, joinArtists, MAX_TITLE_LEN,
+} from '../../src/rules/spotify.js';
+
+const track = (over = {}) => ({
+  is_playing: true,
+  progress_ms: 83_000,
+  currently_playing_type: 'track',
+  item: {
+    name: 'Bohemian Rhapsody',
+    duration_ms: 354_000,
+    artists: [{ name: 'Queen' }],
+    album: { name: 'A Night at the Opera' },
+    external_urls: { spotify: 'https://open.spotify.com/track/abc' },
+  },
+  ...over,
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+test('durations read as mm:ss, and hh:mm:ss only when needed', () => {
+  assert.equal(formatDuration(0), '0:00');
+  assert.equal(formatDuration(83_000), '1:23');
+  assert.equal(formatDuration(354_000), '5:54');
+  assert.equal(formatDuration(3_723_000), '1:02:03', 'a long podcast');
+  assert.equal(formatDuration(-5), '0:00');
+  assert.equal(formatDuration(undefined), '0:00');
+});
+
+test('clip cuts on a word boundary when there is one worth using', () => {
+  assert.equal(clip('short'), 'short');
+  const long = 'word '.repeat(40);
+  const out = clip(long);
+  assert.ok(out.length <= MAX_TITLE_LEN);
+  assert.ok(out.endsWith('…'));
+  assert.ok(!out.includes('  '), 'whitespace collapsed');
+});
+
+test('artists join the way a person would say them', () => {
+  assert.equal(joinArtists([{ name: 'Queen' }]), 'Queen');
+  assert.equal(joinArtists([{ name: 'A' }, { name: 'B' }]), 'A & B');
+  assert.equal(joinArtists([{ name: 'A' }, { name: 'B' }, { name: 'C' }]), 'A, B & C');
+  assert.equal(joinArtists([]), '');
+  assert.equal(joinArtists(undefined), '');
+});
+
+// ── payload shapes ────────────────────────────────────────────────────────────
+
+test('a playing track reads out fully', () => {
+  const np = readNowPlaying(track());
+  assert.equal(np.kind, 'track');
+  assert.equal(np.playing, true);
+  assert.equal(np.title, 'Bohemian Rhapsody');
+  assert.equal(np.subtitle, 'Queen');
+  assert.equal(np.url, 'https://open.spotify.com/track/abc');
+  assert.match(chatLine(np), /Queen — Bohemian Rhapsody \(1:23\/5:54\)/);
+});
+
+test('nothing playing is a 204 — null payload, not an error', () => {
+  const np = readNowPlaying(null);
+  assert.equal(np.kind, 'nothing');
+  assert.match(chatLine(np), /nothing is playing/);
+});
+
+test('paused is not the same as nothing playing', () => {
+  // The item is still populated; only is_playing changes. Reporting "nothing is
+  // playing" here would be wrong, and viewers can see the stream is paused.
+  const np = readNowPlaying(track({ is_playing: false }));
+  assert.equal(np.kind, 'track');
+  assert.equal(np.playing, false);
+  assert.match(chatLine(np), /paused/);
+});
+
+test('an episode has no artists — reading it must not throw', () => {
+  const np = readNowPlaying({
+    is_playing: true,
+    progress_ms: 60_000,
+    currently_playing_type: 'episode',
+    item: { name: 'Episode 12', duration_ms: 3_600_000, show: { name: 'Some Podcast' } },
+  });
+  assert.equal(np.kind, 'episode');
+  assert.equal(np.subtitle, 'Some Podcast');
+  assert.match(chatLine(np), /🎙️ Some Podcast: Episode 12/);
+});
+
+test('an ad says so rather than claiming nothing is on', () => {
+  const np = readNowPlaying({ is_playing: true, currently_playing_type: 'ad', item: null });
+  assert.equal(np.kind, 'ad');
+  assert.match(chatLine(np), /ad/);
+});
+
+test('a local file has no url and still reads fine', () => {
+  const t = track();
+  delete t.item.external_urls;
+  const np = readNowPlaying(t);
+  assert.equal(np.url, null);
+  assert.doesNotMatch(chatLine(np), /https?:/);
+  assert.match(chatLine(np), /Bohemian Rhapsody/);
+});
+
+test('garbage in is "nothing playing", never a thrown command', () => {
+  for (const bad of [undefined, '', 0, [], 'nope']) {
+    assert.equal(readNowPlaying(bad).kind, 'nothing');
+  }
+  assert.equal(readNowPlaying({ currently_playing_type: 'track' }).kind, 'nothing', 'no item');
+});
+
+// ── the overlay line ──────────────────────────────────────────────────────────
+
+test('the overlay is bare text — no link, no timestamp, no emoji', () => {
+  const line = overlayLine(readNowPlaying(track()));
+  assert.equal(line, 'Queen — Bohemian Rhapsody');
+  // A timestamp would be wrong between polls, and a link is unclickable on video.
+  assert.doesNotMatch(line, /https?:|\d:\d\d|🎧/);
+});
+
+test('the overlay CLEARS rather than freezing on the last song', () => {
+  // A stale track name is worse than none, because viewers believe it.
+  assert.equal(overlayLine(readNowPlaying(null)), '');
+  assert.equal(overlayLine(readNowPlaying(track({ is_playing: false }))), '', 'paused');
+  assert.equal(overlayLine(readNowPlaying({ currently_playing_type: 'ad', item: null })), '', 'ad');
+});
+
+test('a prefix is applied to a real line and NOT to an empty one', () => {
+  // "Now Playing:" alone over a black box, with nothing after it, is worse than
+  // showing nothing at all.
+  const opts = { prefix: 'Now Playing: ' };
+  assert.equal(overlayLine(readNowPlaying(track()), opts), 'Now Playing: Queen — Bohemian Rhapsody');
+  assert.equal(overlayLine(readNowPlaying(null), opts), '');
+  assert.equal(overlayLine(readNowPlaying(track({ is_playing: false })), opts), '');
+});
+
+test('the overlay clips hard — it renders on a video frame, not in chat', () => {
+  const np = readNowPlaying(track({
+    item: { ...track().item, name: 'T'.repeat(200), artists: [{ name: 'A'.repeat(200) }] },
+  }));
+  const line = overlayLine(np);
+  assert.ok(line.length <= 125, `overlay line was ${line.length} chars`);
+});


### PR DESCRIPTION
`!song` / `!nowplaying` / `!np` answer what the streamer's Spotify is playing, and
an OBS text source shows the same thing on stream.

## Why no co-location is needed

The Spotify Web API is **account-scoped, not device-scoped**. `/v1/me/player/currently-playing`
returns whatever that account is playing on any device, so kennyBot can run on a
different machine entirely and nothing is installed next to Spotify. That is the
whole reason this is an API integration rather than a local scrape.

You can only read your **own** account — Spotify has no endpoint for "what is user
X playing". Anyone else's playback would require them to authorise this app.

## Verified live, on a real stream

| Check | Result |
|---|---|
| Playing track → chat + overlay | ✅ artists, title, position, link |
| **Paused** | ✅ chat says paused with position; overlay **clears** |
| **Podcast episode** | ✅ named correctly — the case with no `artists` field |
| Track change → overlay follows | ✅ within one poll |
| Scene switch | ✅ identical in both scenes |
| Overlay across two scenes | ✅ one source, two scene items, single write |

Plus `npm test` **180** (14 new) · `npm run test:emulator` **75** · `npm run test:e2e`
**33** (new `!song` scenario; the coverage test enforces one per command).

## Decisions

**Auth mirrors the Twitch bot token.** A refresh token obtained once by
`scripts/get-spotify-token.mjs`, persisted through the same `TokenStore`, and
re-saved if Spotify rotates it. The bot stays outbound-only — only that one-off
script ever listens on a port. The redirect URI is the loopback **IP literal**
(`http://127.0.0.1:8888/callback`); Spotify explicitly rejects `localhost`.

**The overlay writes only when the line changes.** A text source rewritten every
poll re-renders in OBS for nothing. Last-written is held in memory rather than the
database — it is a cache of what OBS was last told, not state worth surviving a
restart, and after a restart the first poll is correct by construction.

**It clears on pause or stop** instead of freezing the last track. A stale song
title is worse than an empty overlay, because viewers believe it.

**One source in several scenes, not a copy per scene.** `obs-overlay-setup.mjs`
creates the input once and adds scene items elsewhere, so a single write updates
every scene and they cannot drift.

**Source creation is a script, not something the bot does at boot.** A bot that
invents sources in your scene collection is a bot you stop trusting.

**The prefix lives in `config.spotify.overlayPrefix`, applied by the caller.**
`src/rules/*` never imports config, so the pure formatter takes it as a parameter.
It is applied only to a non-empty line — a bare "Now Playing:" over a black box
with nothing after it is worse than showing nothing.

**A shared 5s cache.** `!song` is exactly the command chat piles onto, and the
answer cannot meaningfully change in a couple of seconds. Twenty viewers asking at
once is one Spotify request; the overlay poller shares the same cache.

**`!song` is public** — unlike everything else added recently. It is read-only and
reveals only music. Flagged deliberately: making it mod-only is a one-line change.

## Payload shapes, all tested

Spotify's response has more shapes than "a song is playing", and each reaches
chat: nothing playing (**204 with an empty body** — parsing it would throw), paused
(still populated, `is_playing:false`), an **episode** (no `artists` — the naive
`item.artists[0].name` throws mid-command), an ad, and a local file with no URL.

## Known, not fixed here

- **Long titles overflow the canvas.** A podcast title plus show name can reach
  ~120 characters; at the scale used on the test rig that runs off a 1920 frame.
  Fix is shorter clip lengths or an OBS bounds box — deferred rather than guessed
  at, since it depends on how the source is styled.
- **Token refresh past one hour is unproven.** The refresh path is the same code
  that runs at every startup, so it is exercised, but the bot has not yet been up
  long enough for a re-refresh.
- Only `user-read-currently-playing` is requested. Episodes worked with it on the
  test account; if another account returns `item: null` for podcasts, set
  `SPOTIFY_SCOPES` to add `user-read-playback-state` and re-run the token script.
