### PR TITLE
chore: npm run seed:media to reload the !media slot map

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,26 @@ came due during a long offline stretch is quietly re-armed instead of dumping a
 backlog. The defaults are seeded from `src/content/reminders.js` on first boot
 and **never** clobbered afterwards, so edited times survive every deploy.
 
+### Re-seeding `!media` slots locally
+
+The dev emulator DB is ephemeral — `dev:live` and `dev:all` each start an empty
+one — so the slot map has to go back in every session:
+
+```bash
+FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000 npm run seed:media
+npm run seed:media -- --list      # what's mapped right now
+npm run seed:media -- --prod      # deliberately, against production
+```
+
+The map itself is **not in this repo** — it's the streamer's own OBS source
+names, and they have to match character for character. It lives in a gitignored
+file (`MEDIA_SLOTS_FILE`, default `.workspace/media-slots.json`); run the script
+without one and it prints the shape it wants. Get exact names from
+`node scripts/obs-media.mjs`.
+
+Writes go through the same `mapSlot()` as `!media set`, so a mapping this
+accepts is one the chat command would have accepted too.
+
 ## Local development
 
 Requires **Node ≥ 20** and **Java** (for the Firebase emulator).

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",
-    "dev:all": "bash scripts/dev-all.sh"
+    "dev:all": "bash scripts/dev-all.sh",
+    "seed:media": "node scripts/seed-media.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/seed-media.mjs
+++ b/scripts/seed-media.mjs
@@ -1,0 +1,110 @@
+// scripts/seed-media.mjs — load the `!media` slot map into a database.
+//
+//   npm run seed:media                    # → the emulator (needs it running)
+//   npm run seed:media -- --prod          # → production, deliberately
+//   npm run seed:media -- --list          # show what's mapped, write nothing
+//
+// The dev emulator DB is EPHEMERAL — a fresh, empty one every `dev:live` /
+// `dev:all` — so the slots have to be re-seeded each session. Doing that by hand
+// through `!media set` is a dozen chat messages with exact OBS source names in
+// them, which is how a slot ends up looking mapped and playing nothing.
+//
+// THE MAPPING IS NOT IN THIS REPO. It's the streamer's own OBS setup, so it
+// lives in a gitignored file (MEDIA_SLOTS_FILE, default
+// .workspace/media-slots.json) shaped like:
+//
+//   [
+//     { "slot": 1, "inputs": "some-gif | some-sound", "label": "optional" },
+//     { "slot": 2, "inputs": "another-source", "scene": "Alerts", "action": "restart" }
+//   ]
+//
+// `inputs` is one string, sources separated by `|` — the same syntax `!media set`
+// takes, so what you put here is what a mod would type. Get the exact names from
+// `node scripts/obs-media.mjs`; they must match OBS character for character.
+//
+// Writes go through the same mapSlot() the chat command uses, so validation
+// (length, part count, action names) is identical — this cannot create a slot
+// `!media` would have rejected.
+
+import 'dotenv/config';
+import { readFile } from 'node:fs/promises';
+import { initFirebase, closeFirebase, database, PATHS } from '../src/db/firebase.js';
+import { mapSlot } from '../src/db/media.js';
+import { describeSlot, slotInputs } from '../src/rules/media.js';
+
+const SLOTS_FILE = process.env.MEDIA_SLOTS_FILE || '.workspace/media-slots.json';
+const emulator = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const argv = process.argv.slice(2);
+const listOnly = argv.includes('--list');
+
+if (!emulator && !argv.includes('--prod')) {
+  console.error('Refusing to guess a target.');
+  console.error('  emulator:    FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000 npm run seed:media');
+  console.error('  production:  npm run seed:media -- --prod');
+  process.exit(1);
+}
+
+/** RTDB stores arrays as numeric-keyed objects; accept an object map too. */
+function entriesFrom(parsed) {
+  const list = Array.isArray(parsed) ? parsed : Object.entries(parsed).map(([slot, v]) => ({ slot, ...v }));
+  return list.map((e) => ({
+    slot: Number(e.slot),
+    inputs: e.inputs ?? e.input,
+    ...(e.scene ? { scene: e.scene } : {}),
+    ...(e.action ? { action: e.action } : {}),
+    ...(e.label ? { label: e.label } : {}),
+  }));
+}
+
+async function loadSlots() {
+  try {
+    return entriesFrom(JSON.parse(await readFile(SLOTS_FILE, 'utf8')));
+  } catch (err) {
+    console.error(`Could not read ${SLOTS_FILE}: ${err.message}\n`);
+    console.error('No slot map ships in this repository — it is the streamer\'s OBS setup.');
+    console.error('Create it (the path is gitignored) as:\n');
+    console.error('  [ { "slot": 1, "inputs": "some-gif | some-sound", "label": "optional" } ]\n');
+    console.error('Exact source names: node scripts/obs-media.mjs');
+    process.exit(1);
+  }
+}
+
+async function main() {
+  initFirebase();
+  console.error(`→ ${emulator ? `EMULATOR ${emulator}` : process.env.FIREBASE_DATABASE_URL}\n`);
+
+  if (listOnly) {
+    // Read RTDB directly rather than db/media.js's listSlots(): that one serves
+    // the bot's in-memory config mirror, which is empty in a standalone script.
+    const snap = await database().ref(PATHS.mediaSlots()).get();
+    const rows = Object.entries(snap.val() || {})
+      .map(([n, slot]) => ({ ...slot, n: Number(n) }))
+      .filter((slot) => slotInputs(slot).length)
+      .sort((a, b) => a.n - b.n);
+    if (!rows.length) { console.log('(no slots mapped)'); return; }
+    for (const slot of rows) console.log(`  ${describeSlot(slot)}`);
+    return;
+  }
+
+  const entries = await loadSlots();
+  let failed = 0;
+  for (const { slot, ...patch } of entries) {
+    const res = await mapSlot(slot, patch);
+    if (!res.ok) {
+      console.error(`  ✗ slot ${slot}: ${res.reason}`);
+      failed += 1;
+      continue;
+    }
+    console.log(`  ✓ slot ${slot}  ${patch.inputs}`);
+  }
+  if (failed) {
+    process.exitCode = 1;
+    console.error(`\n${failed} slot(s) rejected — the same validation !media set applies.`);
+    return;
+  }
+  console.log(`\n${entries.length} slot(s) mapped. Fire one with !media <n>.`);
+}
+
+main()
+  .catch((err) => { console.error('failed:', err?.message || err); process.exitCode = 1; })
+  .finally(async () => { try { await closeFirebase(); } catch { /* already closed */ } });


