### PR TITLE
fix(obs): !obs filter accepts several filters instead of silently dropping them

### DIFF
--- a/src/commands/mod/obs.js
+++ b/src/commands/mod/obs.js
@@ -25,12 +25,15 @@
 // own command and its own guard rails then.
 import {
   listScenes, setScene, listSources, setSourceVisible,
-  listFilters, setFilter, listAudio, setMute, getStats, obsControlReady,
+  listFilters, setFilters, listAudio, setMute, getStats, obsControlReady,
 } from '../../integrations/obsControl.js';
+
+/** How many filters one `!obs filter` may flip. A mod typo should not fan out. */
+const MAX_FILTERS = 5;
 
 const USAGE =
   'Usage: !obs scenes · scene <name> · sources [scene] · show|hide|toggle <source> · ' +
-  'filters <source> · filter on|off <source> | <filter> · audio · mute|unmute <input> · stats';
+  'filters <source> · filter on|off <source> | <filter> [| <filter>…] · audio · mute|unmute <input> · stats';
 
 /** Chat-sized list: OBS can hold far more scenes than a message can carry. */
 function joinCapped(items, max = 12) {
@@ -135,18 +138,36 @@ export default {
     }
 
     if (verb === 'filter') {
-      // `source | filter` — both are OBS names and both can contain spaces, so a
-      // separator is the only unambiguous split. Same `|` as `!media set`.
+      // `source | filter [| filter…]` — every name here is an OBS name and may
+      // contain spaces, so a separator is the only unambiguous split. Same `|` as
+      // `!media set`. The FIRST part is the source; everything after it is a
+      // filter, which is what makes "flip these two together" expressible.
       const state = String(rest[0] || '').toLowerCase();
-      const [sourceName, filterName] = rest.slice(1).join(' ').split('|').map((s) => s.trim());
-      if ((state !== 'on' && state !== 'off') || !sourceName || !filterName) {
-        reply(`Usage: !obs filter on|off <source> | <filter>`);
+      const parts = rest.slice(1).join(' ').split('|').map((s) => s.trim()).filter(Boolean);
+      const [sourceName, ...filterNames] = parts;
+      if ((state !== 'on' && state !== 'off') || !sourceName || !filterNames.length) {
+        reply(`Usage: !obs filter on|off <source> | <filter> [| <filter>…]`);
         return;
       }
-      const res = await setFilter(sourceName, filterName, state === 'on');
-      reply(res.ok
-        ? `🎛️ "${filterName}" on "${sourceName}" is now ${state}`
-        : `couldn't set it: ${res.reason}`);
+      if (filterNames.length > MAX_FILTERS) {
+        reply(`that's ${filterNames.length} filters — ${MAX_FILTERS} at a time is the limit`);
+        return;
+      }
+      const res = await setFilters(sourceName, filterNames, state === 'on');
+      if (!res.ok) {
+        reply(`couldn't set it: ${res.reason}`);
+        return;
+      }
+      // Partial success is the case worth being loud about: silently reporting
+      // success for the ones that worked is how a mod walks away believing a
+      // filter is on when it never was.
+      const done = res.data.results.filter((r) => r.ok).map((r) => `"${r.filterName}"`);
+      const failed = res.data.results.filter((r) => !r.ok);
+      const okPart = done.length ? `🎛️ ${done.join(' + ')} on "${sourceName}" now ${state}` : '';
+      const badPart = failed.length
+        ? `${done.length ? ' · ' : ''}couldn't set ${failed.map((r) => `"${r.filterName}"`).join(' + ')}: ${failed[0].reason}`
+        : '';
+      reply(`${okPart}${badPart}`);
       return;
     }
 

--- a/src/integrations/obsControl.js
+++ b/src/integrations/obsControl.js
@@ -150,12 +150,39 @@ export function listFilters(sourceName) {
   });
 }
 
