### PR TITLE
feat: subathon shadow ledger with an operator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Underneath both:
 - **automated releases** from Conventional Commits (release-please), with `main`
   protected for everyone including admins
 
-Verified by `npm test` (139 offline unit tests), `npm run test:emulator` (69 — RTDB
+Verified by `npm test` (174 offline unit tests), `npm run test:emulator` (76 — RTDB
 rules + client-write rejection, and the stateful command paths), `npm run test:e2e`
 (31 — every registered command driven through the real dispatcher), and
 `npm run synthetic` (full muster→battle→victory run with UI-contract assertions).
@@ -368,6 +368,37 @@ viewer to discover it.
 The one point of contact is `!start` (`src/db/clipSync.js`), which writes a per-stream
 sync anchor to RTDB — *data the archiver reads*, not a file handoff, and it works
 whether or not local capture is configured.
+
+## Subathon ledger (opt-in, operator-only)
+
+For the occasional subathon, the bot can keep a **shadow ledger**: it watches the
+same sub / gift / cheer events chat already carries, prices each one against a
+tiered rate card, and records it. It is not the timer viewers see — that is a
+separate widget — and it exposes **no chat commands**. Its only purpose is to
+tell the operator how far the two have drifted, since the widget grants at one
+fixed rate while the card changes with stream uptime.
+
+**Off by default and inert until switched on.** There is no env var and no
+redeploy: the feature wakes up when `scripts/subathon.mjs start` writes a record
+to RTDB and sleeps again on `end`. With no record present every handler returns
+immediately — no subscription, no timer, no traffic — which is the state on an
+ordinary stream. There's a check for exactly that at the top of
+`scripts/subathon-sim.mjs`.
+
+| Piece | What it is |
+| --- | --- |
+| `src/rules/subathon.js` | Pure engine — pricing, band selection, gift dedupe, the clock. Offline-testable. |
+| `src/db/subathon.js` | Append-only ledger; the deadline is derived from it, never stored. |
+| `src/events/subathonEvents.js` | Chat wiring. Gift bundles are deduped by hand (EventSub's `isGift` needs a broadcaster token this bot doesn't hold). |
+| `scripts/subathon.mjs` | Operator CLI, run locally against RTDB. |
+| `scripts/subathon-sim.mjs` | Drives the real handlers with fabricated events — a large gift bundle can't be self-gifted or cheaply tested for real. |
+
+**No rate card ships in this repository, by design** — the values are the
+streamer's business, so the engine defines only the shape and refuses to credit
+anything until a card is supplied at runtime from outside the repo. Test fixtures
+use invented numbers, and the ledger lives under `config/subathon`, which is not
+client-readable (see `database.rules.json`; read grants cascade in RTDB, so that
+key must never be added to a readable parent).
 
 ## Environment contract
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ import { seedCuratedFacts } from './src/db/facts.js';
 import { seedCatalog } from './src/db/catalog.js';
 import { createMessageHandler } from './src/events/chat.js';
 import { attachTwitchEvents } from './src/events/twitchEvents.js';
+import { attachSubathonEvents } from './src/events/subathonEvents.js';
 import { startDropScheduler } from './src/events/dropScheduler.js';
 import { startTimerScheduler } from './src/events/timerScheduler.js';
 import { startReminderScheduler } from './src/events/reminderScheduler.js';
@@ -282,6 +283,9 @@ async function main() {
     logger.warn('chat disconnected', { manual, reason: String(reason || '') });
   });
   shutdownHooks.push(attachTwitchEvents({ chat, sender, logger }));
+  // Subathon ledger: prices subs/gifts/bits against the current band and appends
+  // them. A no-op (not even a read) unless a subathon is actually running.
+  shutdownHooks.push(attachSubathonEvents({ chat, logger }));
   await chat.connect();
   shutdownHooks.push(() => chat.quit());
 

