### PR TITLE
fix(raid): end seasons at the finale, earn prestige, and fix loot payout

### DIFF
--- a/docs/raid-game-spec.md
+++ b/docs/raid-game-spec.md
@@ -204,11 +204,17 @@ guaranteed win** (avoid pay-to-win resentment and gambling optics).
 - Season transition: award veterans a **prestige title** (the "cleared on time"
   equivalent); **reset gear** so newcomers start fresh and the meta doesn't
   calcify (character + level may carry or partially reset — see §13).
-- A "veteran" is a hero who **actually raided the outgoing season** — i.e. has a
-  `leaderboard/<seasonId>` entry, which `finishBattle` writes for every signed-up
-  hero of every resolved raid (damage 0 included, so healers count). Prestige is
-  earned, never granted to every account that once ran `!create`: it carries a
-  permanent renown rating bonus. The **gear reset applies to everyone**.
+- **Renown is the only veteran stat; "prestige" is a source of it, not a second
+  number.** Renown comes from two places — `+1` per raid **cleared**, and a
+  **prestige** award at rollover — and converts to a permanent role-rating bonus
+  at `rating.renownPerPoint`, capped at `rating.renownCap`. Gear resets each
+  season; renown never does. That is the whole veteran ladder.
+- Prestige is **earned and scaled by attendance**: `prestigePerRaid` renown for
+  each raid of the outgoing season the hero was actually on the roster for
+  (counted from `raids/<seasonId>/<week>` entries that have a `result` — a week
+  scheduled but never fought counts for nobody), bounded by `prestigeMax`. It is
+  never granted to every account that once ran `!create`. The **gear reset
+  applies to everyone**, veteran or not.
 - A season **ends on its finale**. `!boss next` refuses to schedule past the last
   scripted week and points at `!season rollover` — the boss lookup clamps an
   out-of-range week to the finale, so without that guard a season silently never

--- a/docs/raid-game-spec.md
+++ b/docs/raid-game-spec.md
@@ -204,6 +204,15 @@ guaranteed win** (avoid pay-to-win resentment and gambling optics).
 - Season transition: award veterans a **prestige title** (the "cleared on time"
   equivalent); **reset gear** so newcomers start fresh and the meta doesn't
   calcify (character + level may carry or partially reset — see §13).
+- A "veteran" is a hero who **actually raided the outgoing season** — i.e. has a
+  `leaderboard/<seasonId>` entry, which `finishBattle` writes for every signed-up
+  hero of every resolved raid (damage 0 included, so healers count). Prestige is
+  earned, never granted to every account that once ran `!create`: it carries a
+  permanent renown rating bonus. The **gear reset applies to everyone**.
+- A season **ends on its finale**. `!boss next` refuses to schedule past the last
+  scripted week and points at `!season rollover` — the boss lookup clamps an
+  out-of-range week to the finale, so without that guard a season silently never
+  ends and chat re-fights the same boss (this happened in prod for 3 weeks).
 - Season launch is the natural **invite-a-friend growth moment**; consider a
   referral bonus active at season start.
 

--- a/docs/raid-game-spec.md
+++ b/docs/raid-game-spec.md
@@ -146,6 +146,25 @@ function onChatMessage(user, config) {
   (gear that boosts tank/heal/dps ratings). Equipping raises the character's
   role rating → raid contribution.
 - Items live in an **item catalog** you define per raid tier (§5.4 / §5.5).
+- **Two loot paths, and they are not the same.** *Chat drops* are a communal
+  LOTTERY into general chat — announced by name and rarity, `!grab` enters, one
+  random entrant wins — fired by a cheer, the live scheduler, or mod `!drop`.
+  *Raid rewards* are paid by `finishBattle` on a clear straight into each roster
+  hero's bag (participation roll · survivor bonus · MVP bonus) on the richer
+  `bossRarityWeights` ladder, with no lottery and no choice.
+- Raid rewards are therefore **role-aware**: gear only pays out through
+  `bonuses[player.role]`, so an off-role item is worth exactly 0 to the hero it
+  lands on, forever. Chat drops stay role-blind on purpose — the winner is
+  unknown when the item is picked, the item is announced before anyone grabs,
+  and `!trade` / `!offer` (aka `!give`) can move it.
+- **Bits set a rarity floor, not just a trigger** (`loot.cheer`). Below
+  `minBits` nothing drops; above it the highest band the cheer clears sets a
+  floor, and the ladder re-rolls on the remaining relative weights — so a big
+  cheer can still hit legendary but can never fall to common.
+- Payout is **claimed atomically** (`combat/status` live→done in a transaction).
+  The phase pointer is an in-memory mirror two callers can both read as `live`;
+  without the claim, overlapping ticks award loot, renown and leaderboard
+  damage twice.
 
 ### 5.3 The weekly community raid (many-vs-1)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node --watch index.js",
     "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js test/cooldown.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js test/cooldown.test.js test/season-rollover.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node --watch index.js",
     "dev:live": "bash scripts/dev-live.sh",
     "test": "node --test \"test/rules/**/*.test.js\"",
-    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js test/cooldown.test.js test/season-rollover.test.js\"",
+    "test:emulator": "firebase emulators:exec --only database --project okrafans \"node --test --test-concurrency=1 test/firebase-rules.test.js test/mute.test.js test/roster-refresh.test.js test/market.test.js test/todo.test.js test/duel.test.js test/catalog.test.js test/trade.test.js test/timer.test.js test/reminders.test.js test/cooldown.test.js test/season-rollover.test.js test/raid-payout.test.js\"",
     "test:e2e": "firebase emulators:exec --only database --project okrafans \"node --test test/e2e/commands.e2e.test.js\"",
     "synthetic": "firebase emulators:exec --only database --project okrafans \"node scripts/synthetic-chat.js\"",
     "dev:console": "firebase emulators:exec --only database --project okrafans \"node scripts/dev-console.js\"",

--- a/src/commands/mod/boss.js
+++ b/src/commands/mod/boss.js
@@ -2,7 +2,7 @@
 // Roster locks `lockLeadMs` before raid night; the battle then plays out
 // automatically (or force it early with !raidnight).
 import { setupRaidWeek, nextWeekId, computeNextRaidNight } from '../../db/raid.js';
-import { defaultBoss, seasonBoss } from '../../content/bosses.js';
+import { defaultBoss, seasonBoss, weeksInSeason, SEASON_COUNT } from '../../content/bosses.js';
 import { getSeason, setSeason } from '../../db/configStore.js';
 import { SEASON_LOOT } from '../../content/items.js';
 import { config } from '../../config.js';
@@ -52,7 +52,24 @@ export default {
       }
       const weekId = await nextWeekId(season.id);
       const weekNum = parseInt(String(weekId).replace(/\D/g, ''), 10) || 1;
-      await schedule(season.id, weekId, seasonBoss(season.tier || 1, weekNum), reply, `Week ${weekNum}`);
+
+      // A season has a FIXED number of scripted bosses and ends on its finale.
+      // `seasonBoss` clamps an out-of-range week to that finale, so without this
+      // guard `!boss next` re-schedules the same finale every week forever — the
+      // season silently never ends. Stop and point at the rollover instead.
+      const tier = season.tier || 1;
+      const total = weeksInSeason(tier);
+      if (weekNum > total) {
+        const next = tier + 1;
+        const how = next <= SEASON_COUNT
+          ? `Start the next tier: !season rollover t${next}`
+          : 'No further scripted tier exists — use !season start <id> or !boss set <name>.';
+        reply(`🏁 ${season.name || season.id} is complete — all ${total} bosses have been faced. ${how}`);
+        return;
+      }
+
+      const lead = weekNum === total ? `Week ${weekNum} FINALE` : `Week ${weekNum}`;
+      await schedule(season.id, weekId, seasonBoss(tier, weekNum), reply, lead);
       return;
     }
 

--- a/src/commands/mod/season.js
+++ b/src/commands/mod/season.js
@@ -2,7 +2,7 @@
 // Sets the season pointer + loot table and opens week 1's muster with the first
 // boss scheduled for the next raid night. Gear reset / prestige carryover on
 // season rollover is a later phase (§5.6) — flagged, not silently done.
-import { setSeason } from '../../db/configStore.js';
+import { setSeason, getSeason } from '../../db/configStore.js';
 import { setupRaidWeek, computeNextRaidNight } from '../../db/raid.js';
 import { rolloverAllPlayers } from '../../db/players.js';
 import { seasonBoss } from '../../content/bosses.js';