### PR DESCRIPTION
`npm run seed:media` reloads the `!media` slot map into whichever database you point it at.

The dev emulator DB is ephemeral — `dev:live` and `dev:all` each start an empty one — so the slots have to be re-entered every session. By hand that's a dozen `!media set` messages carrying exact OBS source names, which is exactly how a slot ends up looking mapped and playing nothing.

```bash
FIREBASE_DATABASE_EMULATOR_HOST=127.0.0.1:9000 npm run seed:media
npm run seed:media -- --list      # what's mapped right now
npm run seed:media -- --prod      # deliberately, against production
```

### The map is not in this repo

It's the streamer's own OBS source names, so it loads from a gitignored file (`MEDIA_SLOTS_FILE`, default `.workspace/media-slots.json`). Run the script without one and it prints the shape it expects. Same split as the subathon rate card.

### Notes

- Writes go through the same `mapSlot()` as `!media set`, so this cannot create a slot the chat command would have rejected — validation is identical by construction rather than by duplication.
- `--list` reads RTDB directly rather than `db/media.js`'s `listSlots()`, which serves the bot's in-memory config mirror and is empty in a standalone script.
- Refuses to guess a target: emulator via `FIREBASE_DATABASE_EMULATOR_HOST`, production only with an explicit `--prod`.

### Verified

Against a live emulator with the real slot map: seeds 4 slots, `--list` renders them through `describeSlot` (the same one-liner `!media` prints in chat), and both guards fire — no target, and a missing map file. `npm test` 196 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)