--- a/scripts/subathon-sim.mjs
+++ b/scripts/subathon-sim.mjs
@@ -1,0 +1,172 @@
+// SUBATHON SIMULATOR — fires fake Twitch money events through the REAL handler.
+//
+// You cannot gift yourself a sub, and testing a large bundle for real costs real
+// money, so this drives src/events/subathonEvents.js directly with the same info
+// objects twurple builds from IRC. Everything downstream — dedupe, band pricing, the
+// ledger writes — is the production path; only the socket is faked.
+//
+//   npx firebase emulators:exec --only database --project okrafans \
+//     "node scripts/subathon-sim.mjs"
+//
+// What it proves, in order: a plain sub pays, a resub pays, a LONE gift pays, a
+// 20-sub bundle pays ONCE (not 21 times), bits pay, and a restart part-way
+// through a bundle does not re-credit recipients already covered.
+//
+// The rate card here is INVENTED. The real one is private and lives outside the
+// repository — see the header of src/rules/subathon.js.
+
+import assert from 'node:assert/strict';
+import { initFirebase, closeFirebase, database, PATHS } from '../src/db/firebase.js';
+import { startConfigMirror, getSubathonState } from '../src/db/configStore.js';
+import { attachSubathonEvents } from '../src/events/subathonEvents.js';
+import { startSubathon, clearSubathon, subathonStatus } from '../src/db/subathon.js';
+import { ledgerSeconds } from '../src/rules/subathon.js';
+
+// A MADE-UP rate card — the real one is private and never enters this repo.
+// Round numbers so every expectation below is checkable by eye.
+const RATES = {
+  values: { t1: 2, t2: 4, t3: 10, bit: 0.01, dollar: 1 },
+  bands: { alpha: 100, beta: 50 },
+  schedule: [{ fromHours: 0, band: 'alpha' }, { fromHours: 10, band: 'beta' }],
+  se: 100,
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const quiet = { debug() {}, info() {}, warn() {}, error: (m, x) => console.error('  [err]', m, x?.err || '') };
+
+/** A fake ChatClient: records handlers so the sim can invoke them like Twitch would. */
+function fakeChat() {
+  const handlers = new Map();
+  const make = (name) => (fn) => {
+    if (!handlers.has(name)) handlers.set(name, []);
+    handlers.get(name).push(fn);
+    return { unbind() { handlers.set(name, handlers.get(name).filter((f) => f !== fn)); } };
+  };
+  return {
+    onSub: make('onSub'), onResub: make('onResub'), onSubGift: make('onSubGift'),
+    onCommunitySub: make('onCommunitySub'), onPrimePaidUpgrade: make('onPrimePaidUpgrade'),
+    onGiftPaidUpgrade: make('onGiftPaidUpgrade'), onStandardPayForward: make('onStandardPayForward'),
+    onMessage: make('onMessage'),
+    async fire(name, ...args) {
+      for (const fn of handlers.get(name) || []) await fn(...args);
+    },
+  };
+}
+
+async function ledgerNow() {
+  const snap = await database().ref(PATHS.subathonLedger()).get();
+  return Object.values(snap.val() || {});
+}
+
+async function step(label, fn, expectSeconds) {
+  const before = ledgerSeconds(await ledgerNow());
+  await fn();
+  await sleep(120); // let the appends land
+  const after = ledgerSeconds(await ledgerNow());
+  const got = after - before;
+  const ok = got === expectSeconds;
+  console.log(`  ${ok ? '✓' : '✗'} ${label.padEnd(46)} ${String(got).padStart(6)}s  (expected ${expectSeconds}s)`);
+  assert.equal(got, expectSeconds, label);
+}
+
+async function main() {
+  if (!process.env.FIREBASE_DATABASE_EMULATOR_HOST) {
+    console.error('Refusing to run against production. Use: firebase emulators:exec --only database …');
+    process.exit(1);
+  }
+  initFirebase();
+  await clearSubathon();
+  await startConfigMirror(quiet);
+  await sleep(200); // mirror warm
+
+  // The feature is opt-in per event. With no record written, the wiring is
+  // attached but must do nothing at all — this runs on every ordinary stream.
+  console.log('\n  NO SUBATHON RUNNING — the wiring must be inert\n');
+  const idleChat = fakeChat();
+  const idleDetach = attachSubathonEvents({ chat: idleChat, logger: quiet });
+  await step('a sub credits nothing', () =>
+    idleChat.fire('onSub', '#c', 'v', { plan: '3000', displayName: 'V' }), 0);
+  await step('a gift bundle credits nothing', async () => {
+    await idleChat.fire('onCommunitySub', '#c', 'g', { count: 5, plan: '1000', gifter: 'g' });
+    await idleChat.fire('onSubGift', '#c', 'r', { plan: '1000', gifter: 'g', giftDuration: 1 });
+  }, 0);
+  await step('bits credit nothing', () =>
+    idleChat.fire('onMessage', '#c', 'c', 'x', { bits: 5000, userInfo: { displayName: 'C' } }), 0);
+  idleDetach();
+
+  await startSubathon({ baseHours: 4, rates: RATES });
+  await sleep(200); // mirror picks up the new record
+
+  const chat = fakeChat();
+  let detach = attachSubathonEvents({ chat, logger: quiet });
+  await sleep(150);
+
+  console.log('\n  opening band — the whole run stays under the first threshold\n');
+
+  await step('tier-1 sub', () =>
+    chat.fire('onSub', '#c', 'viewer1', { plan: '1000', displayName: 'Viewer1', isPrime: false }), 200);
+
+  await step('prime sub prices as tier 1', () =>
+    chat.fire('onSub', '#c', 'viewer2', { plan: 'Prime', displayName: 'Viewer2', isPrime: true }), 200);
+
+  await step('tier-3 resub', () =>
+    chat.fire('onResub', '#c', 'viewer3', { plan: '3000', displayName: 'Viewer3', months: 12 }), 1000);
+
+  await step('LONE gift sub (no bundle) still pays', () =>
+    chat.fire('onSubGift', '#c', 'lucky', { plan: '1000', gifter: 'santa', gifterDisplayName: 'Santa', giftDuration: 1 }), 200);
+
+  await step('6-month gift pays six times', () =>
+    chat.fire('onSubGift', '#c', 'lucky2', { plan: '1000', gifter: 'santa2', gifterDisplayName: 'Santa2', giftDuration: 6 }), 1200);
+
+  // The big one: the bundle is credited once, and the individual
+  // USERNOTICEs that follow must add nothing.
+  await step('20-sub bundle pays ONCE', async () => {
+    await chat.fire('onCommunitySub', '#c', 'bomber', { count: 20, plan: '1000', gifter: 'bomber', gifterDisplayName: 'Bomber' });
+    for (let i = 0; i < 20; i += 1) {
+      await chat.fire('onSubGift', '#c', `r${i}`, { plan: '1000', gifter: 'bomber', gifterDisplayName: 'Bomber', giftDuration: 1 });
+    }
+  }, 4000);
+
+  await step('a later lone gift from the same gifter pays', () =>
+    chat.fire('onSubGift', '#c', 'later', { plan: '1000', gifter: 'bomber', gifterDisplayName: 'Bomber', giftDuration: 1 }), 200);
+
+  await step('5000 bits', () =>
+    chat.fire('onMessage', '#c', 'cheerer', 'PogChamp5000', { bits: 5000, userInfo: { displayName: 'Cheerer' } }), 5000);
+
+  await step('a chat message with no bits credits nothing', () =>
+    chat.fire('onMessage', '#c', 'talker', 'hello', { bits: 0, userInfo: { displayName: 'Talker' } }), 0);
+
+  // Restart part-way through: 10 of 20 recipients delivered, then the bot dies.
+  console.log('\n  RESTART MID-BUNDLE\n');
+  await step('bundle of 20 credited, 10 parts delivered', async () => {
+    await chat.fire('onCommunitySub', '#c', 'bomber2', { count: 20, plan: '1000', gifter: 'bomber2', gifterDisplayName: 'Bomber2' });
+    for (let i = 0; i < 10; i += 1) {
+      await chat.fire('onSubGift', '#c', `x${i}`, { plan: '1000', gifter: 'bomber2', gifterDisplayName: 'Bomber2', giftDuration: 1 });
+    }
+  }, 4000);
+
+  detach();
+  const chat2 = fakeChat();
+  detach = attachSubathonEvents({ chat: chat2, logger: quiet });
+  await sleep(250); // the pending map reloads from RTDB
+
+  await step('remaining 10 parts still swallowed after restart', async () => {
+    for (let i = 10; i < 20; i += 1) {
+      await chat2.fire('onSubGift', '#c', `x${i}`, { plan: '1000', gifter: 'bomber2', gifterDisplayName: 'Bomber2', giftDuration: 1 });
+    }
+  }, 0);
+
+  detach();
+  const s = subathonStatus(getSubathonState(), Date.now());
+  console.log(`
+  ledger      ${s.entries} entries, ${s.grantedSeconds}s granted
+  clock       ${Math.round(s.remainingMs / 1000)}s remaining
+  correction  ${s.owedSeconds}s outstanding
+
+  ✓ all checks passed
+`);
+}
+
+main()
+  .catch((err) => { console.error('\n  SIM FAILED:', err?.message || err); process.exitCode = 1; })
+  .finally(async () => { try { await closeFirebase(); } catch { /* already closed */ } });

--- a/scripts/subathon.mjs
+++ b/scripts/subathon.mjs
@@ -1,0 +1,352 @@
+// SUBATHON OPERATOR CLI — the private back channel.
+//
+// Runs LOCALLY (your machine, not the container) and writes straight to the same
+// RTDB the bot reads. The running bot picks changes up through the config mirror
+// it already keeps, so nothing has to be attached to, exec'd into, or restarted.
+//
+//   node scripts/subathon.mjs owed        # what to tell her to add or subtract
+//   node scripts/subathon.mjs status
+//   node scripts/subathon.mjs dono 25 "off-platform"
+//   node scripts/subathon.mjs align 6h22m "restarted, lost events"
+//
+// WHY NOT THE CONTAINER CONSOLE: `docker run -d` closes stdin, so the bot's own
+// process has no readable console — `docker logs` is one-way and `docker exec`
+// starts a NEW process that shares no memory with the bot. There is nothing to
+// type into. This sidesteps that by writing to the state both processes share.
+//
+// CREDENTIALS: needs FIREBASE_DATABASE_URL and GOOGLE_APPLICATION_CREDENTIALS
+// (the service-account JSON) — both from .env, neither in the repo. Cloning the
+// repo gets you this script and no way to point it at anything.
+//
+// RATES ARE NOT IN THIS REPO. `start` reads the card from a gitignored file
+// (SUBATHON_RATES_FILE, default .workspace/subathon-rates.json) and stores it on
+// the event record. Monetary figures are hidden from output unless you pass
+// --money, so a screenshot of this terminal leaks nothing.
+
+import 'dotenv/config';
+import { readFile } from 'node:fs/promises';
+import { initFirebase, closeFirebase } from '../src/db/firebase.js';
+import {
+  readSubathon, startSubathon, stopSubathon, clearSubathon, pauseSubathon,
+  resumeSubathon, adjustSubathon, undoLedgerEntry, creditSubathon, subathonStatus,
+  recordCorrection, alignSubathon,
+} from '../src/db/subathon.js';
+import {
+  parseSeconds, formatDuration, ledgerSeconds, bandTimeline, ledgerBreakdown,
+  describeSe, ratesFrom, seMatchesOpeningBand,
+} from '../src/rules/subathon.js';
+
+const [, , cmd, ...rest] = process.argv;
+const emulator = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const target = emulator ? `EMULATOR ${emulator}` : process.env.FIREBASE_DATABASE_URL;
+const RATES_FILE = process.env.SUBATHON_RATES_FILE || '.workspace/subathon-rates.json';
+const SHOW_MONEY = rest.includes('--money');
+
+const hhmm = (ms) => new Date(ms).toISOString().replace('T', ' ').slice(0, 19) + 'Z';
+const sign = (n) => (n >= 0 ? `+${n}` : String(n));
+// formatDuration floors at zero — right for a clock, wrong for a ledger delta,
+// where a −5m correction must not render as "0s".
+const delta = (seconds) => (seconds < 0 ? `-${formatDuration(-seconds * 1000)}` : formatDuration(seconds * 1000));
+
+function flag(name, fallback = null) {
+  const i = rest.indexOf(`--${name}`);
+  return i >= 0 && rest[i + 1] != null && !rest[i + 1].startsWith('--') ? rest[i + 1] : fallback;
+}
+/** Positional args, with `--flag [value]` pairs stripped out. */
+function positional() {
+  const out = [];
+  for (let i = 0; i < rest.length; i += 1) {
+    if (rest[i].startsWith('--')) {
+      if (rest[i + 1] != null && !rest[i + 1].startsWith('--')) i += 1;
+      continue;
+    }
+    out.push(rest[i]);
+  }
+  return out;
+}
+
+function usage() {
+  console.log(`
+subathon — operator CLI  (target: ${target || 'UNSET'})
+
+  owed                       ➜ the one to run: how much to tell her to add or
+                             subtract externally, since that timer never changes band
+  corrected <dur>|--all      record that you applied that correction
+  align <dur>                force kennyBot's clock to this remaining time
+                             (after a restart that lost events, or a bug)
+  status                     the clock, the band, the outstanding correction
+  reconcile                  full cross-check + the wall-clock band marks
+  ledger [n]                 last n ledger entries (default 20)
+  add <dur> [note]           add/remove raw time — 5m, 90s, 1h30m, -10m
+  dono <amount> [note]       credit a donation, priced at the CURRENT band
+  bits <n> [note]            credit bits the bot missed
+  sub <t1|t2|t3> [n] [note]  credit sub(s) the bot missed
+  undo <entryId>             reverse one entry (appends a compensating entry)
+  pause | resume             freeze/unfreeze the clock AND the band
+  start --base <dur>         begin; rates come from ${RATES_FILE}
+  end                        stop the clock, keep the ledger
+  wipe --yes                 delete the record entirely (test runs only)
+
+  --money                    include monetary figures in the output (off by
+                             default so a screenshot leaks nothing)
+  --off-platform             (dono/bits/sub) the external timer never saw this
+  --only-here                (add) went into kennyBot alone, still owed externally
+`.trimStart());
+}
+
+async function requireActive() {
+  const state = await readSubathon();
+  if (!state?.active) {
+    console.error('No active subathon. Start one with:  node scripts/subathon.mjs start --base <dur>');
+    process.exit(1);
+  }
+  return state;
+}
+
+function printStatus(state, now = Date.now()) {
+  const s = subathonStatus(state, now);
+  if (!s.active) { console.log('subathon: inactive'); return; }
+  console.log(`
+  clock       ${formatDuration(s.remainingMs)} remaining${s.paused ? '   ⏸  PAUSED' : ''}
+  ends        ${hhmm(s.endsAt)}
+  uptime      ${formatDuration(s.elapsedMs)}   (band: ${String(s.band).toUpperCase()})
+  correction  ${delta(s.owedSeconds)} outstanding
+  granted     ${formatDuration(s.grantedSeconds * 1000)} earned  +  ${formatDuration(s.baseSeconds * 1000)} base
+  ledger      ${s.entries} entries
+  soft cap    ${s.softCapHours ?? '—'}h   (not enforced — she calls the end)
+`.trimStart());
+  if (SHOW_MONEY) console.log(`  external timer: ${describeSe(ratesFrom(state).se)}\n`);
+}
+
+async function loadRates() {
+  try {
+    const rates = JSON.parse(await readFile(RATES_FILE, 'utf8'));
+    if (!ratesFrom({ rates }).configured) throw new Error('file has no usable values/bands');
+    return rates;
+  } catch (err) {
+    console.error(`Could not read a rate card from ${RATES_FILE}: ${err.message}`);
+    console.error('No rates ship in this repository — see the private runbook in .workspace/.');
+    process.exit(1);
+  }
+}
+
+async function main() {
+  if (!cmd || cmd === 'help' || cmd === '--help') { usage(); return; }
+  if (!emulator && !process.env.FIREBASE_DATABASE_URL) {
+    console.error('FIREBASE_DATABASE_URL is unset and no emulator host — refusing to guess a target.');
+    process.exit(1);
+  }
+  initFirebase();
+  if (!emulator) console.error(`→ ${target}\n`); // stderr so piping stays clean
+
+  const args = positional();
+  const now = Date.now();
+
+  switch (cmd) {
+    case 'status': {
+      printStatus(await readSubathon(), now);
+      break;
+    }
+
+    case 'owed': {
+      const s = subathonStatus(await requireActive(), now);
+      const owed = s.owedSeconds;
+      console.log(`  kennyBot clock  ${formatDuration(s.remainingMs)}   (band ${String(s.band).toUpperCase()}, uptime ${formatDuration(s.elapsedMs)})`);
+      if (Math.abs(owed) < 30) {
+        console.log(`  correction      none worth calling out (${delta(owed)})`);
+      } else if (owed < 0) {
+        console.log(`\n  ➜  TELL HER: SUBTRACT ${formatDuration(-owed * 1000)}`);
+        console.log('     (the external timer never leaves its opening band, so it has over-granted)');
+      } else {
+        console.log(`\n  ➜  TELL HER: ADD ${formatDuration(owed * 1000)}`);
+      }
+      console.log('\n  once applied:  node scripts/subathon.mjs corrected --all\n');
+      break;
+    }
+
+    case 'corrected': {
+      const state = await requireActive();
+      const all = rest.includes('--all');
+      const seconds = all ? subathonStatus(state, now).owedSeconds : parseSeconds(args[0]);
+      if (seconds == null) { console.error('Usage: corrected <dur> [note]   |   corrected --all'); process.exit(1); }
+      const entry = await recordCorrection(seconds, { note: args.slice(all ? 0 : 1).join(' ') || null }, now);
+      const after = subathonStatus({ ...state, ledger: { ...(state.ledger || {}), [entry.id]: entry } }, now);
+      console.log(`recorded: external timer moved by ${delta(seconds)}  (${entry.id})`);
+      console.log(`outstanding now ${delta(after.owedSeconds)}`);
+      break;
+    }
+
+    case 'align': {
+      const state = await requireActive();
+      const targetSeconds = parseSeconds(args[0]);
+      if (targetSeconds == null) { console.error('Usage: align <dur>   e.g. align 6h22m'); process.exit(1); }
+      const before = subathonStatus(state, now);
+      const entry = await alignSubathon(state, targetSeconds * 1000, { note: args.slice(1).join(' ') || null }, now);
+      console.log(`aligned: ${formatDuration(before.remainingMs)} → ${formatDuration(targetSeconds * 1000)}  (${delta(entry.seconds)})`);
+      console.log('the outstanding correction is unchanged — realigning does not invent one.');
+      break;
+    }
+
+    case 'reconcile': {
+      const state = await readSubathon();
+      const s = subathonStatus(state, now);
+      if (!s.active) { console.log('subathon: inactive'); break; }
+      console.log(`  kennyBot says   ${formatDuration(s.remainingMs)} left   (ends ${hhmm(s.endsAt)})`);
+      console.log(`  uptime          ${formatDuration(s.elapsedMs)}   band ${String(s.band).toUpperCase()}`);
+      console.log(`  correction      ${delta(s.owedSeconds)} outstanding\n`);
+
+      console.log('  where the time came from');
+      for (const r of ledgerBreakdown(state.ledger)) {
+        const money = SHOW_MONEY && r.worth ? `   worth ${r.worth}` : '';
+        console.log(`    ${String(r.kind).padEnd(9)} ${String(r.count).padStart(4)} ×  ${delta(r.seconds).padStart(12)}${money}`);
+      }
+      console.log(`    ${'BASE'.padEnd(9)}       ${formatDuration(s.baseSeconds * 1000).padStart(12)}`);
+      console.log(`    ${'TOTAL'.padEnd(9)}       ${formatDuration((s.baseSeconds + s.grantedSeconds) * 1000).padStart(12)}\n`);
+
+      console.log('  band marks   (kennyBot switches automatically at these times)');
+      for (const b of bandTimeline(state, now)) {
+        const span = b.untilHours == null ? `${b.fromHours}h+` : `${b.fromHours}–${b.untilHours}h`;
+        const when = b.projected ? `~${hhmm(b.at)} (projected)` : hhmm(b.at);
+        const mark = b.active ? ' ← ACTIVE' : b.past ? ' done' : '';
+        console.log(`    ${b.band.toUpperCase().padEnd(8)} ${span.padEnd(9)} ${when}${mark}`);
+      }
+      console.log('');
+      break;
+    }
+
+    case 'ledger': {
+      const state = await readSubathon();
+      const limit = Number(args[0]) || 20;
+      const rows = Object.entries(state?.ledger || {})
+        .map(([id, e]) => ({ id, ...e }))
+        .sort((a, b) => a.at - b.at)
+        .slice(-limit);
+      if (!rows.length) { console.log('(ledger empty)'); break; }
+      for (const r of rows) {
+        const who = r.who ? ` ${r.who}` : '';
+        const band = r.band ? ` @${r.band}` : '';
+        const note = r.note ? `  — ${r.note}` : '';
+        console.log(`${hhmm(r.at)}  ${r.id}  ${sign(r.seconds).padStart(7)}s  ${String(r.kind).padEnd(10)}${band}${who}${note}`);
+      }
+      console.log(`\n  total granted: ${formatDuration(ledgerSeconds(state.ledger) * 1000)}`);
+      break;
+    }
+
+    case 'add': {
+      const state = await requireActive();
+      const seconds = parseSeconds(args[0]);
+      if (seconds == null) { console.error(`Not a duration: "${args[0] ?? ''}"  (try 5m, 90s, 1h30m, -10m)`); process.exit(1); }
+      const entry = await adjustSubathon(seconds, {
+        note: args.slice(1).join(' ') || null, source: 'cli', seenBySe: !rest.includes('--only-here'),
+      }, now);
+      console.log(`${sign(seconds)}s  (${entry.id})`);
+      printStatus({ ...state, ledger: { ...(state.ledger || {}), [entry.id]: entry } }, now);
+      break;
+    }
+
+    case 'dono':
+    case 'bits':
+    case 'sub': {
+      const state = await requireActive();
+      let contribution;
+      let noteFrom = 1;
+      if (cmd === 'dono') {
+        const amount = Number(args[0]);
+        if (!Number.isFinite(amount) || amount <= 0) { console.error('Usage: dono <amount> [note]'); process.exit(1); }
+        contribution = { product: 'dollars', dollars: amount };
+      } else if (cmd === 'bits') {
+        const bits = Number(args[0]);
+        if (!Number.isFinite(bits) || bits <= 0) { console.error('Usage: bits <n> [note]'); process.exit(1); }
+        contribution = { product: 'bits', bits };
+      } else {
+        const tier = String(args[0] || '').toLowerCase();
+        if (!['t1', 't2', 't3'].includes(tier)) { console.error('Usage: sub <t1|t2|t3> [count] [note]'); process.exit(1); }
+        const count = Number(args[1]) > 0 ? Number(args[1]) : 1;
+        contribution = { product: tier, count };
+        noteFrom = Number(args[1]) > 0 ? 2 : 1;
+      }
+      const entry = await creditSubathon(state, contribution, {
+        note: args.slice(noteFrom).join(' ') || null,
+        source: 'cli',
+        kind: cmd,
+        // Off-platform money the external timer never saw is owed in full.
+        seenBySe: !rest.includes('--off-platform'),
+      }, now);
+      console.log(`+${entry.seconds}s @ ${entry.band}  (${entry.id})`);
+      printStatus({ ...state, ledger: { ...(state.ledger || {}), [entry.id]: entry } }, now);
+      break;
+    }
+
+    case 'undo': {
+      const state = await requireActive();
+      const id = args[0];
+      if (!id) { console.error('Usage: undo <entryId>   (get ids from `ledger`)'); process.exit(1); }
+      const entry = await undoLedgerEntry(state, id, {}, now);
+      if (!entry) { console.error(`Nothing to undo for "${id}" — unknown id, or already reversed.`); process.exit(1); }
+      console.log(`reversed ${id}: ${sign(entry.seconds)}s`);
+      printStatus({ ...state, ledger: { ...(state.ledger || {}), [entry.id]: entry } }, now);
+      break;
+    }
+
+    case 'pause': {
+      printStatus(await pauseSubathon(await requireActive(), now), now);
+      break;
+    }
+
+    case 'resume': {
+      printStatus(await resumeSubathon(await requireActive(), now), now);
+      break;
+    }
+
+    case 'start': {
+      const existing = await readSubathon();
+      if (existing?.active) { console.error('A subathon is already active. `end` it first, or `wipe --yes` a test run.'); process.exit(1); }
+      const baseSeconds = parseSeconds(flag('base'));
+      if (baseSeconds == null || baseSeconds <= 0) { console.error('--base is required, e.g. --base 3h'); process.exit(1); }
+      const rates = await loadRates();
+      const state = await startSubathon({
+        baseHours: baseSeconds / 3600, rates, softCapHours: Number(flag('soft-cap')) || null, now,
+      });
+      console.log('started.');
+      printStatus(state, now);
+      // A mismatch here means one of the two systems is not set up the way we
+      // think, and every correction from now on would be wrong. Say so loudly
+      // while there is still time to check.
+      const matches = seMatchesOpeningBand(ratesFrom(state));
+      if (matches === false) {
+        console.log('  ⚠  the external timer is NOT on the opening band — expect a correction from');
+        console.log('     the very first contribution. Verify its settings before going live.\n');
+      } else if (matches === true) {
+        console.log('  ✓ external timer matches the opening band — the correction should stay at');
+        console.log('    zero until the first band change. Watch for that as a setup check.\n');
+      }
+      break;
+    }
+
+    case 'end': {
+      await stopSubathon();
+      console.log('ended — clock stopped, ledger kept for reconciliation.');
+      break;
+    }
+
+    case 'wipe': {
+      if (!emulator && !rest.includes('--yes')) {
+        console.error('Refusing to wipe production state without --yes (this deletes the ledger).');
+        process.exit(1);
+      }
+      await clearSubathon();
+      console.log('wiped.');
+      break;
+    }
+
+    default:
+      console.error(`Unknown command: ${cmd}\n`);
+      usage();
+      process.exit(1);
+  }
+}
+
+main()
+  .catch((err) => { console.error('failed:', err?.message || err); process.exitCode = 1; })
+  // The RTDB SDK keeps a socket open; without this the CLI hangs after a write.
+  .finally(async () => { try { await closeFirebase(); } catch { /* already closed */ } });

--- a/src/db/configStore.js
+++ b/src/db/configStore.js
@@ -31,6 +31,12 @@ const mirror = {
   // config/reminders: id → scheduled-nudge record. Evaluated on every reminder
   // tick, so it's mirrored rather than re-read.
   reminders: {},
+  // config/subathon: the clock + its append-only ledger. Mirrored because every
+  // sub and every cheer has to be priced against the CURRENT band, and going to
+  // RTDB for the schedule on each event would put a network round-trip in front
+  // of something that arrives in bursts (a large gift bundle is one event per
+  // recipient).
+  subathon: null,
 };
 
 let started = false;
@@ -63,6 +69,7 @@ export async function startConfigMirror(logger = console) {
   const timerRef = db.ref(PATHS.configTimer());
   const liveSinceRef = db.ref(PATHS.configLiveSince());
   const remindersRef = db.ref(PATHS.reminders());
+  const subathonRef = db.ref(PATHS.subathon());
 
   // Seed drop-scheduler defaults once (never clobber a mod's settings).
   await dropRef.transaction((v) => (v == null ? { enabled: gameConfig.loot.scheduler.enabled, intervalSec: gameConfig.loot.scheduler.intervalSec } : v));
@@ -77,11 +84,22 @@ export async function startConfigMirror(logger = console) {
   timerRef.on('value', (s) => { mirror.timer = s.val() || null; });
   liveSinceRef.on('value', (s) => { mirror.liveSince = s.val() || null; });
   remindersRef.on('value', (s) => { mirror.reminders = s.val() || {}; });
+  // Log the on/off edge. The subathon is switched on by a CLI writing a record,
+  // with no restart and no env var — so without this there is nothing in the log
+  // to confirm the bot actually saw it, which is the one thing an operator wants
+  // to check before the event starts. Deliberately no rates or totals.
+  subathonRef.on('value', (s) => {
+    const next = s.val() || null;
+    const was = Boolean(mirror.subathon?.active);
+    const now = Boolean(next?.active);
+    mirror.subathon = next;
+    if (now !== was) logger.info?.(now ? 'subathon ACTIVE' : 'subathon inactive', { startedAt: next?.startedAt ?? null });
+  });
 
   // Wait for the initial reads so the mirror is warm before chat starts.
-  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap, liveSinceSnap, remindersSnap] = await Promise.all([
+  const [liveSnap, expSnap, mutedSnap, clipSnap, seasonSnap, raidSnap, dropSnap, timerSnap, liveSinceSnap, remindersSnap, subathonSnap] = await Promise.all([
     liveRef.get(), expRef.get(), mutedRef.get(), clipRef.get(), seasonRef.get(), raidRef.get(), dropRef.get(),
-    timerRef.get(), liveSinceRef.get(), remindersRef.get(),
+    timerRef.get(), liveSinceRef.get(), remindersRef.get(), subathonRef.get(),
   ]);
   mirror.live = Boolean(liveSnap.val());
   mirror.expMode = expSnap.val() || gameConfig.liveGate.defaultExpMode;
@@ -93,6 +111,7 @@ export async function startConfigMirror(logger = console) {
   mirror.timer = timerSnap.val() || null;
   mirror.liveSince = liveSinceSnap.val() || null;
   mirror.reminders = remindersSnap.val() || {};
+  mirror.subathon = subathonSnap.val() || null;
   logger.info?.('config mirror warm', {
     live: mirror.live, expMode: mirror.expMode, chatMuted: mirror.chatMuted, clipMode: mirror.clipMode,
   });
@@ -185,6 +204,14 @@ export async function setReminderState(id, state) {
   if (cur) mirror.reminders = { ...mirror.reminders, [id]: { ...cur, state } };
   await database().ref(PATHS.reminderState(id)).set(state || null);
   return state;
+}
+
+/**
+ * The subathon record (clock + rate card + ledger), or null when none is running.
+ * Read on every sub and every cheer, so it comes from the mirror.
+ */
+export function getSubathonState() {
+  return mirror.subathon;
 }
 
 /**

--- a/src/db/firebase.js
+++ b/src/db/firebase.js
@@ -101,6 +101,14 @@ export const PATHS = {
   reminders: () => 'config/reminders',
   reminder: (id) => `config/reminders/${id}`,
   reminderState: (id) => `config/reminders/${id}/state`,
+  // SUBATHON: the clock (an absolute deadline, so a restart mid-event resumes
+  // instead of losing hours) plus an APPEND-ONLY ledger of every credit. The
+  // ledger is not bookkeeping decoration — it is how a long event gets
+  // reconciled afterwards, and how a mistyped adjustment at 4am gets reversed
+  // without guessing what the clock "should" say.
+  subathon: () => 'config/subathon',
+  subathonLedger: () => 'config/subathon/ledger',
+  subathonLedgerEntry: (id) => `config/subathon/ledger/${id}`,
   configLock: () => 'config/lock',
   // OKRA FACTS (/info/): approved facts are client-read-only; the submission
   // queue + counter are admin-only.

--- a/src/db/subathon.js
+++ b/src/db/subathon.js
@@ -1,0 +1,234 @@
+// SUBATHON persistence. Two rules shape everything here, both learned from
+// production logs rather than guessed at:
+//
+//   1. EVERY CREDIT IS AN APPEND. `push().set()` on the ledger, never a
+//      transaction and never a read-modify-write on a running total. The host's
+//      network blips several times a day (production logs show `transaction at
+//      … failed: disconnect`), and a transaction that fails mid-event is a
+//      contribution nobody gets credited for. Plain writes buffer in the SDK and
+//      flush on reconnect; transactions don't.
+//
+//   2. THE DEADLINE IS DERIVED FROM THE LEDGER (see src/rules/subathon.js), so
+//      the bot and the operator's CLI can both write concurrently without either
+//      clobbering the other's total.
+//
+// The ledger is append-only in spirit as well as mechanism: an undo appends a
+// compensating negative entry rather than deleting anything, because the point
+// of the log is to survive being reconciled against Twitch's numbers the next
+// morning, and a deletion is exactly what makes that impossible.
+
+import { database, PATHS } from './firebase.js';
+import {
+  ratesFrom, creditFor, seSecondsFor, outstandingCorrection,
+  elapsedMs, remainingMs, endsAt, currentBand, ledgerSeconds, planToProduct,
+} from '../rules/subathon.js';
+
+/** Read the whole subathon node once (the CLI path — the bot uses the mirror). */
+export async function readSubathon() {
+  const snap = await database().ref(PATHS.subathon()).get();
+  return snap.val() || null;
+}
+
+/**
+ * Begin a subathon. `baseHours` is the starting clock and `rates` is the card it
+ * runs on — both supplied by the operator, neither with a default in this repo.
+ */
+export async function startSubathon({ baseHours, rates, softCapHours = null, now = Date.now() } = {}) {
+  if (!ratesFrom({ rates }).configured) {
+    throw new Error('no rate card — supply one (see the private runbook); none ships in this repo');
+  }
+  const state = {
+    active: true,
+    startedAt: now,
+    baseSeconds: Math.round(baseHours * 3600),
+    paused: false,
+    pausedAt: null,
+    pausedMs: 0,
+    softCapHours, // display only — nothing enforces it, she calls the end
+    // The rate card, stored WITH the event so retuning it later can never
+    // retroactively reprice a run that already happened. Supplied at start time
+    // from a private file; no values ship in this repository.
+    rates,
+    ledger: null,
+  };
+  await database().ref(PATHS.subathon()).set(state);
+  return state;
+}
+
+/** End it. Keeps the record (and the ledger) for reconciliation; stops the clock. */
+export async function stopSubathon() {
+  await database().ref(PATHS.subathon()).update({ active: false, endedAt: Date.now() });
+}
+
+/** Wipe the record entirely — for clearing a test run, not for ending an event. */
+export async function clearSubathon() {
+  await database().ref(PATHS.subathon()).remove();
+}
+
+/**
+ * Freeze the clock. Both the countdown and the elapsed-uptime band hold still,
+ * so a technical break costs neither time nor a price increase.
+ */
+export async function pauseSubathon(state, now = Date.now()) {
+  if (!state?.active || state.paused) return state;
+  await database().ref(PATHS.subathon()).update({ paused: true, pausedAt: now });
+  return { ...state, paused: true, pausedAt: now };
+}
+
+export async function resumeSubathon(state, now = Date.now()) {
+  if (!state?.active || !state.paused) return state;
+  const pausedMs = Math.max(0, Number(state.pausedMs) || 0) + Math.max(0, now - (Number(state.pausedAt) || now));
+  await database().ref(PATHS.subathon()).update({ paused: false, pausedAt: null, pausedMs });
+  return { ...state, paused: false, pausedAt: null, pausedMs };
+}
+
+/**
+ * Price a contribution at the band in force now and append it to the ledger.
+ *
+ * `contribution` is `{ product, count?, months?, bits?, dollars? }` where product
+ * is one of the keys in PRODUCTS — see src/rules/subathon.js.
+ *
+ * @returns {{ id: string, seconds: number, band: string, worth: number }}
+ */
+export async function creditSubathon(state, contribution, meta = {}, now = Date.now()) {
+  const rates = ratesFrom(state);
+  const { seconds, band, worth, configured } = creditFor(contribution, elapsedMs(state, now), rates);
+  if (!configured) throw new Error('subathon has no usable rate card — refusing to credit zero silently');
+  // `seenBySe: false` is for money the external timer never saw — an
+  // off-platform donation, say. Everything on Twitch it sees for itself.
+  const seSeconds = meta.seenBySe === false ? 0 : seSecondsFor(contribution, rates.se, rates.values);
+  return appendLedger({
+    at: now,
+    seconds,
+    seSeconds,
+    band,
+    worth,
+    kind: meta.kind || contribution.product,
+    who: meta.who ?? null,
+    note: meta.note ?? null,
+    source: meta.source || 'chat',
+    ...(contribution.count > 1 ? { count: contribution.count } : {}),
+    ...(contribution.months > 1 ? { months: contribution.months } : {}),
+    ...(contribution.bits ? { bits: contribution.bits } : {}),
+  });
+}
+
+/**
+ * Record that a correction was applied in the external timer — `seconds` is what
+ * was typed into its add-time field (negative to subtract). kennyBot's own clock
+ * is already right, so this moves only the external side of the comparison.
+ */
+export async function recordCorrection(seconds, { note = null, who = null } = {}, now = Date.now()) {
+  return appendLedger({
+    at: now,
+    seconds: 0,
+    seSeconds: Math.round(seconds),
+    band: null,
+    kind: 'correction',
+    who,
+    note,
+    source: 'cli',
+  });
+}
+
+/**
+ * Force kennyBot's clock to a stated remaining time. For after a restart that
+ * lost events, or a bug fixed mid-stream — the ledger is authoritative right up
+ * until it demonstrably isn't, and then this is how you say so.
+ *
+ * The difference is applied to BOTH sides, so realigning the clock does not
+ * silently invent a correction for her to apply externally.
+ */
+export async function alignSubathon(state, targetRemainingMs, { note = null } = {}, now = Date.now()) {
+  const deltaSeconds = Math.round((targetRemainingMs - remainingMs(state, now)) / 1000);
+  return appendLedger({
+    at: now,
+    seconds: deltaSeconds,
+    seSeconds: deltaSeconds,
+    band: null,
+    kind: 'align',
+    who: null,
+    note,
+    source: 'cli',
+  });
+}
+
+/**
+ * Add or remove raw seconds with no pricing — the manual path (a donation the
+ * bot can't see, a correction, a bonus). Always carries a note: an unexplained
+ * ±20 minutes in the ledger is worse than no ledger at all.
+ */
+export async function adjustSubathon(seconds, { who = null, note = null, source = 'manual', seenBySe = true } = {}, now = Date.now()) {
+  const rounded = Math.round(seconds);
+  return appendLedger({
+    at: now,
+    seconds: rounded,
+    // A raw adjustment is normally typed into BOTH systems, so it creates no gap.
+    // `seenBySe: false` says it went into kennyBot only, and should be reported
+    // as still owed externally.
+    seSeconds: seenBySe ? rounded : 0,
+    band: null, // unpriced by definition
+    kind: 'adjust',
+    who,
+    note,
+    source,
+  });
+}
+
+/**
+ * Reverse one ledger entry by appending its negation. Nothing is deleted, so the
+ * original mistake and its correction both stay visible the next morning.
+ */
+export async function undoLedgerEntry(state, id, { who = null } = {}, now = Date.now()) {
+  const entry = state?.ledger?.[id];
+  if (!entry) return null;
+  if (entry.undoes) return null; // don't undo an undo — that's an add, spell it out
+  const already = Object.values(state.ledger || {}).some((e) => e?.undoes === id);
+  if (already) return null;
+  return appendLedger({
+    at: now,
+    seconds: -Math.round(Number(entry.seconds) || 0),
+    // Reverse BOTH sides: undoing a double-credit must not leave a phantom
+    // correction owed for the half that was never real.
+    seSeconds: -Math.round(Number(entry.seSeconds) || 0),
+    band: null,
+    kind: 'undo',
+    undoes: id,
+    who,
+    note: `reversed ${entry.kind}${entry.who ? ` from ${entry.who}` : ''}`,
+    source: 'manual',
+  });
+}
+
+/** The single write everything above funnels through. Append-only, no transaction. */
+async function appendLedger(entry) {
+  const ref = database().ref(PATHS.subathonLedger()).push();
+  await ref.set(entry);
+  return { id: ref.key, ...entry };
+}
+
+/**
+ * Everything a caller needs to render the clock, derived in one place so chat,
+ * the overlay and the CLI can never disagree about what time it is.
+ */
+export function subathonStatus(state, now = Date.now()) {
+  if (!state?.active) return { active: false };
+  return {
+    active: true,
+    paused: Boolean(state.paused),
+    startedAt: state.startedAt,
+    endsAt: endsAt(state),
+    remainingMs: remainingMs(state, now),
+    elapsedMs: elapsedMs(state, now),
+    band: currentBand(state, now),
+    grantedSeconds: ledgerSeconds(state.ledger),
+    baseSeconds: Number(state.baseSeconds) || 0,
+    softCapHours: state.softCapHours ?? null,
+    entries: Object.keys(state.ledger || {}).length,
+    // The headline number: what to tell her to add in SE (negative = subtract).
+    owedSeconds: outstandingCorrection(state.ledger),
+    se: ratesFrom(state).se,
+  };
+}
+
+export { planToProduct };

--- a/src/events/subathonEvents.js
+++ b/src/events/subathonEvents.js
@@ -1,0 +1,166 @@
+// SUBATHON chat wiring — Twitch money events → ledger credits.
+//
+// Everything here comes off the CHAT connection, not EventSub, because there is
+// no broadcaster-owned token for the target channel (index.js logs `eventsub
+// disabled — broadcaster token is not the channel owner`). USERNOTICEs and the
+// `bits` tag are delivered to every joined client and need no scopes, so this
+// works with what we have.
+//
+// The cost of that choice is dedupe. A gift bundle arrives as ONE
+// `onCommunitySub` carrying the count, followed by a separate `onSubGift` per
+// recipient; crediting both pays double. EventSub's `is_gift` flag would settle
+// it in one field, and we don't have it — so we count the bundle and swallow
+// exactly that many individual gifts from the same gifter, which still lets a
+// LONE gift pay.
+//
+// The pending-bundle map is persisted to RTDB and re-read on the first event of
+// each run. A bug found mid-stream means a restart, and a restart part-way
+// through a large bundle would otherwise come back up empty and credit the
+// remaining recipients a second time.
+//
+// WITH NO SUBATHON RUNNING THIS MODULE DOES NOTHING. Every handler returns on a
+// mirror read; there is no subscription, no timer and no traffic. It is attached
+// on every stream and only wakes up once `scripts/subathon.mjs start` has
+// written a record.
+//
+// Every handler is failure-isolated: a subathon that can't write must never take
+// chat down with it. A missed credit is recoverable from the CLI; a dead bot is
+// not recoverable at 4am.
+
+import { getSubathonState } from '../db/configStore.js';
+import { creditSubathon } from '../db/subathon.js';
+import { database, PATHS } from '../db/firebase.js';
+import { planToProduct, noteGiftBomb, consumeGiftSub } from '../rules/subathon.js';
+
+/**
+ * @param {{ chat: import('@twurple/chat').ChatClient, logger: any }} deps
+ * @returns {() => void} cleanup
+ */
+export function attachSubathonEvents({ chat, logger }) {
+  const listeners = [];
+
+  // Working copy of the pending-bundle map. Seeded from the config mirror the
+  // first time an event lands on a given run, then written through: within a
+  // burst of gift USERNOTICEs the mirror has not caught up yet, so the local
+  // copy is what the next event in the burst must see.
+  //
+  // Seeding lazily (rather than holding an RTDB listener) is what keeps this
+  // module inert between events: with no subathon running it does nothing at
+  // all, no subscription and no traffic.
+  let pending = {};
+  let syncedFor = null;
+
+  const active = () => {
+    const state = getSubathonState();
+    if (!state?.active) return null;
+    if (syncedFor !== state.startedAt) {
+      // New run, or the first event after a restart — adopt whatever was
+      // persisted. `start` writes the whole node, so a fresh run has none.
+      pending = state.pendingGifts || {};
+      syncedFor = state.startedAt;
+      logger.info?.('subathon ledger active', { startedAt: state.startedAt });
+    }
+    return state;
+  };
+
+  const savePending = async (next) => {
+    pending = next; // local first — the next event in a burst must see it
+    try {
+      await database().ref(`${PATHS.subathon()}/pendingGifts`).set(next);
+    } catch (err) {
+      // Losing the persisted copy only costs us dedupe across a restart, which
+      // the operator can correct. Never let it stop the credit.
+      logger.warn?.('subathon pending-gift persist failed', { err: String(err) });
+    }
+  };
+
+  /** One place for "price it, write it, log it" so every path logs identically. */
+  async function credit(contribution, meta) {
+    const state = active();
+    if (!state) return;
+    try {
+      const entry = await creditSubathon(state, contribution, meta);
+      // Deliberately no monetary figure here. Logs get pasted around, and the
+      // rate card plus a worth value is enough to reconstruct channel revenue.
+      // Seconds and band are what an operator needs to debug a credit anyway.
+      logger.info('subathon credit', {
+        kind: entry.kind, who: entry.who, seconds: entry.seconds, band: entry.band, id: entry.id,
+      });
+    } catch (err) {
+      // Loud, because this is money and the operator needs to know to re-enter it.
+      logger.error('subathon credit FAILED — re-enter from the CLI', {
+        kind: meta?.kind, who: meta?.who, err: String(err),
+      });
+    }
+  }
+
+  const attach = (name, handler) => {
+    if (typeof chat[name] === 'function') listeners.push(chat[name](handler));
+    else logger.warn?.('chat event not available in this twurple version', { event: name });
+  };
+
+  // Direct subs and resubs. A gifted sub does NOT arrive here — it comes through
+  // onSubGift with the gifter attributed — so there's no overlap to dedupe.
+  const onSubLike = (kind) => async (_ch, user, info) => {
+    if (info?.isPrime === false && info?.plan == null) return;
+    await credit(
+      { product: planToProduct(info?.plan) },
+      { kind, who: info?.displayName || user, note: info?.isPrime ? 'prime' : null },
+    );
+  };
+  attach('onSub', onSubLike('sub'));
+  attach('onResub', onSubLike('resub'));
+
+  // The bundle: credit the WHOLE thing here, then swallow its parts below.
+  attach('onCommunitySub', async (_ch, user, info) => {
+    if (!active()) return; // also seeds `pending` on the first event of a run
+    const count = Math.max(1, Number(info?.count) || 1);
+    const gifter = info?.gifterDisplayName || info?.gifter || user || null;
+    await savePending(noteGiftBomb(pending, info?.gifter || user, count, Date.now()));
+    await credit(
+      { product: planToProduct(info?.plan), count },
+      { kind: 'giftbomb', who: gifter, note: `${count} × ${info?.plan || '1000'}` },
+    );
+  });
+
+  // An individual gift. Credited only when it is NOT part of a bundle we already
+  // paid for — which is the case for a one-off gift to a single person.
+  attach('onSubGift', async (_ch, _recipient, info) => {
+    if (!active()) return; // MUST come first: it seeds `pending` from the mirror
+    const { credit: shouldCredit, pending: next } = consumeGiftSub(pending, info?.gifter, Date.now());
+    await savePending(next);
+    if (!shouldCredit) return; // part of a bundle already credited in full
+    const months = Math.max(1, Number(info?.giftDuration) || 1);
+    await credit(
+      { product: planToProduct(info?.plan), months },
+      {
+        kind: 'subgift',
+        who: info?.gifterDisplayName || info?.gifter || 'anonymous',
+        note: months > 1 ? `${months}-month gift` : null,
+      },
+    );
+  });
+
+  // Upgrades are new money that produces no sub event of its own.
+  attach('onPrimePaidUpgrade', async (_ch, user, info) => {
+    await credit({ product: planToProduct(info?.plan) }, { kind: 'upgrade', who: info?.displayName || user });
+  });
+  attach('onGiftPaidUpgrade', async (_ch, user, info) => {
+    await credit({ product: 't1' }, { kind: 'upgrade', who: info?.displayName || user });
+  });
+  attach('onStandardPayForward', async (_ch, user, info) => {
+    await credit({ product: 't1' }, { kind: 'payforward', who: info?.displayName || user });
+  });
+
+  // Bits ride on an ordinary chat message rather than a dedicated event. This is
+  // a second onMessage listener alongside the game handler, which twurple allows.
+  attach('onMessage', async (_ch, user, _text, msg) => {
+    const bits = Number(msg?.bits) || 0;
+    if (bits <= 0) return;
+    await credit({ product: 'bits', bits }, { kind: 'bits', who: msg?.userInfo?.displayName || user });
+  });
+
+  return () => {
+    for (const l of listeners) l?.unbind?.();
+  };
+}

--- a/src/rules/subathon.js
+++ b/src/rules/subathon.js
@@ -1,0 +1,441 @@
+// SUBATHON — the pure clock-and-price engine. Like the rest of rules/*, it takes
+// the clock as an argument and touches no I/O, so a day-long event is testable in
+// milliseconds (see test/rules/subathon.test.js, which runs offline in CI).
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// NO RATES LIVE IN THIS REPOSITORY. THIS IS DELIBERATE — DO NOT ADD ANY.
+//
+// The repo is public. The payout figures, the per-band rates and the band
+// thresholds are together enough to reconstruct the channel's revenue from
+// publicly visible sub counts, and the streamer has asked that this stay
+// private. So this module defines only the SHAPE of a rate card; the values are
+// supplied at runtime from `config/subathon/rates` in RTDB, seeded from a
+// gitignored file outside the repo.
+//
+// That means no defaults, no examples, and no illustrative arithmetic in
+// comments or tests. Anything unconfigured prices at zero and says so, which is
+// a loud, safe failure rather than a wrong number nobody questions.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The rate card is one number per band. Each product is worth some amount, each
+// band grants some number of seconds per unit of that worth, and every price is
+// the product of the two — so the card is a handful of numbers rather than a
+// grid somebody has to keep internally consistent, and a new product prices
+// itself with no new entry.
+//
+// BANDS ARE KEYED ON ELAPSED UPTIME, not on time banked. The band reflects how
+// long she has been awake, not how big the pot is. Elapsed excludes paused time,
+// so an outage never silently changes the price.
+//
+// THERE IS NO HARD CAP. The terminal band extends forever; where the event
+// actually ends is her call on the night.
+
+const HOUR_MS = 3_600_000;
+const num = (v, fallback) => (Number.isFinite(Number(v)) ? Number(v) : fallback);
+
+/** Product keys a rate card may price. Names only — never values. */
+export const PRODUCTS = ['t1', 't2', 't3', 'bits', 'dollars'];
+
+/** Used when nothing is configured: one unnamed band worth nothing. */
+const EMPTY_RATES = { values: {}, bands: {}, schedule: [], se: null };
+
+/**
+ * Pull the rate card off a stored subathon record. Always returns the full
+ * shape, so callers never branch on missing config — they check `configured`.
+ */
+export function ratesFrom(state) {
+  const r = state?.rates;
+  if (!r) return { ...EMPTY_RATES, configured: false };
+  const values = r.values && typeof r.values === 'object' ? r.values : {};
+  const bands = r.bands && typeof r.bands === 'object' ? r.bands : {};
+  return {
+    values,
+    bands,
+    schedule: normalizeSchedule(r.schedule, bands),
+    se: r.se ?? null,
+    configured: Object.keys(values).length > 0 && Object.keys(bands).length > 0,
+  };
+}
+
+/** Twitch plan id → product key. Prime and tier 1 are paid identically. */
+export function planToProduct(plan) {
+  switch (String(plan)) {
+    case '3000': return 't3';
+    case '2000': return 't2';
+    case '1000':
+    case 'Prime':
+    case 'prime': return 't1';
+    default: return 't1'; // unknown plan: price it as the lowest tier rather than drop it
+  }
+}
+
+/**
+ * Ordered elapsed-hour thresholds → band name. The LAST entry is terminal: it
+ * applies from its threshold to forever, which is what makes "past the target is
+ * still the top band" fall out without needing a cap.
+ *
+ * RTDB stores arrays as numeric-keyed objects, so both shapes are accepted.
+ */
+export function normalizeSchedule(schedule, bands = {}) {
+  const list = Array.isArray(schedule)
+    ? schedule
+    : schedule && typeof schedule === 'object' ? Object.values(schedule) : [];
+  return list
+    .map((e) => ({ fromHours: num(e?.fromHours, NaN), band: String(e?.band || '') }))
+    .filter((e) => Number.isFinite(e.fromHours) && e.band && bands[e.band] != null)
+    .sort((a, b) => a.fromHours - b.fromHours);
+}
+
+/**
+ * Which band is in force after `elapsedMs` of uptime, or null if the schedule is
+ * unusable. Never guesses — an unconfigured event must not quietly pick a price.
+ */
+export function bandFor(elapsedMs, schedule) {
+  const entries = Array.isArray(schedule) ? schedule : [];
+  if (!entries.length) return null;
+  const hours = Math.max(0, num(elapsedMs, 0)) / HOUR_MS;
+  let band = null;
+  for (const entry of entries) {
+    if (hours >= entry.fromHours) band = entry.band;
+    else break;
+  }
+  return band ?? entries[0].band; // below the lowest threshold → the first band
+}
+
+/**
+ * What one contribution is worth, in the rate card's own units.
+ * `count` multiplies gift bundles; `months` multiplies multi-month gifts, since
+ * those are that many separate payouts.
+ */
+export function worthOf(contribution, values = {}) {
+  const product = String(contribution?.product || '');
+  if (product === 'bits') return Math.max(0, num(contribution.bits, 0)) * num(values.bit, 0);
+  if (product === 'dollars') return Math.max(0, num(contribution.dollars, 0)) * num(values.dollar, 0);
+  const unit = num(values[product], NaN);
+  if (!Number.isFinite(unit)) return 0;
+  const count = Math.max(1, Math.floor(num(contribution?.count, 1)));
+  const months = Math.max(1, Math.floor(num(contribution?.months, 1)));
+  return unit * count * months;
+}
+
+/**
+ * Price one contribution at the band in force RIGHT NOW.
+ *
+ * A contribution never splits across a boundary: whatever band is live when it
+ * lands prices the whole thing. Splitting would be marginally fairer and much
+ * harder to explain in chat or audit afterwards.
+ *
+ * @returns {{ seconds: number, band: string|null, worth: number, configured: boolean }}
+ */
+export function creditFor(contribution, elapsedMs, rates) {
+  const r = rates?.configured != null ? rates : ratesFrom({ rates });
+  const band = bandFor(elapsedMs, r.schedule);
+  if (!band || !r.configured) return { seconds: 0, band: null, worth: 0, configured: false };
+  const worth = worthOf(contribution, r.values);
+  // Round rather than floor: unit values below 1 can land a hair under an exact
+  // result in floating point.
+  return {
+    seconds: Math.round(worth * num(r.bands[band], 0)),
+    band,
+    worth: Math.round(worth * 100) / 100,
+    configured: true,
+  };
+}
+
+// ── Gift-bomb dedupe ────────────────────────────────────────────────────────
+//
+// A gift bundle arrives as ONE `onCommunitySub` carrying the count, followed by
+// a separate `onSubGift` for every recipient. Credit both and every bundle pays
+// double — the most common subathon-timer bug, and the one EventSub's `isGift`
+// flag would have settled for us if a broadcaster token were available.
+//
+// So we count the bundle and swallow exactly that many individual gifts from the
+// same gifter. A lone gift still pays, which is the case the naive "ignore all
+// gift subs" fix gets wrong.
+//
+// State in, state out — no closure, so a test can assert on it directly.
+
+const ANON_GIFTER = '__anon__';
+/** Pending bundles expire so a stale count can't swallow a genuine gift later. */
+export const GIFT_WINDOW_MS = 10 * 60_000;
+
+export function gifterKey(gifter) {
+  const s = String(gifter ?? '').trim().toLowerCase();
+  return s || ANON_GIFTER;
+}
+
+/** Record a bundle; the next `count` individual gifts from them are its parts. */
+export function noteGiftBomb(pending, gifter, count, now) {
+  const key = gifterKey(gifter);
+  const n = Math.max(0, Math.floor(num(count, 0)));
+  if (!n) return pending;
+  const prev = pending?.[key];
+  // A second bundle before the first drained ADDS to it rather than replacing
+  // it — a gifter can fire two back to back.
+  const carry = prev && now - prev.at < GIFT_WINDOW_MS ? prev.count : 0;
+  return { ...pending, [key]: { count: carry + n, at: now } };
+}
+
+/**
+ * Should this individual gift sub be credited?
+ * @returns {{ credit: boolean, pending: object }}
+ */
+export function consumeGiftSub(pending, gifter, now) {
+  const key = gifterKey(gifter);
+  const entry = pending?.[key];
+  if (!entry || entry.count <= 0 || now - entry.at >= GIFT_WINDOW_MS) {
+    return { credit: true, pending: dropExpired(pending, now) };
+  }
+  const next = { ...pending, [key]: { count: entry.count - 1, at: entry.at } };
+  if (next[key].count <= 0) delete next[key];
+  return { credit: false, pending: next };
+}
+
+/** Keep the pending map from growing across a long event. */
+function dropExpired(pending, now) {
+  if (!pending) return {};
+  const out = {};
+  for (const [key, entry] of Object.entries(pending)) {
+    if (now - entry.at < GIFT_WINDOW_MS) out[key] = entry;
+  }
+  return out;
+}
+
+// ── Clock ───────────────────────────────────────────────────────────────────
+//
+// THE DEADLINE IS DERIVED, NEVER STORED. It is
+//
+//     startedAt + (baseSeconds + Σ ledger.seconds) × 1000 + pausedMs
+//
+// which matters because two processes write here: the bot crediting events from
+// chat, and the operator's CLI crediting by hand. If both did read-modify-write
+// on a stored `endsAt`, concurrent writes would silently lose one. A transaction
+// would fix that — except production logs show transactions are exactly what
+// fails when the host's network blips, while plain writes buffer and flush on
+// reconnect. So every credit is an APPEND, the deadline is recomputed from the
+// sum, and there is nothing for two writers to clobber.
+
+/** Total seconds granted so far. RTDB hands the ledger back as an object. */
+export function ledgerSeconds(ledger) {
+  if (!ledger) return 0;
+  const rows = Array.isArray(ledger) ? ledger : Object.values(ledger);
+  return rows.reduce((sum, e) => sum + num(e?.seconds, 0), 0);
+}
+
+// Presence, not truthiness: `startedAt` is an epoch and 0 is a legal one.
+const startOf = (state) => num(state?.startedAt, NaN);
+
+/**
+ * The instant the clock is measured against. A paused subathon is frozen at the
+ * moment it paused, which holds both "time left" and "elapsed uptime" still
+ * without either being stored.
+ */
+function effectiveNow(state, now) {
+  return state?.paused ? num(state.pausedAt, now) : now;
+}
+
+/** Absolute deadline, recomputed from the ledger. */
+export function endsAt(state) {
+  const start = startOf(state);
+  if (!Number.isFinite(start)) return 0;
+  const granted = (num(state.baseSeconds, 0) + ledgerSeconds(state.ledger)) * 1000;
+  return start + granted + Math.max(0, num(state.pausedMs, 0));
+}
+
+/**
+ * Uptime so far, EXCLUDING every paused stretch. This is what picks the band, so
+ * an outage must not make the next hour more expensive.
+ */
+export function elapsedMs(state, now) {
+  const start = startOf(state);
+  if (!Number.isFinite(start)) return 0;
+  return Math.max(0, effectiveNow(state, now) - start - Math.max(0, num(state.pausedMs, 0)));
+}
+
+/** Time left on the clock. Zero once it runs out — it never goes negative. */
+export function remainingMs(state, now) {
+  if (!state?.active) return 0;
+  return Math.max(0, endsAt(state) - effectiveNow(state, now));
+}
+
+/** The band a contribution landing right now would be priced at. */
+export function currentBand(state, now) {
+  return bandFor(elapsedMs(state, now), ratesFrom(state).schedule);
+}
+
+/**
+ * When each band starts, in wall-clock terms — the operator's cross-check.
+ *
+ * kennyBot advances bands automatically at fixed elapsed-uptime marks; the
+ * external timer widget has to be switched by hand, and in this setup it isn't
+ * switched at all. That gap is what the correction ledger measures, and this is
+ * where the operator sees it coming.
+ *
+ * Future marks are PROJECTIONS — they assume no further pauses, because a pause
+ * that hasn't happened yet can't be accounted for.
+ */
+export function bandTimeline(state, now) {
+  const { schedule, bands } = ratesFrom(state);
+  const start = startOf(state);
+  if (!Number.isFinite(start) || !schedule.length) return [];
+  const pausedTotal = Math.max(0, num(state?.pausedMs, 0));
+  const elapsedHours = elapsedMs(state, now) / HOUR_MS;
+
+  return schedule.map((entry, i) => {
+    const next = schedule[i + 1] ?? null;
+    return {
+      band: entry.band,
+      rate: num(bands[entry.band], 0),
+      fromHours: entry.fromHours,
+      untilHours: next ? next.fromHours : null, // null = terminal
+      // Exact for marks already crossed (every pause so far is in pausedTotal);
+      // a projection for the ones ahead.
+      at: start + entry.fromHours * HOUR_MS + pausedTotal,
+      active: elapsedHours >= entry.fromHours && (!next || elapsedHours < next.fromHours),
+      past: Boolean(next) && elapsedHours >= next.fromHours,
+      projected: elapsedHours < entry.fromHours,
+    };
+  });
+}
+
+// ── The correction ledger ───────────────────────────────────────────────────
+//
+// THIS IS THE POINT OF THE WHOLE FEATURE. The external timer grants time at ONE
+// fixed rate; it does not step through the bands. So from the first band change
+// onward it is wrong — and because bands only get more expensive, it is wrong in
+// the generous direction.
+//
+// kennyBot therefore stores TWO numbers per contribution: what the rate card
+// says (`seconds`) and what the external timer granted (`seSeconds`). The
+// difference, summed, is the running amount to correct by — negative meaning
+// subtract, which the widget's add-time field supports.
+//
+// Applying a correction is recorded as an entry with `seconds: 0` and
+// `seSeconds` set to what was applied: it moves the external side without
+// touching kennyBot's, which is what closes the gap.
+//
+// kennyBot never sees the external timer's clock and does not need to. The
+// correction is a function of events BOTH systems observed, so both clocks —
+// and the start time, and the base — cancel out entirely. The blind spot is the
+// inverse: money the widget saw that chat did not surface, which is why
+// donations are entered by hand.
+
+/**
+ * What the external timer granted for a contribution.
+ *
+ * `se` is EITHER a flat seconds-per-unit-of-worth number (the whole column, if
+ * the widget was filled in consistently) OR a per-product map of the actual
+ * seconds in its fields, keyed `t1`/`t2`/`t3`/`bits100`/`dollar`.
+ *
+ * The map exists because the widget has a separate box per product and nothing
+ * forces those boxes to agree. Assuming they do would make every correction
+ * wrong in a way nobody would notice until the numbers were compared at the end.
+ */
+export function seSecondsFor(contribution, se, values = {}) {
+  if (se == null) return 0;
+  if (typeof se === 'number') return Math.round(worthOf(contribution, values) * se);
+
+  const flat = num(se.perUnit, NaN);
+  const product = String(contribution?.product || '');
+  const count = Math.max(1, Math.floor(num(contribution?.count, 1)));
+  const months = Math.max(1, Math.floor(num(contribution?.months, 1)));
+
+  if (product === 'bits') {
+    const per100 = num(se.bits100, NaN);
+    if (Number.isFinite(per100)) return Math.round((Math.max(0, num(contribution.bits, 0)) / 100) * per100);
+  } else if (product === 'dollars') {
+    const perDollar = num(se.dollar, NaN);
+    if (Number.isFinite(perDollar)) return Math.round(Math.max(0, num(contribution.dollars, 0)) * perDollar);
+  } else {
+    const configured = num(se[product], NaN);
+    if (Number.isFinite(configured)) return Math.round(configured * count * months);
+  }
+  if (!Number.isFinite(flat)) return 0;
+  return Math.round(worthOf(contribution, values) * flat);
+}
+
+/**
+ * How far the external timer is out, right now, in seconds.
+ * Negative = it has granted too much and time should be SUBTRACTED there.
+ */
+export function outstandingCorrection(ledger) {
+  const rows = !ledger ? [] : Array.isArray(ledger) ? ledger : Object.values(ledger);
+  return rows.reduce((sum, e) => sum + num(e?.seconds, 0) - num(e?.seSeconds, 0), 0);
+}
+
+/** Whether the external timer's config matches the band the schedule opens on. */
+export function seMatchesOpeningBand(rates) {
+  const r = rates?.configured != null ? rates : ratesFrom({ rates });
+  if (!r.configured || !r.schedule.length || r.se == null) return null;
+  const opening = num(r.bands[r.schedule[0].band], NaN);
+  const se = typeof r.se === 'number' ? r.se : num(r.se.perUnit, NaN);
+  if (!Number.isFinite(opening) || !Number.isFinite(se)) return null;
+  return opening === se;
+}
+
+/**
+ * Ledger totals grouped by kind — where the number came from, so a disagreement
+ * can be localised instead of just noticed.
+ */
+export function ledgerBreakdown(ledger) {
+  const rows = !ledger ? [] : Array.isArray(ledger) ? ledger : Object.values(ledger);
+  const by = new Map();
+  for (const e of rows) {
+    const kind = String(e?.kind || 'other');
+    const acc = by.get(kind) || { kind, count: 0, seconds: 0, worth: 0 };
+    acc.count += 1;
+    acc.seconds += num(e?.seconds, 0);
+    acc.worth += num(e?.worth, 0);
+    by.set(kind, acc);
+  }
+  return [...by.values()]
+    .map((a) => ({ ...a, worth: Math.round(a.worth * 100) / 100 }))
+    .sort((a, b) => b.seconds - a.seconds);
+}
+
+/** `4h 07m 12s` — long-form, because this clock is read at a glance. */
+export function formatDuration(ms) {
+  const total = Math.max(0, Math.floor(num(ms, 0) / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h) return `${h}h ${String(m).padStart(2, '0')}m ${String(s).padStart(2, '0')}s`;
+  if (m) return `${m}m ${String(s).padStart(2, '0')}s`;
+  return `${s}s`;
+}
+
+/**
+ * Parse an operator duration into SECONDS: `300`, `5m`, `1h30m`, `-10m`. Reuses
+ * nothing from src/db/timer.js on purpose — that one is minutes-by-default
+ * (`!timer 10` means ten minutes), and silently reading `-10` as ten minutes off
+ * this clock is not a mistake worth risking. Here a bare number is SECONDS and a
+ * unit is required for anything longer.
+ * @returns {number|null} seconds, or null if it isn't a duration
+ */
+export function parseSeconds(text) {
+  const t = String(text ?? '').trim().toLowerCase();
+  if (!t) return null;
+  const sign = t.startsWith('-') ? -1 : 1;
+  const body = t.replace(/^[+-]/, '');
+  if (/^\d+$/.test(body)) return sign * Number(body);
+
+  const parts = body.match(/(\d+(?:\.\d+)?)(h|m|s)/g);
+  if (!parts || parts.join('') !== body) return null;
+  const unit = { h: 3600, m: 60, s: 1 };
+  let total = 0;
+  for (const part of parts) {
+    const [, n, u] = /(\d+(?:\.\d+)?)(h|m|s)/.exec(part);
+    total += Number(n) * unit[u];
+  }
+  return sign * Math.round(total);
+}
+
+/** Human-readable summary of the external timer's assumed config. */
+export function describeSe(se) {
+  if (se == null) return 'not configured';
+  if (typeof se === 'number') return `flat ${se}s per unit`;
+  const parts = ['t1', 't2', 't3', 'bits100', 'dollar']
+    .filter((k) => Number.isFinite(Number(se[k])))
+    .map((k) => `${k}=${se[k]}s`);
+  return parts.length ? parts.join('  ') : `flat ${num(se.perUnit, 0)}s per unit`;
+}

--- a/test/firebase-rules.test.js
+++ b/test/firebase-rules.test.js
@@ -57,6 +57,28 @@ runOrSkip('client WRITE to leaderboard/bosses/raids/config is rejected', async (
   }
 });
 
+// The subathon record holds the rate card and a per-contributor ledger. Both are
+// private: the rates would let anyone reconstruct channel revenue from public
+// sub counts, and the ledger names who gave what. RTDB read grants CASCADE and
+// cannot be revoked deeper, so `config/subathon` must never be added to the
+// readable-children list above it. This test is what stops that happening by
+// accident.
+runOrSkip('client READ of the subathon rates and ledger is rejected', async () => {
+  await database().ref('config/subathon').set({
+    active: true,
+    rates: { values: { t1: 1 }, bands: { a: 1 }, schedule: [{ fromHours: 0, band: 'a' }] },
+    ledger: { x: { seconds: 1, who: 'someone' } },
+  });
+  try {
+    for (const path of ['config/subathon', 'config/subathon/rates', 'config/subathon/ledger']) {
+      const res = await fetch(restUrl(path));
+      assert.equal(res.status, 401, `client read of ${path} must be denied`);
+    }
+  } finally {
+    await database().ref('config/subathon').remove().catch(() => {});
+  }
+});
+
 runOrSkip('client can READ public game state', async () => {
   await database().ref('config/live').set(true);
   const res = await fetch(restUrl('config/live'));

--- a/test/rules/subathon.test.js
+++ b/test/rules/subathon.test.js
@@ -1,0 +1,306 @@
+// Offline tests for the subathon engine (node --test, no Firebase, no Twitch).
+//
+// EVERY NUMBER BELOW IS INVENTED. The real rate card is private (see the header
+// of src/rules/subathon.js) and must never appear here — a test fixture is still
+// a file in a public repository. These values are chosen to be obviously
+// synthetic and to make the arithmetic easy to check by eye.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ratesFrom, bandFor, creditFor, worthOf, planToProduct, normalizeSchedule,
+  noteGiftBomb, consumeGiftSub, GIFT_WINDOW_MS,
+  elapsedMs, remainingMs, endsAt, ledgerSeconds, currentBand, bandTimeline,
+  ledgerBreakdown, seSecondsFor, outstandingCorrection, seMatchesOpeningBand,
+  formatDuration, parseSeconds, describeSe,
+} from '../../src/rules/subathon.js';
+
+const HOUR = 3_600_000;
+const at = (hours) => hours * HOUR;
+
+// A made-up rate card. Products are worth round numbers and the bands halve, so
+// every expected value below can be checked mentally.
+const RATES = {
+  values: { t1: 2, t2: 4, t3: 10, bit: 0.01, dollar: 1 },
+  bands: { alpha: 100, beta: 50, gamma: 25 },
+  schedule: [
+    { fromHours: 0, band: 'alpha' },
+    { fromHours: 2, band: 'beta' },
+    { fromHours: 5, band: 'gamma' },
+  ],
+  se: 100, // the external timer parked on the opening band
+};
+const rates = ratesFrom({ rates: RATES });
+
+test('a price is the worth of the product times the band rate', () => {
+  assert.equal(creditFor({ product: 't1' }, at(0), rates).seconds, 200); // 2 × 100
+  assert.equal(creditFor({ product: 't3' }, at(0), rates).seconds, 1000); // 10 × 100
+  assert.equal(creditFor({ product: 't3' }, at(2), rates).seconds, 500); // 10 × 50
+  assert.equal(creditFor({ product: 't3' }, at(5), rates).seconds, 250); // 10 × 25
+  assert.equal(creditFor({ product: 'bits', bits: 1000 }, at(0), rates).seconds, 1000); // 10 × 100
+  assert.equal(creditFor({ product: 'dollars', dollars: 3 }, at(2), rates).seconds, 150);
+});
+
+test('an unconfigured event prices at zero and says so, rather than guessing', () => {
+  const empty = ratesFrom({});
+  assert.equal(empty.configured, false);
+  const r = creditFor({ product: 't1' }, at(0), empty);
+  assert.deepEqual(r, { seconds: 0, band: null, worth: 0, configured: false });
+});
+
+test('bands advance on ELAPSED uptime, and the last one is terminal', () => {
+  assert.equal(bandFor(at(0), rates.schedule), 'alpha');
+  assert.equal(bandFor(at(1.99), rates.schedule), 'alpha');
+  assert.equal(bandFor(at(2), rates.schedule), 'beta');
+  assert.equal(bandFor(at(4.99), rates.schedule), 'beta');
+  assert.equal(bandFor(at(5), rates.schedule), 'gamma');
+  assert.equal(bandFor(at(500), rates.schedule), 'gamma', 'no hard cap — the last band runs forever');
+});
+
+test('a contribution never splits across a band boundary', () => {
+  const before = creditFor({ product: 't3', count: 10 }, at(2) - 1000, rates);
+  const after = creditFor({ product: 't3', count: 10 }, at(2), rates);
+  assert.equal(before.seconds, 10_000, 'whole bundle at the outgoing band');
+  assert.equal(after.seconds, 5_000, 'whole bundle at the incoming band');
+});
+
+test('Prime pays as tier 1; an unknown plan is priced as the lowest tier', () => {
+  assert.equal(planToProduct('Prime'), 't1');
+  assert.equal(planToProduct('1000'), 't1');
+  assert.equal(planToProduct('2000'), 't2');
+  assert.equal(planToProduct('3000'), 't3');
+  assert.equal(planToProduct('9000'), 't1');
+});
+
+test('a multi-month gift pays once per month of money', () => {
+  assert.equal(worthOf({ product: 't1', months: 6 }, RATES.values), 12);
+  assert.equal(worthOf({ product: 't3', count: 2, months: 3 }, RATES.values), 60);
+});
+
+test('sub-unit values do not land a rounding step low', () => {
+  // 0.01 × 100 × 25 is 24.999… in float; the result must still be 25.
+  assert.equal(creditFor({ product: 'bits', bits: 100 }, at(5), rates).seconds, 25);
+  assert.equal(creditFor({ product: 'bits', bits: 1 }, at(5), rates).seconds, 0);
+});
+
+// ── Gift-bundle dedupe — the bug that would double every gifted sub ─────────
+
+test('a bundle of 20 pays once, not twenty-one times', () => {
+  const now = 1_000_000;
+  let pending = noteGiftBomb({}, 'GifterA', 20, now);
+  let credited = 0;
+  for (let i = 0; i < 20; i += 1) {
+    const r = consumeGiftSub(pending, 'GifterA', now + i * 100);
+    pending = r.pending;
+    if (r.credit) credited += 1;
+  }
+  assert.equal(credited, 0, 'every individual gift belongs to the bundle');
+});
+
+test('a lone gift sub with no bundle before it still pays', () => {
+  assert.equal(consumeGiftSub({}, 'GifterB', 1_000_000).credit, true);
+});
+
+test('a gifter who sends two bundles back to back has both absorbed', () => {
+  const now = 1_000_000;
+  let pending = noteGiftBomb({}, 'GifterC', 5, now);
+  pending = noteGiftBomb(pending, 'GifterC', 5, now + 500);
+  let credited = 0;
+  for (let i = 0; i < 10; i += 1) {
+    const r = consumeGiftSub(pending, 'GifterC', now + 1000 + i);
+    pending = r.pending;
+    if (r.credit) credited += 1;
+  }
+  assert.equal(credited, 0);
+  assert.equal(consumeGiftSub(pending, 'GifterC', now + 2000).credit, true, 'the next one is genuinely new');
+});
+
+test('anonymous gifters share one bucket and still dedupe', () => {
+  const now = 1_000_000;
+  let pending = noteGiftBomb({}, null, 3, now);
+  let credited = 0;
+  for (let i = 0; i < 3; i += 1) {
+    const r = consumeGiftSub(pending, undefined, now + i);
+    pending = r.pending;
+    if (r.credit) credited += 1;
+  }
+  assert.equal(credited, 0);
+});
+
+test('a stale bundle cannot swallow a real gift much later', () => {
+  const now = 1_000_000;
+  const pending = noteGiftBomb({}, 'GifterD', 5, now);
+  assert.equal(consumeGiftSub(pending, 'GifterD', now + GIFT_WINDOW_MS + 1).credit, true);
+});
+
+test('gifter matching is case-insensitive', () => {
+  const pending = noteGiftBomb({}, 'GifterE', 1, 1_000_000);
+  assert.equal(consumeGiftSub(pending, 'gIfTeRe', 1_000_010).credit, false);
+});
+
+// ── Clock ───────────────────────────────────────────────────────────────────
+
+const baseState = (over = {}) => ({
+  active: true, startedAt: 0, baseSeconds: 4 * 3600, paused: false,
+  pausedAt: null, pausedMs: 0, rates: RATES, ledger: null, ...over,
+});
+
+test('the deadline is derived from base + ledger, not stored', () => {
+  const state = baseState({ ledger: { a: { seconds: 600 }, b: { seconds: 300 } } });
+  assert.equal(endsAt(state), (4 * 3600 + 900) * 1000);
+  assert.equal(remainingMs(state, 0), (4 * 3600 + 900) * 1000);
+});
+
+test('the ledger sums whether RTDB hands it back as an object or an array', () => {
+  assert.equal(ledgerSeconds({ a: { seconds: 10 }, b: { seconds: 5 } }), 15);
+  assert.equal(ledgerSeconds([{ seconds: 10 }, { seconds: 5 }]), 15);
+  assert.equal(ledgerSeconds(null), 0);
+});
+
+test('a negative entry subtracts, and the clock floors at zero', () => {
+  assert.equal(remainingMs(baseState({ baseSeconds: 60, ledger: { a: { seconds: -600 } } }), 0), 0);
+});
+
+test('pausing freezes BOTH the countdown and the elapsed-uptime band', () => {
+  // 4h on the clock, paused one hour in: 3h left, 1h of uptime. Distinct numbers
+  // so neither assertion can pass by coincidence.
+  const state = baseState({ paused: true, pausedAt: at(1) });
+  assert.equal(remainingMs(state, at(4)), at(3), 'clock held at 3h left');
+  assert.equal(elapsedMs(state, at(4)), at(1), 'uptime held at 1h');
+});
+
+test('resuming preserves the remainder and does not advance the band', () => {
+  const remainingAtPause = remainingMs(baseState({ paused: true, pausedAt: at(2) }), at(2));
+  const resumed = baseState({ pausedMs: at(3) }); // a 3h outage, absorbed
+  assert.equal(remainingMs(resumed, at(5)), remainingAtPause, 'no time lost or gained');
+  assert.equal(elapsedMs(resumed, at(5)), at(2), 'the outage did not raise the price');
+});
+
+test('an outage does not push the band up', () => {
+  assert.equal(currentBand(baseState(), at(2)), 'beta');
+  assert.equal(currentBand(baseState({ pausedMs: at(1) }), at(2)), 'alpha', 'only 1h of real uptime');
+});
+
+// ── Reconciliation against the external timer ───────────────────────────────
+
+test('nothing is owed while the external timer matches the live band', () => {
+  const ledger = {};
+  for (const [i, c] of [{ product: 't1' }, { product: 't3' }, { product: 'bits', bits: 500 }].entries()) {
+    ledger[i] = {
+      seconds: creditFor(c, at(0), rates).seconds,
+      seSeconds: seSecondsFor(c, RATES.se, RATES.values),
+    };
+  }
+  assert.equal(outstandingCorrection(ledger), 0);
+  assert.equal(seMatchesOpeningBand(rates), true);
+});
+
+test('the external timer over-grants once the band moves past it', () => {
+  const c = { product: 't3' };
+  assert.equal(seSecondsFor(c, RATES.se, RATES.values), 1000, 'what it gives, always');
+  assert.equal(creditFor(c, at(2), rates).seconds, 500, 'what the card says now');
+  assert.equal(outstandingCorrection({ a: { seconds: 500, seSeconds: 1000 } }), -500, 'subtract');
+});
+
+test('applying a correction closes the gap exactly', () => {
+  const ledger = { a: { seconds: 500, seSeconds: 1000 } };
+  assert.equal(outstandingCorrection(ledger), -500);
+  const closed = { ...ledger, fix: { kind: 'correction', seconds: 0, seSeconds: -500 } };
+  assert.equal(outstandingCorrection(closed), 0);
+});
+
+test('money the external timer never saw is owed in full', () => {
+  assert.equal(outstandingCorrection({ a: { seconds: 777, seSeconds: 0 } }), 777);
+});
+
+test('per-field external config is honoured when the fields disagree', () => {
+  // t3 left on a different column from the rest.
+  const se = { t1: 200, t2: 400, t3: 1500, bits100: 100, dollar: 100 };
+  assert.equal(seSecondsFor({ product: 't1' }, se, RATES.values), 200);
+  assert.equal(seSecondsFor({ product: 't3' }, se, RATES.values), 1500);
+  assert.equal(seSecondsFor({ product: 't3', count: 4 }, se, RATES.values), 6000);
+  assert.equal(seSecondsFor({ product: 'bits', bits: 500 }, se, RATES.values), 500);
+  assert.equal(seSecondsFor({ product: 'dollars', dollars: 3 }, se, RATES.values), 300);
+  assert.equal(seMatchesOpeningBand(ratesFrom({ rates: { ...RATES, se } })), null, 'no single rate to compare');
+});
+
+test('an unset per-field value falls back to the flat rate', () => {
+  const se = { t1: 200, perUnit: 100 };
+  assert.equal(seSecondsFor({ product: 't3' }, se, RATES.values), 1000);
+});
+
+test('a missing external config owes nothing rather than inventing a number', () => {
+  assert.equal(seSecondsFor({ product: 't3' }, null, RATES.values), 0);
+  assert.equal(describeSe(null), 'not configured');
+});
+
+test('the band timeline marks which band is live and projects the rest', () => {
+  const rows = bandTimeline(baseState(), at(3));
+  assert.deepEqual(rows.map((r) => r.band), ['alpha', 'beta', 'gamma']);
+  assert.equal(rows[1].at, at(2));
+  assert.equal(rows[1].active, true);
+  assert.equal(rows[0].past, true);
+  assert.equal(rows[2].projected, true);
+  assert.equal(rows[2].untilHours, null, 'terminal');
+});
+
+test('a pause pushes every band mark later on the wall clock', () => {
+  assert.equal(bandTimeline(baseState(), at(1))[1].at, at(2));
+  assert.equal(bandTimeline(baseState({ pausedMs: at(2) }), at(1))[1].at, at(4));
+});
+
+test('the breakdown localises where the time came from and stays signed', () => {
+  const rows = ledgerBreakdown({
+    a: { kind: 'sub', seconds: 200 },
+    b: { kind: 'sub', seconds: 100 },
+    c: { kind: 'bits', seconds: 700 },
+    d: { kind: 'adjust', seconds: -300 },
+  });
+  assert.deepEqual(rows.map((r) => r.kind), ['bits', 'sub', 'adjust'], 'largest first');
+  assert.equal(rows.find((r) => r.kind === 'sub').count, 2);
+  assert.equal(rows.find((r) => r.kind === 'sub').seconds, 300);
+  assert.equal(rows.find((r) => r.kind === 'adjust').seconds, -300);
+});
+
+// ── Operator input ──────────────────────────────────────────────────────────
+
+test('durations parse as SECONDS by default, unlike !timer', () => {
+  assert.equal(parseSeconds('300'), 300, 'a bare number is seconds here');
+  assert.equal(parseSeconds('5m'), 300);
+  assert.equal(parseSeconds('90s'), 90);
+  assert.equal(parseSeconds('1h30m'), 5400);
+  assert.equal(parseSeconds('-10m'), -600);
+  assert.equal(parseSeconds('+2h'), 7200);
+});
+
+test('anything that is not a duration is rejected rather than guessed at', () => {
+  for (const bad of ['', '  ', 'abc', '5x', '5m30', 'm', '1h30', null, undefined]) {
+    assert.equal(parseSeconds(bad), null, `rejects ${JSON.stringify(bad)}`);
+  }
+});
+
+test('a malformed stored schedule yields no band rather than a wrong one', () => {
+  assert.deepEqual(normalizeSchedule([{ fromHours: 'x', band: 'nope' }], RATES.bands), []);
+  assert.equal(bandFor(at(50), []), null);
+  assert.equal(ratesFrom({ rates: { values: RATES.values, bands: RATES.bands, schedule: null } }).schedule.length, 0);
+});
+
+test('a schedule naming an unknown band is dropped, not priced at zero', () => {
+  const s = normalizeSchedule([{ fromHours: 0, band: 'alpha' }, { fromHours: 3, band: 'ghost' }], RATES.bands);
+  assert.deepEqual(s.map((e) => e.band), ['alpha']);
+});
+
+test('RTDB numeric-keyed schedule objects are accepted', () => {
+  const stored = { 0: { fromHours: 0, band: 'alpha' }, 1: { fromHours: 5, band: 'gamma' } };
+  const s = normalizeSchedule(stored, RATES.bands);
+  assert.equal(bandFor(at(1), s), 'alpha');
+  assert.equal(bandFor(at(6), s), 'gamma');
+});
+
+test('durations format for a glance on stream', () => {
+  assert.equal(formatDuration(0), '0s');
+  assert.equal(formatDuration(45_000), '45s');
+  assert.equal(formatDuration(605_000), '10m 05s');
+  assert.equal(formatDuration(4 * HOUR + 7 * 60_000 + 12_000), '4h 07m 12s');
+  assert.equal(formatDuration(-5), '0s');
+});


### PR DESCRIPTION
Same feature as #69, cherry-picked onto `main`.

> **#69 targets `dev` and is the one to review.** This PR exists so the subathon
> can reach production without waiting for the rest of the `dev` queue. Merge
> order is yours to pick — see *Relationship to `dev`* below.

For the occasional subathon, the bot keeps a **shadow ledger**: it watches the
sub / gift / cheer events chat already carries, prices each against a tiered rate
card, and records it. It is **not** the timer viewers see — a separate widget is —
and it adds **no chat commands**. Its only job is to tell the operator how far the
two have drifted, because that widget grants at one fixed rate while the card
changes with stream uptime.

### Off by default, and inert until switched on

No env var, no redeploy. The feature wakes when `scripts/subathon.mjs start`
writes a record and sleeps again on `end`. With no record present every handler
returns on a single in-memory read — no subscription, no timer, no traffic —
which is the state on an ordinary stream. The simulator asserts that before it
asserts anything else.

### No rate card ships in this repository

The card, the thresholds and the product values together would let anyone
reconstruct channel revenue from public sub counts, and the streamer asked for
that to stay private. So:

- `src/rules/subathon.js` defines only the **shape**; values load at start time
  from a gitignored file and are stored on the event record.
- Nothing defaults to a guess — an event with no card **refuses to credit**
  rather than silently pricing at zero.
- Test fixtures use invented numbers; the CLI hides monetary figures unless
  `--money`; bot logs record seconds and band but never worth, because logs get
  pasted around.
- `config/subathon` is not client-readable. `database.rules.json` already denied
  it; this PR adds a **test asserting so**, because RTDB read grants cascade and
  cannot be revoked deeper — adding `subathon` to a readable parent later would
  silently expose the ledger.

### Three design choices came from production logs, not guesswork

- **EventSub is disabled on the target channel** (`broadcaster token is not the
  channel owner`), so money events come from chat USERNOTICEs. That means
  hand-rolling gift-bundle dedupe, since EventSub's `isGift` is unavailable. The
  pending-bundle map is persisted and re-read on the first event of each run, so
  a restart part-way through a bundle does not re-credit recipients already
  covered.
- **Transactions fail when the host's network blips**, several times a day
  (`transaction at … failed: disconnect`). Every credit is therefore an append
  via `push().set()`, never a transaction.
- **The bot and the CLI both write here**, so the deadline is DERIVED from the
  ledger rather than stored, and concurrent writers cannot clobber a running
  total.

Bands key on elapsed uptime excluding pauses (an outage must not raise the
price), contributions never split across a boundary, and there is no hard cap —
the terminal band runs forever.

### Relationship to `dev`

`main` does not have `!media` (#64), which touches the same regions of
`src/db/firebase.js` and `src/db/configStore.js` as this feature — so the
cherry-pick conflicted there. Both files were reset to `main`'s version and the
subathon hunks applied directly, so **this branch contains no `!media` code**
(verified: `mediaSlot` / `obsMedia` appear nowhere in `src/` or `scripts/`).

Consequence worth knowing before merging: landing this on `main` while `!media`,
`!obs` (#66) and `!song` (#67) remain `dev`-only means those two files differ
between the branches, and merging `dev` → `main` later will conflict in them
again. Merging `dev` → `main` **first** avoids that entirely and makes this PR
unnecessary — #69 would simply flow through.

### Verified

All three suites and the simulator run **on this branch**, not just on the `dev`
one — the whole point of the exercise was that the `main` base is different:

- `npm test` **174** · `npm run test:emulator` **76** · `npm run test:e2e` **31**
  (lower offline/e2e counts than #69 because `main` has no `!media` tests)
- `scripts/subathon-sim.mjs` — **14 checks green**, driving the *real* handlers
  with fabricated events: inert with no subathon · a lone gift pays · a bundle
  pays **once**, not once per recipient · multi-month gifts pay per month · Prime
  prices as the lowest tier · **a restart part-way through a bundle** does not
  re-credit the rest

Live smoke test (on the `dev`-based branch, same code): bot boots against
scasplte2 with **zero warnings or errors**, logs nothing while no subathon
exists, and picks up `start` from the CLI in ~150ms with **no restart** —
`subathon ACTIVE` — through to `end` and `wipe`.

### Not included

No chat commands (anything useful here is either monetary or duplicates what the
widget already shows viewers). No overlay. Live crediting from a *real* Twitch
money event is unproven — it cannot be exercised on scasplte2 without spending
real money, which is what the simulator exists to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