@@ -47,14 +47,22 @@ export default {
 
     if (sub === 'rollover') {
       // New tier: RESET everyone's gear (fresh start, newcomers aren't behind),
-      // KEEP level + renown, and grant prestige renown for the season cleared (§5.6).
+      // KEEP level + renown, and grant prestige renown to the heroes who actually
+      // raided the OUTGOING season (§5.6 awards it to veterans). Read that season
+      // before openSeason() overwrites the pointer.
       if (!/^[a-zA-Z0-9_-]{1,32}$/.test(id)) {
         reply('Usage: !season rollover <id> [name]');
         return;
       }
-      const count = await rolloverAllPlayers();
+      const outgoing = getSeason();
+      const { reset, prestiged } = await rolloverAllPlayers({ seasonId: outgoing?.id });
       const boss = await openSeason(id, name);
-      reply(`🔄 Season rolled over to ${name} (${id}). ${count} heroes' gear reset — levels & veteran renown kept, prestige granted. Week 1: ${boss.name}.`);
+      const from = outgoing?.name || outgoing?.id || 'the last season';
+      reply(
+        `🔄 Season rolled over to ${name} (${id}). ${reset} heroes' gear reset (levels & renown kept) · ` +
+        `${prestiged} veteran${prestiged === 1 ? '' : 's'} of ${from} earned prestige. ` +
+        `Week 1: ${boss.name} — !muster to join!`,
+      );
       return;
     }
 

--- a/src/commands/mod/season.js
+++ b/src/commands/mod/season.js
@@ -55,13 +55,16 @@ export default {
         return;
       }
       const outgoing = getSeason();
-      const { reset, prestiged } = await rolloverAllPlayers({ seasonId: outgoing?.id });
+      const { reset, prestiged, granted, best } = await rolloverAllPlayers({ seasonId: outgoing?.id });
       const boss = await openSeason(id, name);
       const from = outgoing?.name || outgoing?.id || 'the last season';
+      const prestigeLine = prestiged
+        ? `${prestiged} veteran${prestiged === 1 ? '' : 's'} of ${from} earned ${granted} prestige renown ` +
+          `(+${config.raid.prestigePerRaid} per raid attended, best ${best})`
+        : `no veterans of ${from} to reward`;
       reply(
         `🔄 Season rolled over to ${name} (${id}). ${reset} heroes' gear reset (levels & renown kept) · ` +
-        `${prestiged} veteran${prestiged === 1 ? '' : 's'} of ${from} earned prestige. ` +
-        `Week 1: ${boss.name} — !muster to join!`,
+        `${prestigeLine}. Week 1: ${boss.name} — !muster to join!`,
       );
       return;
     }

--- a/src/commands/offer.js
+++ b/src/commands/offer.js
@@ -5,13 +5,13 @@
 import { runExchange } from './trade.js';
 
 export default {
-  names: ['offer', 'gift'],
+  names: ['offer', 'gift', 'give'],
   mod: false,
   cooldownMs: 3_000,
   // The recipient answers the bot's own prompt with `!offer accept`, often right
   // after looking at it with a bare `!offer` (or mistyping it once). Keying the
   // cooldown per sub-verb keeps those from cancelling each other out.
   cooldownPerSubcommand: true,
-  help: '!offer @user <item|#> [+ credits] — GIVE an item/credits to someone (one-way); they reply !offer accept / decline',
+  help: '!offer @user <item|#> [+ credits] (aka !give / !gift) — GIVE an item/credits to someone (one-way); they reply !offer accept / decline',
   run: (ctx) => runExchange(ctx, 'offer'),
 };