-/** Turn one filter on or off. */
-export function setFilter(sourceName, filterName, enabled) {
+/**
+ * Turn one or more filters on a source on or off, over a SINGLE connection.
+ *
+ * Two things this deliberately does not do. It does not open a connection per
+ * filter — `run()` wraps one, and flipping three filters should not mean three
+ * handshakes. And it does not abort the batch on the first bad name: a typo in
+ * the second of three filters would otherwise leave the first applied, the third
+ * untouched, and the mod guessing which. Each filter reports its own outcome and
+ * the caller says exactly what happened.
+ *
+ * @param {string[]} filterNames
+ * @returns {Promise<{ok:true,data:{sourceName:string,enabled:boolean,results:Array<{filterName:string,ok:boolean,reason?:string}>}}|{ok:false,reason:string}>}
+ */
+export function setFilters(sourceName, filterNames, enabled) {
   return run(async (request) => {
-    await request('SetSourceFilterEnabled', { sourceName, filterName, filterEnabled: enabled });
-    return { sourceName, filterName, enabled };
+    const results = [];
+    for (const filterName of filterNames) {
+      try {
+        await request('SetSourceFilterEnabled', { sourceName, filterName, filterEnabled: enabled });
+        results.push({ filterName, ok: true });
+      } catch (err) {
+        // OBS's own message names the thing it couldn't find, which beats
+        // anything we would write here.
+        results.push({ filterName, ok: false, reason: String(err?.message || err) });
+      }
+    }
+    return { sourceName, enabled, results };
   });
+}
+
+/** Turn one filter on or off. Thin wrapper — the batch form is the real one. */
+export function setFilter(sourceName, filterName, enabled) {
+  return setFilters(sourceName, [filterName], enabled);
 }
 
 // ── audio ────────────────────────────────────────────────────────────────────

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -529,9 +529,17 @@ export const SCENARIOS = [
         assert.match(await bot.send(mod, '!obs filters cam'), /Chroma Key/);
         // Source and filter are both OBS names and both may contain spaces, so
         // `|` is the only unambiguous split — same separator as !media set.
-        assert.match(await bot.send(mod, '!obs filter off cam | Chroma Key'), /is now off/);
+        assert.match(await bot.send(mod, '!obs filter off cam | Chroma Key'), /now off/);
         assert.deepEqual(calls.at(-1).data, { sourceName: 'cam', filterName: 'Chroma Key', filterEnabled: false });
         assert.match(await bot.send(mod, '!obs filter off cam'), /Usage: !obs filter/, 'needs both names');
+
+        // MULTIPLE filters in one go. The first part is the source; every part
+        // after it is a filter. Previously the extras were silently dropped —
+        // the command reported success having flipped only the first.
+        const multi = await bot.send(mod, '!obs filter on cam | Chroma Key | Blur');
+        assert.match(multi, /"Chroma Key" \+ "Blur"/, 'both are named back');
+        assert.deepEqual(calls.slice(-2).map((c) => c.data.filterName), ['Chroma Key', 'Blur']);
+        assert.ok(calls.slice(-2).every((c) => c.data.filterEnabled === true));
 
         assert.match(await bot.send(mod, '!obs audio'), /Mic/);
         assert.match(await bot.send(mod, '!obs mute Mic'), /muted/);

--- a/test/rules/obs.test.js
+++ b/test/rules/obs.test.js
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import {
   initObsControlWith, obsControlReady,
   listScenes, setScene, listSources, setSourceVisible,
-  listFilters, setFilter, listAudio, setMute, getStats,
+  listFilters, setFilter, setFilters, listAudio, setMute, getStats,
 } from '../../src/integrations/obsControl.js';
 
 /** Records every request and answers with a small fake OBS. */
@@ -149,6 +149,33 @@ test('setting a filter names both the source and the filter', async () => {
   assert.deepEqual(obs.calls[0].data, {
     sourceName: 'cam', filterName: 'Chroma Key', filterEnabled: false,
   });
+});
+
+test('several filters flip in one batch, in the order given', async () => {
+  // They share a single run() — and therefore a single connection — which the
+  // request-level seam cannot observe; what it CAN show is that all three were
+  // issued, in order, with the same target state.
+  const res = await setFilters('cam', ['Chroma Key', 'Blur', 'Sharpen'], true);
+  assert.equal(res.ok, true);
+  assert.deepEqual(obs.calls.map((c) => c.data.filterName), ['Chroma Key', 'Blur', 'Sharpen']);
+  assert.ok(obs.calls.every((c) => c.data.filterEnabled === true));
+  assert.deepEqual(res.data.results.map((r) => r.ok), [true, true, true]);
+});
+
+test('a bad filter name does not abort the ones after it', async () => {
+  // The bug this guards: aborting mid-batch leaves the first applied, the last
+  // untouched, and the mod with no idea which is which.
+  const o = fakeObs({
+    SetSourceFilterEnabled: (d) => {
+      if (d.filterName === 'Nope') throw new Error(`No filter was found by the name of \`Nope\``);
+      return {};
+    },
+  });
+  initObsControlWith(o.request);
+  const res = await setFilters('cam', ['Chroma Key', 'Nope', 'Blur'], true);
+  assert.equal(res.ok, true, 'the batch itself succeeded');
+  assert.deepEqual(res.data.results.map((r) => r.ok), [true, false, true]);
+  assert.match(res.data.results[1].reason, /Nope/, "OBS's own message is passed through");
 });
 
 // ── audio ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Reported from live use: enabling two filters at once only applied the first.

### What was wrong

`src/commands/mod/obs.js` destructured only the first two parts:

```js
const [sourceName, filterName] = rest.slice(1).join(' ').split('|').map((s) => s.trim());
```

So `!obs filter on cam | Chroma Key | Blur` set **Chroma Key**, threw **Blur** away, and replied as if both had worked. The silence is the real defect — a mod walks away believing a filter is on when it never was.

### What it does now

The first part is the source; **every part after it is a filter**. That's what someone trying to flip two together already expects, since `!media set` uses the same `|` for the same reason — these are OBS names and may contain spaces, so a separator is the only unambiguous split.

```
!obs filter on cam | Chroma Key | Blur
🎛️ "Chroma Key" + "Blur" on "cam" now on
```

Capped at 5 per command so a typo can't fan out.

### Batch semantics

`setFilters()` applies them over a **single connection** — `run()` wraps one, and three filters shouldn't mean three handshakes — and **does not abort on the first bad name**. Aborting mid-batch would leave the first applied, the third untouched, and the mod guessing which. Each filter carries its own outcome, and the reply names what worked and what didn't, passing through OBS's own error text:

```
!obs filter on cam | Chroma Key | Nope
🎛️ "Chroma Key" on "cam" now on · couldn't set "Nope": No filter was found by the name of `Nope`
```

`setFilter()` remains as a one-filter wrapper.

### Tests

- `test/rules/obs.test.js` — a batch issues all three in order with the same target state; a bad name in the middle does **not** abort the ones after it, and OBS's message is passed through
- `test/e2e/scenarios.js` — the multi-filter case through the real dispatcher, asserting both filters are named back **and** that both `SetSourceFilterEnabled` calls actually reached OBS

`npm test` 198 · `test:emulator` 75 · `test:e2e` 34, all passing.

Not verified against real OBS — the seam is the obs-websocket `request` itself, so what's asserted is the protocol call OBS would receive, but a live `!obs filter on <source> | <a> | <b>` is worth one try before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)