--- a/src/config.js
+++ b/src/config.js
@@ -89,6 +89,14 @@ export const config = {
   // ── Weekly raid: muster → raid night → automated battle (spec §5.8) ───────
   raid: {
     seasonWeeks: 6, // a season = 6 weekly bosses + a prestige finale (§5.6)
+    // PRESTIGE at season rollover (§5.6): renown granted for the weeks a hero
+    // actually raided that season, so attendance scales the reward instead of
+    // everyone getting the same flat lump. Renown is the ONLY veteran stat —
+    // "prestige" is a source of it, not a separate number — and it converts at
+    // rating.renownPerPoint, so a full 6-week season (~6 prestige + ~6 clear
+    // renown) is about +24 rating and three seasons lands near renownCap.
+    prestigePerRaid: 1,
+    prestigeMax: 10, // safety bound if a season ever runs long (t1 ran 8 weeks)
     // Roster locks this long before raid night; gear/level after lock don't
     // affect this battle (determinism + fairness, IMPLEMENTATION §L.1).
     lockLeadMs: 15 * 60 * 1000,

--- a/src/config.js
+++ b/src/config.js
@@ -72,6 +72,24 @@ export const config = {
     // BOSS-battle rewards roll on a HIGHER-rarity table (clearing a raid should
     // feel better than a chat drop — owner request).
     bossRarityWeights: { common: 18, uncommon: 34, rare: 28, epic: 14, legendary: 6 },
+    // BITS → a communal chat drop. `minBits` is the trigger (100 fired far too
+    // often); above it the cheer buys a rarity FLOOR, so a big cheer cannot roll
+    // a common. Bands are [minBits, floor] ascending — the highest one the cheer
+    // clears wins. The floor restricts the ladder and re-rolls on the remaining
+    // relative weights, so 5000 bits still reaches legendary, it just can't fall
+    // below epic. The drop is still a LOTTERY into general chat: the cheerer
+    // gets no edge (owner decision), they buy the item for the community.
+    cheer: {
+      minBits: 500,
+      /** @type {[number, 'common'|'uncommon'|'rare'|'epic'|'legendary'][]} */
+      floors: [
+        [500, 'common'],
+        [1000, 'uncommon'],
+        [2500, 'rare'],
+        [5000, 'epic'],
+        [10000, 'legendary'],
+      ],
+    },
     // Claim is a LOTTERY over a window (spec §5.2): every !grab in the window
     // ENTERS the viewer; at window close ONE winner is drawn for the ONE item, so
     // a drop never mints duplicates. TIER-FAIR — every entrant has equal odds in

--- a/src/content/bosses.js
+++ b/src/content/bosses.js
@@ -227,6 +227,23 @@ export function bossFor(seasonNumber, weekNumber) {
 /** Flat list of all 18 bosses (id-keyed iteration / admin tooling). */
 export const ALL_BOSSES = SEASONS.flat();
 
+/**
+ * How many scripted weekly bosses a season has (its finale is the last one).
+ * `bossFor` CLAMPS an out-of-range week to the finale, which is the right
+ * defensive behavior for a lookup but silently repeats the finale forever if a
+ * caller keeps asking for week 7, 8, 9… Callers that schedule content must ask
+ * this FIRST and stop at the end of the season (see !boss next).
+ * @param {number} seasonNumber 1-based
+ * @returns {number}
+ */
+export function weeksInSeason(seasonNumber) {
+  const s = Math.max(1, Math.min(SEASONS.length, seasonNumber || 1)) - 1;
+  return SEASONS[s].length;
+}
+
+/** How many seasons of scripted content exist (the last tier has no successor). */
+export const SEASON_COUNT = SEASONS.length;
+
 // ─── engine wiring (resolve ability sets + back-compat helpers) ──────────────
 import { BOSS_ABILITY_SETS, DEFAULT_BOSS_ABILITIES } from './abilities.js';
 

--- a/src/db/players.js
+++ b/src/db/players.js
@@ -200,27 +200,58 @@ export async function addLoot(userId, itemId) {
 }
 
 /**
+ * Who actually took part in a season: the uids with a `leaderboard/<seasonId>`
+ * entry. `finishBattle` writes one for EVERY signed-up hero of every resolved
+ * raid (damage 0 included), so this is participation, not a damage ranking — a
+ * healer who never hit the boss is in it, and it matches `stats.raidsParticipated`.
+ * @param {string|null|undefined} seasonId
+ * @returns {Promise<Set<string>>} empty when there is no season to be a veteran of
+ */
+async function seasonParticipants(seasonId) {
+  if (!seasonId) return new Set();
+  const snap = await database().ref(`leaderboard/${seasonId}`).get();
+  return new Set(Object.keys(snap.val() || {}));
+}
+
+/**
  * Season rollover (spec §5.6): reset every hero's GEAR (re-roll starter, clear
  * the bag) so a new tier starts fresh and newcomers aren't behind — but KEEP
- * level + renown, and award prestige renown for the season cleared. Returns the
- * number of heroes rolled over.
- * @param {{ prestigeRenown?: number }} [opts]
+ * level + renown.
+ *
+ * PRESTIGE IS EARNED, NOT GRANTED TO EVERYONE. Only heroes who actually raided
+ * in the outgoing season (`seasonId`) get the prestige renown and the
+ * `seasonsPlayed` bump — spec §5.6 awards it to *veterans*, and handing it to
+ * every account that ever ran `!create` would devalue it and inflate the
+ * permanent renown rating bonus for people who never showed up. Gear still
+ * resets for everyone, veteran or not.
+ *
+ * Called with no `seasonId` there is nothing to have been a veteran OF, so no
+ * prestige is awarded (the gear reset still happens).
+ *
+ * @param {{ prestigeRenown?: number, seasonId?: string|null }} [opts]
+ * @returns {Promise<{ reset: number, prestiged: number }>}
  */
-export async function rolloverAllPlayers({ prestigeRenown = 3 } = {}) {
+export async function rolloverAllPlayers({ prestigeRenown = 3, seasonId = null } = {}) {
+  const veterans = await seasonParticipants(seasonId);
   const snap = await database().ref('players').get();
   const players = snap.val() || {};
-  let count = 0;
+  let reset = 0;
+  let prestiged = 0;
   for (const [uid, p] of Object.entries(players)) {
     if (!p?.role) continue;
-    await database().ref(PATHS.player(uid)).update({
+    const update = {
       equipped: rollStarterEquipped(p.role),
       inventory: [],
-      renown: (p.renown || 0) + prestigeRenown,
-      'stats/seasonsPlayed': (p.stats?.seasonsPlayed || 0) + 1,
-    });
-    count += 1;
+    };
+    if (veterans.has(uid)) {
+      update.renown = (p.renown || 0) + prestigeRenown;
+      update['stats/seasonsPlayed'] = (p.stats?.seasonsPlayed || 0) + 1;
+      prestiged += 1;
+    }
+    await database().ref(PATHS.player(uid)).update(update);
+    reset += 1;
   }
-  return count;
+  return { reset, prestiged };
 }
 
 /**

--- a/src/db/players.js
+++ b/src/db/players.js
@@ -200,17 +200,39 @@ export async function addLoot(userId, itemId) {
 }
 
 /**
- * Who actually took part in a season: the uids with a `leaderboard/<seasonId>`
- * entry. `finishBattle` writes one for EVERY signed-up hero of every resolved
- * raid (damage 0 included), so this is participation, not a damage ranking — a
- * healer who never hit the boss is in it, and it matches `stats.raidsParticipated`.
+ * How many of a season's raids each hero actually turned up for: uid → week count.
+ *
+ * A week counts when the battle RESOLVED (`result` exists — a scheduled week that
+ * never ran is not a raid anyone attended) and the hero was on its roster. Read
+ * straight from `raids/<seasonId>` rather than from a stored counter so it is
+ * retroactively correct for seasons that predate this code, and so it needs no
+ * new write on the raid-night hot path. One read per rollover; the node is
+ * bounded by weeks × roster.
  * @param {string|null|undefined} seasonId
- * @returns {Promise<Set<string>>} empty when there is no season to be a veteran of
+ * @returns {Promise<Map<string, number>>} empty when there is no season to be a veteran of
  */
-async function seasonParticipants(seasonId) {
-  if (!seasonId) return new Set();
-  const snap = await database().ref(`leaderboard/${seasonId}`).get();
-  return new Set(Object.keys(snap.val() || {}));
+async function seasonAttendance(seasonId) {
+  if (!seasonId) return new Map();
+  const snap = await database().ref(`raids/${seasonId}`).get();
+  const counts = new Map();
+  for (const week of Object.values(snap.val() || {})) {
+    if (!week?.result) continue; // scheduled but never fought
+    for (const uid of Object.keys(week.signups || {})) counts.set(uid, (counts.get(uid) || 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Prestige earned for a season: renown scaled by how many of its raids you
+ * attended, bounded so a long season can't mint a runaway veteran. Pure.
+ * @param {number} raidsAttended
+ * @param {{ raid: { prestigePerRaid: number, prestigeMax: number } }} cfg
+ * @returns {number} 0 when the hero never raided that season
+ */
+export function prestigeFor(raidsAttended, cfg = config) {
+  const n = Math.max(0, Math.floor(raidsAttended || 0));
+  if (n === 0) return 0;
+  return Math.min(n * cfg.raid.prestigePerRaid, cfg.raid.prestigeMax);
 }
 
 /**
@@ -218,40 +240,47 @@ async function seasonParticipants(seasonId) {
  * the bag) so a new tier starts fresh and newcomers aren't behind — but KEEP
  * level + renown.
  *
- * PRESTIGE IS EARNED, NOT GRANTED TO EVERYONE. Only heroes who actually raided
- * in the outgoing season (`seasonId`) get the prestige renown and the
+ * PRESTIGE IS EARNED, AND IT SCALES WITH ATTENDANCE. Only heroes who actually
+ * raided the outgoing season (`seasonId`) get prestige renown and the
  * `seasonsPlayed` bump — spec §5.6 awards it to *veterans*, and handing it to
- * every account that ever ran `!create` would devalue it and inflate the
- * permanent renown rating bonus for people who never showed up. Gear still
- * resets for everyone, veteran or not.
+ * every account that ever ran `!create` would devalue it and inflate a permanent
+ * rating bonus for people who never showed up. Someone who raided every week
+ * earns proportionally more than someone who turned up twice. Gear still resets
+ * for everyone, veteran or not.
  *
  * Called with no `seasonId` there is nothing to have been a veteran OF, so no
  * prestige is awarded (the gear reset still happens).
  *
- * @param {{ prestigeRenown?: number, seasonId?: string|null }} [opts]
- * @returns {Promise<{ reset: number, prestiged: number }>}
+ * @param {{ seasonId?: string|null, cfg?: object }} [opts]
+ * @returns {Promise<{ reset: number, prestiged: number, granted: number, best: number }>}
+ *   granted = total renown handed out; best = the largest single award.
  */
-export async function rolloverAllPlayers({ prestigeRenown = 3, seasonId = null } = {}) {
-  const veterans = await seasonParticipants(seasonId);
+export async function rolloverAllPlayers({ seasonId = null, cfg = config } = {}) {
+  const attendance = await seasonAttendance(seasonId);
   const snap = await database().ref('players').get();
   const players = snap.val() || {};
   let reset = 0;
   let prestiged = 0;
+  let granted = 0;
+  let best = 0;
   for (const [uid, p] of Object.entries(players)) {
     if (!p?.role) continue;
     const update = {
       equipped: rollStarterEquipped(p.role),
       inventory: [],
     };
-    if (veterans.has(uid)) {
-      update.renown = (p.renown || 0) + prestigeRenown;
+    const prestige = prestigeFor(attendance.get(uid), cfg);
+    if (prestige > 0) {
+      update.renown = (p.renown || 0) + prestige;
       update['stats/seasonsPlayed'] = (p.stats?.seasonsPlayed || 0) + 1;
       prestiged += 1;
+      granted += prestige;
+      best = Math.max(best, prestige);
     }
     await database().ref(PATHS.player(uid)).update(update);
     reset += 1;
   }
-  return { reset, prestiged };
+  return { reset, prestiged, granted, best };
 }
 
 /**

--- a/src/db/raid.js
+++ b/src/db/raid.js
@@ -295,7 +295,26 @@ function damageByUid(log) {
 export async function finishBattle(seasonId, weekId, { now = Date.now() } = {}) {
   const db = database();
   const p = getRaidPointer();
-  if (p?.phase === 'done') return null;
+  if (p?.phase === 'done') return null; // cheap short-circuit; NOT the real guard
+
+  // ATOMIC CLAIM (same shape as processDrops' draw claim). The pointer check
+  // above reads the in-memory config mirror, which two overlapping callers can
+  // both see as 'live' — two instances, or a payout that outruns the 30s phase
+  // tick. Without this, every award below runs twice: doubled loot rolls,
+  // doubled leaderboard damage, doubled renown. Flipping combat status
+  // live→done in a transaction lets exactly one caller through.
+  //
+  // Claiming BEFORE paying out means a crash mid-payout leaves it partially
+  // awarded rather than retried — deliberately preferred over a silent,
+  // compounding double-award, and recoverable by hand.
+  let claimed = false;
+  const claim = await db.ref(`${PATHS.combat(seasonId, weekId)}/status`).transaction((status) => {
+    if (status == null) return null; // no combat to finish (or empty cache → refetch)
+    if (status === 'done') return undefined; // already paid out → abort
+    claimed = true;
+    return 'done';
+  });
+  if (!claimed || !claim.committed) return null;
 
   const [combatSnap, signupSnap] = await Promise.all([
     db.ref(PATHS.combat(seasonId, weekId)).get(),
@@ -324,8 +343,11 @@ export async function finishBattle(seasonId, weekId, { now = Date.now() } = {}) 
     const lootTable = getSeason()?.lootTable?.length ? getSeason().lootTable : DEFAULT_LOOT_TABLE;
     const weights = config.loot.bossRarityWeights;
     const survivors = new Set(combat.result?.survivors || []);
+    // Role-aware: a raid reward lands directly in ONE named hero's bag with no
+    // lottery and no choice, and gear only pays out via bonuses[player.role] —
+    // so an off-role item is worth exactly 0 to them, forever.
     const roll = (uid) => {
-      const id = pickDrop(lootTable, getItem, Math.random, config, weights);
+      const id = pickDrop(lootTable, getItem, Math.random, config, weights, { role: signups[uid]?.role });
       return id ? addLoot(uid, id) : Promise.resolve();
     };
     for (const uid of Object.keys(signups)) {
@@ -335,7 +357,7 @@ export async function finishBattle(seasonId, weekId, { now = Date.now() } = {}) 
     if (combat.result?.mvp) await roll(combat.result.mvp); // MVP bonus
   }
 
-  await db.ref(`${PATHS.combat(seasonId, weekId)}/status`).set('done');
+  // combat/status was already set to 'done' by the claim above.
   await db.ref(`${PATHS.raid(seasonId, weekId)}/result/status`).set('done');
   await db.ref(`${PATHS.boss(seasonId, weekId)}/status`).set(downed ? 'downed' : 'wiped');
   await db.ref(`${PATHS.raid(seasonId, weekId)}/result/resolvedAt`).set(SERVER_TIMESTAMP);

--- a/src/events/twitchEvents.js
+++ b/src/events/twitchEvents.js
@@ -5,7 +5,7 @@
 // levers (per-sub EXP boosts, channel points via EventSub) are later phases.
 import { setSubStatus } from '../db/players.js';
 import { setDrop } from '../db/drops.js';
-import { pickDrop } from '../rules/loot.js';
+import { pickDrop, cheerRarityFloor } from '../rules/loot.js';
 import { getItem, DEFAULT_LOOT_TABLE } from '../content/items.js';
 import { getSeason, isChatMuted } from '../db/configStore.js';
 import { config } from '../config.js';
@@ -85,15 +85,21 @@ export function attachTwitchEvents({ chat, sender, logger }) {
   attach('onMessage', async (_ch, _user, _text, msg) => {
     try {
       const bits = msg?.bits || 0;
-      if (bits < 100) return;
-      const itemId = pickDrop(lootTable(), getItem, Math.random, config);
+      // The size of the cheer sets a rarity FLOOR (config.loot.cheer). Below the
+      // trigger nothing drops at all — 100 bits fired far too often.
+      const minRarity = cheerRarityFloor(bits, config);
+      if (!minRarity) return;
+      const itemId = pickDrop(lootTable(), getItem, Math.random, config, null, { minRarity });
       if (!itemId) return;
       const drop = await setDrop(itemId);
       if (drop.status === 'full') return;
+      // Only shout about the floor when the cheer actually bought one above the
+      // base tier, so a 500-bit cheer doesn't brag about guaranteeing a common.
+      const bought = minRarity === 'common' ? '' : ` (${bits} bits guarantees ${minRarity}+!)`;
       const line =
         drop.status === 'open'
-          ? `${bits} bits! A ${drop.rarity} ${drop.name} dropped — !grab to enter the draw!`
-          : `${bits} bits! A ${drop.rarity} ${drop.name} is queued — !grab when it opens!`;
+          ? `${bits} bits! A ${drop.rarity} ${drop.name} dropped${bought} — !grab to enter the draw!`
+          : `${bits} bits! A ${drop.rarity} ${drop.name} is queued${bought} — !grab when it opens!`;
       say(line);
     } catch (err) {
       logger.error('cheer handler failed', { err: String(err) });

--- a/src/rules/loot.js
+++ b/src/rules/loot.js
@@ -22,16 +22,35 @@ export function weightedPick(weights, rng) {
   return entries[entries.length - 1][0]; // FP safety net
 }
 
+/** Rarity ladder, ascending. Index order is the only thing that defines "better". */
+export const RARITY_ORDER = /** @type {Rarity[]} */ (['common', 'uncommon', 'rare', 'epic', 'legendary']);
+
 /**
  * Roll a rarity off a weight table. Defaults to the chat-drop ladder; pass
- * `weights` (e.g. config.loot.bossRarityWeights) for richer boss-battle loot.
+ * `weights` (e.g. config.loot.bossRarityWeights) for richer raid-reward loot.
+ *
+ * `minRarity` sets a FLOOR (a big cheer can't roll a common): the ladder is
+ * restricted to rarities at or above it and re-rolled on their RELATIVE weights,
+ * rather than collapsing everything below onto the floor. So a `rare` floor still
+ * reaches epic and legendary in their usual proportions — it just can't fall
+ * through. A floor no item can satisfy is ignored rather than failing the roll.
+ *
  * @param {() => number} rng
  * @param {{ loot: { rarityWeights: Record<Rarity, number> } }} config
  * @param {Record<Rarity, number>} [weights]
+ * @param {Rarity} [minRarity]
  * @returns {Rarity}
  */
-export function rollRarity(rng, config, weights) {
-  return /** @type {Rarity} */ (weightedPick(weights || config.loot.rarityWeights, rng));
+export function rollRarity(rng, config, weights, minRarity) {
+  const table = weights || config.loot.rarityWeights;
+  const floor = RARITY_ORDER.indexOf(/** @type {Rarity} */ (minRarity));
+  if (floor > 0) {
+    const eligible = Object.fromEntries(
+      Object.entries(table).filter(([r, w]) => w > 0 && RARITY_ORDER.indexOf(/** @type {Rarity} */ (r)) >= floor),
+    );
+    if (Object.keys(eligible).length > 0) return /** @type {Rarity} */ (weightedPick(eligible, rng));
+  }
+  return /** @type {Rarity} */ (weightedPick(table, rng));
 }
 
 /**
@@ -40,22 +59,55 @@ export function rollRarity(rng, config, weights) {
  * rolled rarity, falls back to a uniform pick over the whole table so a drop
  * never fails to materialize.
  *
+ * `opts.role` narrows the pool to items that BENEFIT that role first. Gear only
+ * contributes via `bonuses[player.role]`, so an item for another role is worth
+ * exactly 0 to the recipient, forever — dead weight, not a consolation prize.
+ * That matters for raid rewards, which land directly in one named hero's bag
+ * with no lottery and no choice. Chat drops pass no role on purpose: the winner
+ * is not known when the item is picked, it is announced before anyone grabs, and
+ * `!trade` / `!offer` can move it afterwards.
+ *
  * @param {string[]} lootTable  item ids eligible this season
- * @param {(itemId: string) => ({ rarity: Rarity }|null)} getItem
+ * @param {(itemId: string) => ({ rarity: Rarity, bonuses?: Record<string, number> }|null)} getItem
  * @param {() => number} rng
  * @param {object} config
- * @param {Record<string, number>} [weights]  rarity weight override (boss loot)
+ * @param {Record<string, number>|null} [weights]  rarity weight override (raid rewards)
+ * @param {{ role?: string, minRarity?: Rarity }} [opts]
  * @returns {string|null} chosen item id, or null if the table is empty
  */
-export function pickDrop(lootTable, getItem, rng, config, weights) {
-  const pool = (lootTable || []).filter((id) => getItem(id));
+export function pickDrop(lootTable, getItem, rng, config, weights, opts = {}) {
+  let pool = (lootTable || []).filter((id) => getItem(id));
   if (pool.length === 0) return null;
 
-  const rarity = rollRarity(rng, config, weights);
+  // Prefer items this role can actually use; keep the whole pool if a season
+  // has nothing for them, so a drop never fails to materialize.
+  if (opts.role) {
+    const usable = pool.filter((id) => typeof getItem(id)?.bonuses?.[opts.role] === 'number');
+    if (usable.length > 0) pool = usable;
+  }
+
+  const rarity = rollRarity(rng, config, weights, opts.minRarity);
   const ofRarity = pool.filter((id) => getItem(id).rarity === rarity);
   const choices = ofRarity.length > 0 ? ofRarity : pool;
   const idx = Math.floor(rng() * choices.length);
   return choices[Math.min(idx, choices.length - 1)];
+}
+
+/**
+ * Rarity floor a cheer buys, or undefined below the trigger. Bands are
+ * `[minBits, rarity]` ascending; the highest band whose threshold the cheer
+ * meets wins. Pure — the caller supplies config.
+ * @param {number} bits
+ * @param {{ loot: { cheer: { minBits: number, floors: [number, Rarity][] } } }} config
+ * @returns {Rarity|undefined}
+ */
+export function cheerRarityFloor(bits, config) {
+  const n = Number(bits) || 0;
+  const { minBits, floors } = config.loot.cheer;
+  if (n < minBits) return undefined;
+  let floor;
+  for (const [threshold, rarity] of floors) if (n >= threshold) floor = rarity;
+  return floor;
 }
 
 /**

--- a/test/raid-payout.test.js
+++ b/test/raid-payout.test.js
@@ -1,0 +1,117 @@
+// Raid payout must happen EXACTLY ONCE (spec §5.8). Run via `npm run test:emulator`.
+//
+// finishBattle's cheap short-circuit reads the in-memory config mirror, which two
+// overlapping callers can both observe as 'live' — two bot instances, or a payout
+// that outruns the 30s phase tick. Before the atomic claim, a probe showed two
+// concurrent calls awarding everything twice: 2 renown, 2 raidsParticipated,
+// 6 loot rolls instead of 3, and doubled leaderboard damage.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase, PATHS } from '../src/db/firebase.js';
+import { startConfigMirror, setRaidPointer, setSeason } from '../src/db/configStore.js';
+import { finishBattle } from '../src/db/raid.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+const S = 's_payout_test';
+const W = 'w1';
+const U = 'u_payout_test';
+
+/** A cleared battle with one surviving MVP: 1 participation + 1 survivor + 1 MVP roll. */
+async function seedResolvedBattle() {
+  const db = database();
+  await db.ref(PATHS.player(U)).set({
+    displayName: 'Payee', class: 'Ranger', role: 'dps', level: 5, renown: 0,
+    equipped: {}, inventory: [], stats: { raidsParticipated: 0 },
+  });
+  await db.ref(PATHS.signup(S, W, U)).set({
+    displayName: 'Payee', role: 'dps', level: 5, maxHp: 100, power: 10, healing: 0,
+  });
+  await db.ref(PATHS.combat(S, W)).set({
+    seed: 1, status: 'live', bossMaxHp: 100,
+    result: { downed: true, bossHpRemaining: 0, mvp: U, survivors: [U] },
+    log: { 0: { type: 'action', kind: 'damage', target: 'boss', actor: U, amount: 500 } },
+  });
+  await db.ref(`leaderboard/${S}`).remove();
+  await setRaidPointer({ seasonId: S, weekId: W, phase: 'live', doneAt: 1 });
+}
+
+async function payout() {
+  const db = database();
+  const p = (await db.ref(PATHS.player(U)).get()).val();
+  const lb = (await db.ref(PATHS.leaderboardEntry(S, U)).get()).val();
+  return {
+    renown: p.renown || 0,
+    raids: p.stats?.raidsParticipated || 0,
+    items: (p.inventory || []).length,
+    damage: lb?.damage || 0,
+  };
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(noopLogger);
+  await setSeason({ id: S, name: 'Payout', tier: 1, weeks: 6, lootTable: ['itm_s1_thornnettle_dirk'] });
+});
+
+beforeEach(async () => {
+  if (!host) return;
+  await seedResolvedBattle();
+});
+
+after(async () => {
+  if (!host) return;
+  const db = database();
+  await Promise.all([
+    db.ref(PATHS.player(U)).remove(),
+    db.ref(`raids/${S}`).remove(),
+    db.ref(`leaderboard/${S}`).remove(),
+    db.ref(PATHS.configRaid()).remove(),
+    db.ref(PATHS.seasonCurrent()).remove(),
+  ]).catch(() => {});
+  await closeFirebase();
+});
+
+runOrSkip('a single payout awards loot, renown, participation and damage once', async () => {
+  await finishBattle(S, W);
+  assert.deepEqual(await payout(), { renown: 1, raids: 1, items: 3, damage: 500 });
+});
+
+runOrSkip('calling finishBattle again is a no-op', async () => {
+  await finishBattle(S, W);
+  const once = await payout();
+  await finishBattle(S, W);
+  assert.deepEqual(await payout(), once, 'a second sequential call must not re-award');
+});
+
+runOrSkip('TWO CONCURRENT payouts award exactly once, not twice', async () => {
+  // The regression: overlapping phase ticks with a mirror that still says 'live'.
+  const [a, b] = await Promise.all([finishBattle(S, W), finishBattle(S, W)]);
+  assert.deepEqual(await payout(), { renown: 1, raids: 1, items: 3, damage: 500 });
+  assert.ok(a === null || b === null, 'exactly one caller should win the claim');
+});
+
+runOrSkip('five concurrent payouts still award exactly once', async () => {
+  const results = await Promise.all(Array.from({ length: 5 }, () => finishBattle(S, W)));
+  assert.deepEqual(await payout(), { renown: 1, raids: 1, items: 3, damage: 500 });
+  assert.equal(results.filter(Boolean).length, 1, 'exactly one winner among five racers');
+});
+
+runOrSkip('every raid reward is usable by the hero it lands on', async () => {
+  // The dps hero must never be handed tank/healer gear by the raid payout.
+  await database().ref(PATHS.seasonCurrent()).update({
+    lootTable: ['itm_s1_cinder_spade', 'itm_s1_mire_poultice', 'itm_s1_thornnettle_dirk'],
+  });
+  await new Promise((r) => setTimeout(r, 200)); // let the season mirror catch up
+  await finishBattle(S, W);
+  const p = (await database().ref(PATHS.player(U)).get()).val();
+  const bag = p.inventory || [];
+  assert.ok(bag.length > 0, 'the clear should have paid out');
+  for (const entry of bag) {
+    const id = typeof entry === 'string' ? entry : entry?.id;
+    assert.equal(id, 'itm_s1_thornnettle_dirk', `dps was handed ${id}, which does nothing for them`);
+  }
+});

--- a/test/rules/loot.test.js
+++ b/test/rules/loot.test.js
@@ -46,3 +46,88 @@ test('pickWinner draws exactly one entrant uniformly, null when empty', () => {
   assert.equal(pickWinner(entries, () => 0.99), 'c'); // 2.97 → idx 2
   assert.equal(pickWinner({}, () => 0.5), null); // no entrants → no winner
 });
+
+// ─── role-aware raid rewards ────────────────────────────────────────────────
+// Gear only pays out via bonuses[player.role], so an off-role item is worth
+// exactly 0 to the hero who receives it — forever. That is tolerable for a chat
+// drop (announced first, winner random, tradeable) but not for a raid reward,
+// which lands straight in one named hero's bag with no lottery and no choice.
+
+import { SEASON_LOOT, ITEMS } from '../../src/content/items.js';
+import { cheerRarityFloor, RARITY_ORDER } from '../../src/rules/loot.js';
+
+test('a raid reward rolled for a role is ALWAYS usable by that role', () => {
+  for (const role of ['tank', 'healer', 'dps']) {
+    for (const table of SEASON_LOOT) {
+      for (let i = 0; i < 400; i++) {
+        const id = pickDrop(table, getItem, Math.random, config, config.loot.bossRarityWeights, { role });
+        assert.ok(
+          typeof ITEMS[id].bonuses?.[role] === 'number',
+          `${role} was handed ${id}, which does nothing for them`,
+        );
+      }
+    }
+  }
+});
+
+test('a role with nothing in the table still gets an item rather than nothing', () => {
+  // Never silently drop the reward on the floor if a season has no role gear.
+  const table = ['itm_starter_tank_weapon_01'];
+  const id = pickDrop(table, getItem, Math.random, config, null, { role: 'healer' });
+  assert.equal(id, 'itm_starter_tank_weapon_01');
+});
+
+test('chat drops pass no role and stay open to the whole table', () => {
+  const seen = new Set();
+  for (let i = 0; i < 600; i++) seen.add(pickDrop(SEASON_LOOT[0], getItem, Math.random, config));
+  const roles = new Set([...seen].flatMap((id) => Object.keys(ITEMS[id].bonuses || {})));
+  assert.ok(roles.size > 1, 'the lottery pool must not be silently narrowed to one role');
+});
+
+// ─── cheer → rarity floor ───────────────────────────────────────────────────
+
+test('a cheer below the trigger drops nothing at all', () => {
+  assert.equal(cheerRarityFloor(0, config), undefined);
+  assert.equal(cheerRarityFloor(100, config), undefined, '100 bits used to fire — too often');
+  assert.equal(cheerRarityFloor(config.loot.cheer.minBits - 1, config), undefined);
+});
+
+test('bigger cheers buy a higher rarity floor, monotonically', () => {
+  let prev = -1;
+  for (const [bits, rarity] of config.loot.cheer.floors) {
+    const got = cheerRarityFloor(bits, config);
+    assert.equal(got, rarity, `${bits} bits should floor at ${rarity}`);
+    const idx = RARITY_ORDER.indexOf(got);
+    assert.ok(idx > prev, 'floors must ascend with the cheer size');
+    prev = idx;
+  }
+  const [topBits, topRarity] = config.loot.cheer.floors.at(-1);
+  assert.equal(cheerRarityFloor(topBits * 10, config), topRarity, 'above the top band it stays capped');
+});
+
+test('a floor never rolls below itself, and still reaches the tiers above', () => {
+  const seen = new Set();
+  for (let i = 0; i < 3000; i++) seen.add(rollRarity(Math.random, config, null, 'epic'));
+  assert.deepEqual([...seen].sort(), ['epic', 'legendary'], 'epic floor: epic or better, and legendary is reachable');
+  for (let i = 0; i < 200; i++) {
+    assert.equal(rollRarity(Math.random, config, null, 'legendary'), 'legendary', 'the top floor is a guarantee');
+  }
+});
+
+test('a floor no weight can satisfy falls back rather than failing the roll', () => {
+  // bossRarityWeights has no zero entries, but a tuned table might.
+  const noTop = { common: 10, uncommon: 5, rare: 0, epic: 0, legendary: 0 };
+  const r = rollRarity(Math.random, config, noTop, 'epic');
+  assert.ok(RARITY_ORDER.includes(r), 'must still return a rarity');
+});
+
+test('a 5000-bit cheer cannot produce a common', () => {
+  const floor = cheerRarityFloor(5000, config);
+  for (let i = 0; i < 500; i++) {
+    const id = pickDrop(SEASON_LOOT[0], getItem, Math.random, config, null, { minRarity: floor });
+    assert.ok(
+      RARITY_ORDER.indexOf(ITEMS[id].rarity) >= RARITY_ORDER.indexOf(floor),
+      `5000 bits rolled a ${ITEMS[id].rarity}`,
+    );
+  }
+});

--- a/test/rules/season-progression.test.js
+++ b/test/rules/season-progression.test.js
@@ -12,6 +12,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { SEASONS, SEASON_COUNT, weeksInSeason, bossFor, seasonBoss } from '../../src/content/bosses.js';
 import { SEASON_LOOT } from '../../src/content/items.js';
+import { prestigeFor } from '../../src/db/players.js';
+import { renownBonus } from '../../src/rules/rating.js';
 import { config } from '../../src/config.js';
 
 test('every season has the number of weeks the config promises', () => {
@@ -64,4 +66,33 @@ test('seasonBoss resolves abilities and a recommended roster for every week', ()
       assert.ok(b.recommended > 0, `${b.id} has no recommended count`);
     }
   }
+});
+
+// ── prestige (spec §5.6) ────────────────────────────────────────────────────
+// There is no separate "prestige" stat: prestige is renown, awarded at rollover
+// for the weeks you actually raided. These pin the scale, since renown converts
+// into a PERMANENT role-rating bonus that gear resets never take away.
+
+test('prestige is zero for a hero who never raided the season', () => {
+  assert.equal(prestigeFor(0), 0);
+  assert.equal(prestigeFor(undefined), 0);
+  assert.equal(prestigeFor(-3), 0, 'nonsense input cannot mint renown');
+});
+
+test('prestige scales one-for-one with raids attended, up to the cap', () => {
+  const per = config.raid.prestigePerRaid;
+  assert.equal(prestigeFor(1), per);
+  assert.equal(prestigeFor(6), 6 * per);
+  assert.ok(prestigeFor(6) > prestigeFor(2), 'showing up every week beats a cameo');
+  assert.equal(prestigeFor(config.raid.prestigeMax + 50), config.raid.prestigeMax);
+});
+
+test('a full-attendance season stays a perk, never a substitute for gear', () => {
+  // A perfect season ≈ prestige for every week + 1 renown per clear.
+  const seasonRenown = prestigeFor(config.raid.seasonWeeks) + config.raid.seasonWeeks;
+  const rating = renownBonus({ renown: seasonRenown }, config);
+  // Season-1 epics sit at +58..64 role rating for a single slot.
+  assert.ok(rating < 60, `one perfect season is worth +${rating} rating — should stay under one epic item`);
+  // …and a career vet is capped, by design.
+  assert.equal(renownBonus({ renown: 9999 }, config), config.rating.renownCap * config.rating.renownPerPoint);
 });

--- a/test/rules/season-progression.test.js
+++ b/test/rules/season-progression.test.js
@@ -1,0 +1,67 @@
+// Season progression: a season is a FIXED-LENGTH arc that ends on its finale.
+//
+// The bug these lock down cost eight weeks of prod: `bossFor` clamps an
+// out-of-range week to the last boss, so `!boss next` — which derives the week
+// from a COUNT of already-scheduled bosses — happily scheduled week 7, 8 and 9
+// and got the week-6 finale back every time. The season never ended, gear never
+// reset, and chat fought the Scarecrow King three times in a row.
+//
+// The clamp itself is correct for a lookup (never return undefined); the fix is
+// that schedulers must ask `weeksInSeason` first. These tests pin both halves.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SEASONS, SEASON_COUNT, weeksInSeason, bossFor, seasonBoss } from '../../src/content/bosses.js';
+import { SEASON_LOOT } from '../../src/content/items.js';
+import { config } from '../../src/config.js';
+
+test('every season has the number of weeks the config promises', () => {
+  assert.equal(SEASON_COUNT, SEASONS.length);
+  for (let s = 1; s <= SEASON_COUNT; s++) {
+    assert.equal(weeksInSeason(s), config.raid.seasonWeeks,
+      `season ${s} must have config.raid.seasonWeeks bosses — the season record written to RTDB says so`);
+  }
+});
+
+test('bossFor CLAMPS past the finale — the trap schedulers must guard against', () => {
+  const finale = bossFor(1, weeksInSeason(1));
+  assert.equal(finale.id, 's1w6');
+  // This is the exact prod failure: weeks 7 and 8 resolved to the week-6 finale.
+  assert.equal(bossFor(1, 7).id, finale.id, 'week 7 clamps to the finale');
+  assert.equal(bossFor(1, 8).id, finale.id, 'week 8 clamps to the finale');
+  assert.equal(bossFor(1, 99).id, finale.id);
+  // …so a scheduler MUST compare against weeksInSeason instead of trusting the lookup.
+  assert.equal(7 > weeksInSeason(1), true, 'the guard that !boss next now applies');
+});
+
+test('weeksInSeason clamps its own input rather than throwing', () => {
+  assert.equal(weeksInSeason(0), config.raid.seasonWeeks);
+  assert.equal(weeksInSeason(99), config.raid.seasonWeeks);
+  assert.equal(weeksInSeason(undefined), config.raid.seasonWeeks);
+});
+
+test('each season is six DISTINCT bosses — no accidental repeats in the content', () => {
+  for (let s = 1; s <= SEASON_COUNT; s++) {
+    const names = [];
+    for (let w = 1; w <= weeksInSeason(s); w++) names.push(bossFor(s, w).name);
+    assert.equal(new Set(names).size, names.length, `season ${s} repeats a boss name`);
+  }
+});
+
+test('the next tier has content and its own loot table to roll over into', () => {
+  // !boss next points at `!season rollover t<tier+1>`; that has to lead somewhere.
+  assert.equal(seasonBoss(2, 1).id, 's2w1');
+  assert.equal(SEASON_LOOT.length, SEASON_COUNT, 'one loot table per season');
+  for (let s = 1; s <= SEASON_COUNT; s++) {
+    assert.ok(SEASON_LOOT[s - 1].length > 0, `season ${s} has no loot table`);
+  }
+});
+
+test('seasonBoss resolves abilities and a recommended roster for every week', () => {
+  for (let s = 1; s <= SEASON_COUNT; s++) {
+    for (let w = 1; w <= weeksInSeason(s); w++) {
+      const b = seasonBoss(s, w);
+      assert.ok(Array.isArray(b.abilities) && b.abilities.length > 0, `${b.id} has no abilities`);
+      assert.ok(b.recommended > 0, `${b.id} has no recommended count`);
+    }
+  }
+});

--- a/test/season-rollover.test.js
+++ b/test/season-rollover.test.js
@@ -42,6 +42,16 @@ async function waitForSeason(pred, ms = 3000) {
 }
 
 /** Pretend `n` bosses have already been scheduled this season, so nextWeekId → w(n+1). */
+/** Record that `uid` was on the roster of `n` RESOLVED raids this season. */
+async function seedAttendance(uid, n) {
+  const updates = {};
+  for (let i = 1; i <= n; i++) {
+    updates[`raids/${SEASON}/w${i}/result`] = { downed: true, bossHpRemaining: 0, status: 'done' };
+    updates[`raids/${SEASON}/w${i}/signups/${uid}`] = { displayName: uid, role: 'dps', level: 12 };
+  }
+  await database().ref().update(updates);
+}
+
 async function seedScheduledWeeks(n) {
   const weeks = {};
   for (let i = 1; i <= n; i++) weeks[`w${i}`] = { name: `Boss ${i}`, baseHp: 1000, atk: 50, status: 'downed' };
@@ -118,17 +128,19 @@ runOrSkip('rollover grants prestige ONLY to heroes who raided the outgoing seaso
   const db = database();
   await db.ref(PATHS.player(VET)).set(makePlayer(4));
   await db.ref(PATHS.player(AFK)).set(makePlayer(0));
-  // finishBattle writes a leaderboard entry for every signup of a resolved raid.
-  // The AFK hero has a character but never raided, so has none.
-  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 12345 });
+  // The veteran was on the roster of 3 resolved raids; the AFK hero has a
+  // character but never raided, so attends none.
+  await seedAttendance(VET, 3);
 
-  const { reset, prestiged } = await rolloverAllPlayers({ seasonId: SEASON, prestigeRenown: 3 });
+  const { reset, prestiged, best } = await rolloverAllPlayers({ seasonId: SEASON });
 
   assert.equal(prestiged, 1, 'exactly one veteran');
   assert.ok(reset >= 2, 'gear resets for everyone, veteran or not');
 
   const vet = (await db.ref(PATHS.player(VET)).get()).val();
-  assert.equal(vet.renown, 7, 'veteran keeps its 4 renown and gains 3 prestige');
+  const expected = 3 * config.raid.prestigePerRaid;
+  assert.equal(best, expected);
+  assert.equal(vet.renown, 4 + expected, 'veteran keeps its 4 renown and gains prestige per raid attended');
   assert.equal(vet.stats.seasonsPlayed, 1);
 
   const afk = (await db.ref(PATHS.player(AFK)).get()).val();
@@ -140,7 +152,7 @@ runOrSkip('rollover resets gear for everyone, including non-participants', async
   const db = database();
   await db.ref(PATHS.player(VET)).set(makePlayer(4));
   await db.ref(PATHS.player(AFK)).set(makePlayer(0));
-  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 1 });
+  await seedAttendance(VET, 1);
 
   await rolloverAllPlayers({ seasonId: SEASON });
 
@@ -155,7 +167,7 @@ runOrSkip('rollover resets gear for everyone, including non-participants', async
 runOrSkip('with no outgoing season nobody is a veteran, but gear still resets', async () => {
   const db = database();
   await db.ref(PATHS.player(VET)).set(makePlayer(4));
-  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 1 });
+  await seedAttendance(VET, 4);
 
   const { prestiged } = await rolloverAllPlayers({ seasonId: null });
 
@@ -163,4 +175,49 @@ runOrSkip('with no outgoing season nobody is a veteran, but gear still resets', 
   const vet = (await db.ref(PATHS.player(VET)).get()).val();
   assert.equal(vet.renown, 4, 'renown untouched');
   assert.ok(vet.equipped.weapon.id.startsWith('itm_starter_'));
+});
+
+runOrSkip('prestige SCALES with attendance — more raids, more renown', async () => {
+  const db = database();
+  const KEEN = 'u_keen_test';
+  const RARE = 'u_rare_test';
+  await db.ref(PATHS.player(KEEN)).set(makePlayer(0));
+  await db.ref(PATHS.player(RARE)).set(makePlayer(0));
+  await seedAttendance(KEEN, 6); // every week
+  await seedAttendance(RARE, 2); // turned up twice
+
+  const { granted, best } = await rolloverAllPlayers({ seasonId: SEASON });
+
+  const keen = (await db.ref(PATHS.player(KEEN)).get()).val();
+  const rare = (await db.ref(PATHS.player(RARE)).get()).val();
+  assert.equal(keen.renown, 6 * config.raid.prestigePerRaid);
+  assert.equal(rare.renown, 2 * config.raid.prestigePerRaid);
+  assert.ok(keen.renown > rare.renown, 'attendance must be worth more than a cameo');
+  assert.equal(best, keen.renown);
+  assert.equal(granted, keen.renown + rare.renown);
+
+  await db.ref(PATHS.player(KEEN)).remove();
+  await db.ref(PATHS.player(RARE)).remove();
+});
+
+runOrSkip('a week that was scheduled but never fought earns no prestige', async () => {
+  const db = database();
+  await db.ref(PATHS.player(VET)).set(makePlayer(0));
+  await seedAttendance(VET, 2);
+  // A third week exists with a roster but no result — the battle never ran.
+  await db.ref(`raids/${SEASON}/w3/signups/${VET}`).set({ displayName: 'Tester', role: 'dps', level: 12 });
+
+  const { best } = await rolloverAllPlayers({ seasonId: SEASON });
+
+  assert.equal(best, 2 * config.raid.prestigePerRaid, 'only the two RESOLVED raids count');
+});
+
+runOrSkip('prestige is bounded so an overlong season cannot mint a runaway veteran', async () => {
+  const db = database();
+  await db.ref(PATHS.player(VET)).set(makePlayer(0));
+  await seedAttendance(VET, config.raid.prestigeMax + 5);
+
+  const { best } = await rolloverAllPlayers({ seasonId: SEASON });
+
+  assert.equal(best, config.raid.prestigeMax, 'capped at config.raid.prestigeMax');
 });

--- a/test/season-rollover.test.js
+++ b/test/season-rollover.test.js
@@ -1,0 +1,166 @@
+// Season rollover + end-of-season guard (spec §5.6). Run via `npm run test:emulator`
+// (skipped without the emulator host, same as roster-refresh.test.js).
+//
+// Two guarantees, both learned from an eight-week prod incident where the season
+// never ended:
+//   1. `!boss next` STOPS at the finale instead of re-scheduling it forever.
+//   2. Prestige on rollover is EARNED — only heroes who actually raided the
+//      outgoing season get the renown + seasonsPlayed bump. Gear resets for all.
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initFirebase, database, closeFirebase, PATHS } from '../src/db/firebase.js';
+import { startConfigMirror, setSeason, getSeason } from '../src/db/configStore.js';
+import { rolloverAllPlayers } from '../src/db/players.js';
+import bossCmd from '../src/commands/mod/boss.js';
+import { itemObject } from '../src/content/items.js';
+import { config } from '../src/config.js';
+
+const host = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+const runOrSkip = host ? test : test.skip;
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} };
+
+const SEASON = 's_rollover_test';
+const VET = 'u_vet_test';
+const AFK = 'u_afk_test';
+const WEEKS = config.raid.seasonWeeks;
+
+const makePlayer = (renown) => ({
+  displayName: 'Tester', class: 'Ranger', role: 'dps', level: 12,
+  equipped: { weapon: itemObject('itm_s1_final_knell_reaper'), armor: itemObject('itm_s1_blightstalker_hide') },
+  inventory: ['itm_s1_ember_token', 'itm_s1_cinder_spade'],
+  renown, exp: 0, stats: { seasonsPlayed: 0, raidsParticipated: 0 },
+});
+
+/** The season mirror is fed by an async RTDB listener — poll until it converges. */
+async function waitForSeason(pred, ms = 3000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (pred(getSeason())) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error('config/season mirror did not converge in time');
+}
+
+/** Pretend `n` bosses have already been scheduled this season, so nextWeekId → w(n+1). */
+async function seedScheduledWeeks(n) {
+  const weeks = {};
+  for (let i = 1; i <= n; i++) weeks[`w${i}`] = { name: `Boss ${i}`, baseHp: 1000, atk: 50, status: 'downed' };
+  await database().ref(PATHS.bossesForSeason(SEASON)).set(weeks);
+}
+
+/** Run `!boss <args>` and return what it said in chat. */
+async function runBoss(...args) {
+  let said = '';
+  await bossCmd.run({ args, reply: (t) => { said = t; }, logger: noopLogger });
+  return said;
+}
+
+async function cleanGame() {
+  await Promise.all([
+    database().ref(PATHS.bossesForSeason(SEASON)).remove(),
+    database().ref(`raids/${SEASON}`).remove(),
+    database().ref(`leaderboard/${SEASON}`).remove(),
+    database().ref(PATHS.player(VET)).remove(),
+    database().ref(PATHS.player(AFK)).remove(),
+    database().ref(PATHS.configRaid()).remove(),
+  ]);
+}
+
+before(async () => {
+  if (!host) return;
+  initFirebase();
+  await startConfigMirror(noopLogger);
+});
+
+beforeEach(async () => {
+  if (!host) return;
+  await cleanGame();
+});
+
+after(async () => {
+  if (!host) return;
+  await cleanGame().catch(() => {});
+  await database().ref(PATHS.seasonCurrent()).remove().catch(() => {});
+  await closeFirebase();
+});
+
+// ── 1. the end-of-season guard ──────────────────────────────────────────────
+
+runOrSkip('!boss next refuses past the finale instead of repeating it', async () => {
+  await setSeason({ id: SEASON, name: 'Rollover Test', tier: 1, weeks: WEEKS, startsAt: Date.now() });
+  await waitForSeason((s) => s?.id === SEASON);
+  await seedScheduledWeeks(WEEKS); // the whole season is already scheduled
+
+  const said = await runBoss('next');
+
+  assert.match(said, /complete/i, `expected a season-complete refusal, got: ${said}`);
+  assert.match(said, /rollover/i, 'the refusal must point at the way forward');
+  const after = await database().ref(PATHS.boss(SEASON, `w${WEEKS + 1}`)).get();
+  assert.equal(after.exists(), false, 'a week past the finale must NOT be scheduled');
+});
+
+runOrSkip('!boss next still schedules the finale itself, and labels it', async () => {
+  await setSeason({ id: SEASON, name: 'Rollover Test', tier: 1, weeks: WEEKS, startsAt: Date.now() });
+  await waitForSeason((s) => s?.id === SEASON);
+  await seedScheduledWeeks(WEEKS - 1); // one week left: the finale
+
+  const said = await runBoss('next');
+
+  assert.match(said, /FINALE/, `the last week should announce itself, got: ${said}`);
+  const finale = await database().ref(PATHS.boss(SEASON, `w${WEEKS}`)).get();
+  assert.equal(finale.exists(), true, 'the finale must still be schedulable');
+  assert.equal(finale.val().status, 'signup');
+});
+
+// ── 2. prestige is earned, not handed out ───────────────────────────────────
+
+runOrSkip('rollover grants prestige ONLY to heroes who raided the outgoing season', async () => {
+  const db = database();
+  await db.ref(PATHS.player(VET)).set(makePlayer(4));
+  await db.ref(PATHS.player(AFK)).set(makePlayer(0));
+  // finishBattle writes a leaderboard entry for every signup of a resolved raid.
+  // The AFK hero has a character but never raided, so has none.
+  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 12345 });
+
+  const { reset, prestiged } = await rolloverAllPlayers({ seasonId: SEASON, prestigeRenown: 3 });
+
+  assert.equal(prestiged, 1, 'exactly one veteran');
+  assert.ok(reset >= 2, 'gear resets for everyone, veteran or not');
+
+  const vet = (await db.ref(PATHS.player(VET)).get()).val();
+  assert.equal(vet.renown, 7, 'veteran keeps its 4 renown and gains 3 prestige');
+  assert.equal(vet.stats.seasonsPlayed, 1);
+
+  const afk = (await db.ref(PATHS.player(AFK)).get()).val();
+  assert.equal(afk.renown, 0, 'a hero who never raided earns no prestige');
+  assert.equal(afk.stats.seasonsPlayed, 0, 'nor a season played');
+});
+
+runOrSkip('rollover resets gear for everyone, including non-participants', async () => {
+  const db = database();
+  await db.ref(PATHS.player(VET)).set(makePlayer(4));
+  await db.ref(PATHS.player(AFK)).set(makePlayer(0));
+  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 1 });
+
+  await rolloverAllPlayers({ seasonId: SEASON });
+
+  for (const uid of [VET, AFK]) {
+    const p = (await db.ref(PATHS.player(uid)).get()).val();
+    assert.ok(p.equipped.weapon.id.startsWith('itm_starter_'), `${uid} should be back on starter gear`);
+    assert.equal(p.inventory ?? null, null, `${uid}'s bag should be empty`);
+    assert.equal(p.level, 12, 'level survives the reset');
+  }
+});
+
+runOrSkip('with no outgoing season nobody is a veteran, but gear still resets', async () => {
+  const db = database();
+  await db.ref(PATHS.player(VET)).set(makePlayer(4));
+  await db.ref(PATHS.leaderboardEntry(SEASON, VET)).set({ damage: 1 });
+
+  const { prestiged } = await rolloverAllPlayers({ seasonId: null });
+
+  assert.equal(prestiged, 0, 'there is no season to have been a veteran of');
+  const vet = (await db.ref(PATHS.player(VET)).get()).val();
+  assert.equal(vet.renown, 4, 'renown untouched');
+  assert.ok(vet.equipped.weapon.id.startsWith('itm_starter_'));
+});


### PR DESCRIPTION
Three rounds of raid-game bugs found while diagnosing why prod season `t1` ran for eight weeks and re-fought the same boss. All findings were verified against the emulator (and, for the season state, a read-only read of prod) rather than reasoned about.

## What was wrong

**The season never ended.** `bossFor` clamps an out-of-range week to the season's last boss — correct for a lookup, but `!boss next` derives the week from a *count* of already-scheduled bosses and never checked the bound. Weeks 7 and 8 both resolved to the week-6 finale and scheduled it again. Nothing else ends a season: `season.weeks` is written to RTDB and read by no code.

**Prestige went to everyone.** `rolloverAllPlayers` granted renown and a `seasonsPlayed` bump to every account with a character — in prod that is 14 heroes, 9 of whom have never raided — and renown is a *permanent* role-rating bonus.

**Raid rewards paid twice under concurrency.** `finishBattle`'s only re-entry guard read the in-memory config mirror, which two overlapping callers can both see as `live`. A probe confirmed doubled loot, renown, participation and leaderboard damage.

**Raid rewards were mostly unusable.** `pickDrop` filtered by rarity and never by role, and no season item benefits more than one role. A raid reward had a 28% / 31% / 41% chance (tank / healer / dps) of doing anything at all for the hero it landed in.

**Bit cheers ignored the amount.** Drops fired at ≥100 bits and rolled the same flat ladder whatever the cheer — 5000 bits and 100 bits were identical rolls.

## What this changes

- `!boss next` stops at the finale and points at `!season rollover`; the last week announces itself as the FINALE.
- Prestige is earned **and scales with attendance** — `raid.prestigePerRaid` renown per raid of the outgoing season the hero was actually on the roster for, bounded by `raid.prestigeMax`. Counted from raid nodes carrying a `result`, so it is retroactively correct for seasons predating this code and adds no write to the raid-night path. Gear still resets for everyone.
- Payout is claimed atomically (`combat/status` live→done in a transaction), the same shape `processDrops` already uses.
- Raid rewards pass the recipient's role: measured **100% usable** across all roles and seasons. Chat drops stay role-blind by design — the winner is unknown at pick time, the item is announced before anyone grabs, and `!trade`/`!offer` can move it.
- Bits trigger at 500 and buy a rarity **floor**; the ladder re-rolls on the remaining relative weights, so 5000 bits reaches legendary 20% of the time but can never produce a common.
- `!give` aliases `!offer`.
- Spec §5.2 / §5.6 updated: the two loot paths are now written down as distinct, and renown is documented as the only veteran stat ("prestige" is a source of it, not a second number).

## Verification

`npm test` 191 · `npm run test:emulator` 89 · `npm run test:e2e` 31 — all green.

New tests pin every finding, including the ones a probe found: five concurrent `finishBattle` calls award exactly once, and a raid reward is always in-role.

The rollover was rehearsed in the emulator against a replica of prod's real `t1` state (14 heroes, 8 scheduled weeks, the 5 real participants) before any of this was proposed. Nothing has been written to prod.

## Not included

Three smaller bugs found and deliberately left out to keep this reviewable: `!season start <existing id>` silently clobbers week 1's boss and result; `nextWeekId` counts children rather than taking a max, so a deleted week causes an id collision; and `finishBattle` reads the *current* season's loot table rather than the one the raid belonged to (fixing that properly means stamping the table onto the raid node, which changes the site's data contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)