### PR TITLE
feat(items): fill every season out to a full rarity pyramid (72 → 699 items)

### DIFF
--- a/docs/design/items.md
+++ b/docs/design/items.md
@@ -11,10 +11,52 @@ current engine only understands flat per-role `bonuses`).
 | Pool | Count | Notes |
 |---|---|---|
 | Starter gear (common) | **24** | 4 weapons + 4 armors per role (tank/healer/dps), season-agnostic |
-| Season 1 — *The Ashen Sprout* | 16 | ember/mire/thorn flavor, ramp ×1.0 |
-| Season 2 — *The Drowned Bloom* | 16 | tide/brine/storm/glass, ramp ×1.25 |
-| Season 3 — *The Hallowed Harvest* | 16 | astral/gilded/void/okra-finale, ramp ×1.5 |
-| **Total** | **72** | |
+| Season 1 — *The Proving Bed* | 225 | 16 hand-tuned + 209 pyramid; first frost & foul weeds, ramp ×1.0 |
+| Season 2 — *The Sweltering Patch* | 225 | 16 hand-tuned + 209 pyramid; high-summer blight, ramp ×1.25 |
+| Season 3 — *The Last Harvest* | 225 | 16 hand-tuned + 209 pyramid; rot & untimely frost, ramp ×1.5 |
+| **Total** | **699** | |
+
+### 1a. The pyramid (why 225 a season)
+
+The original 16-per-season tables left most role×slot pairs empty: **every season
+had exactly one tank weapon and one dps armor**, so a tank's entire six-week
+weapon progression was "starter gear, then the one drop", and most role×slot
+pairs had no legendary at all. Each season now fills a full rarity pyramid:
+
+| | common | uncommon | rare | epic | legendary |
+|---|---|---|---|---|---|
+| per role × slot | 9 | 7 | 5 | 3 | **1** |
+
+= 25 per role×slot × 3 roles × 3 slots = **225 a season**. The shape mirrors the
+drop weights: the tiers you roll often carry the variety, the top tier is a
+single trophy per role per slot.
+
+The pyramid is authored as a **name table** (`SEASON_GEAR` in `items.js`), not as
+600+ object literals — names are the content, while ids and bonuses follow by
+rule, so the balance ladder lives in one place. Within a tier, values fan out
+±4% per step so nine commons are nine slightly different items rather than nine
+reskins. Generated bands land on the hand-tuned ones exactly (S1 common 8–12,
+legendary 96–104).
+
+**Ids are derived from names** (`itm_s<season>_<slug>`) and are the stable
+contract — bags, equipped slots and the site's Compendium key off them.
+Renaming an item changes its id and orphans anything holding it. The original
+48 season ids are hand-authored, untouched, and win on any clash, because prod
+players are holding them right now.
+
+### 1b. Known drift: Season 2's legacy names
+
+`SEASON_THEMES` (bosses.js) and the S2 boss roster are **high summer** —
+Sunscorch, the Ten-Lined Horde, the Snaptrap Coven, the Hornworm Broodmother,
+the Cornstalk Colossus. The 16 legacy S2 items are **aquatic** (brine, tide,
+glacial, seafoam, coral, riptide, leviathan, "the Drowned Court"), authored
+against an older season plan called *The Drowned Bloom* that no longer exists
+anywhere else in the codebase. The 209 new S2 items follow the bosses.
+
+That leaves 16 aquatic items in a summer season — visible in the Compendium and
+in chat. Fixing it means **renaming those 16 (keeping their ids)**, which is
+safe but leaves id/name mismatches like `itm_s2_brineforged_maul` → a summer
+name. Deliberately left as an owner decision rather than done silently.
 
 Exports: `ITEMS` (id→item), `STARTER_WEAPONS`/`STARTER_ARMOR` (role→[ids]),
 `SEASON_LOOT` (3 arrays), plus parity helpers `getItem`, `itemObject`,

--- a/src/content/items.js
+++ b/src/content/items.js
@@ -25,7 +25,7 @@ export const SLOTS = /** @type {const} */ (['weapon', 'armor', 'trinket']);
  *   bonuses: Partial<Record<Role, number>>
  * }>}
  */
-export const ITEMS = {
+const HAND_ITEMS = {
   // ═══════════════════════════════════════════════════════════════════════════
   // STARTER GEAR (season-agnostic, common). New characters roll a RANDOM weapon
   // and a RANDOM armor from these pools (see getStarterEquipped). 4 weapons +
@@ -167,10 +167,14 @@ export const STARTER_ARMOR = {
 // rules/loot.js#pickDrop. Each table deliberately spans common -> legendary so
 // every rarity roll has a match (otherwise the 60-weight common rolls fall back
 // to a uniform pick over the whole table and over-drop rares+).
+//
+// These are the ORIGINAL hand-tuned 16 per season. The generated pyramid below
+// is appended to them — these ids are already in players' bags and equipped
+// slots, so they are never renumbered or removed.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** @type {string[][]} */
-export const SEASON_LOOT = [
+const HAND_SEASON_LOOT = [
   // Season 1 — The Ashen Sprout
   [
     'itm_s1_cinder_spade', 'itm_s1_mire_poultice', 'itm_s1_thornnettle_dirk',
@@ -196,6 +200,785 @@ export const SEASON_LOOT = [
     'itm_s3_lifebloom_of_the_first_dawn', 'itm_s3_heart_of_the_worldokra',
   ],
 ];
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SEASON GEAR PYRAMID
+//
+// The hand-authored tables above gave each season 16 items TOTAL, which left
+// most role×slot pairs with nothing: every season had exactly one tank weapon
+// and one dps armor, so a tank's whole six-week weapon progression was "starter
+// gear, then the one drop". This block fills each season out to a full pyramid.
+//
+// Per role × slot, per season:
+//     common 9 · uncommon 7 · rare 5 · epic 3 · legendary 1   (= 25)
+//   × 3 roles × 3 slots                                       (= 225 a season)
+//
+// The shape is deliberate: the tiers you roll OFTEN carry the most variety, and
+// the top tier is a single trophy. Combined with the rarity weights, a hero sees
+// many different commons across a season and at most one legendary.
+//
+// Authored as a NAME TABLE rather than 600+ object literals: the names are the
+// content, while ids and role-rating bonuses follow from them by rule, so the
+// balance ladder lives in ONE place instead of being restated 600 times.
+//
+// IDS ARE DERIVED FROM NAMES (`itm_s<season>_<slug>`) and are the stable
+// contract — bags, equipped slots and the site's Compendium all key off them.
+// RENAMING AN ITEM CHANGES ITS ID and orphans anything holding it. Add freely;
+// rename only with a migration. Tests pin the count and the id derivation.
+// ═════════════════════════════════════════════════════════════════════════════
+
+/** Items per rarity, per role × slot, per season. */
+export const PYRAMID = Object.freeze({ common: 9, uncommon: 7, rare: 5, epic: 3, legendary: 1 });
+
+/**
+ * Season-1 role rating a single item grants, by rarity. Read off the original
+ * hand-tuned 48 (common ~10 · uncommon ~19 · rare ~37 · epic ~61 · legendary
+ * ~100) so generated gear sits in the same band as the gear beside it.
+ */
+const RARITY_BASE = Object.freeze({ common: 10, uncommon: 19, rare: 37, epic: 61, legendary: 100 });
+
+/** Power multiplier per season (matches the hand-tuned S2 ≈ 1.25×, S3 ≈ 1.5×). */
+const SEASON_POWER = Object.freeze([1.0, 1.25, 1.5]);
+
+/**
+ * Spread WITHIN a rarity tier, so nine commons are not nine identical items:
+ * a tier fans out ~±4% per step around its base. Finding a better common is
+ * then a real (small) upgrade rather than a purely cosmetic one.
+ */
+const TIER_SPREAD = 0.04;
+
+/**
+ * The pyramid as `[name, role, slot, rarity]`, one array per season. Names carry
+ * that season's theme, taken from its BOSSES: S1 the first frost and foul weeds,
+ * S2 the high-summer blight, S3 the last harvest's rot and untimely frost.
+ * @type {[string, 'tank'|'healer'|'dps', 'weapon'|'armor'|'trinket', string][][]}
+ */
+const SEASON_GEAR = [
+  // ══ SEASON 1 — The Proving Bed (first frost & foul weeds) ══
+  [
+    // tank · weapon
+    ['Rust-Bitten Mattock', 'tank', 'weapon', 'common'],
+    ['Splintered Fence Maul', 'tank', 'weapon', 'common'],
+    ['Chipped Flagstone Cudgel', 'tank', 'weapon', 'common'],
+    ['Bent Coldframe Bar', 'tank', 'weapon', 'common'],
+    ['Warped Trellis Beam', 'tank', 'weapon', 'common'],
+    ['Cracked Millstone Hammer', 'tank', 'weapon', 'common'],
+    ['Blunted Turf Spade', 'tank', 'weapon', 'common'],
+    ['Frost-Split Fencepost', 'tank', 'weapon', 'common'],
+    ['Tempered Loam Mattock', 'tank', 'weapon', 'uncommon'],
+    ['Ironbark Cudgel', 'tank', 'weapon', 'uncommon'],
+    ['Emberbrand Maul', 'tank', 'weapon', 'uncommon'],
+    ['Thistleiron Spade', 'tank', 'weapon', 'uncommon'],
+    ['Coldforge Sledge', 'tank', 'weapon', 'uncommon'],
+    ['Barkbound Bludgeon', 'tank', 'weapon', 'uncommon'],
+    ['Grubcrusher Maul', 'tank', 'weapon', 'uncommon'],
+    ['Cinderweight Sledge', 'tank', 'weapon', 'rare'],
+    ['Thornsteel Mattock', 'tank', 'weapon', 'rare'],
+    ['Rimeplate Warhammer', 'tank', 'weapon', 'rare'],
+    ['Mirebreaker Maul', 'tank', 'weapon', 'rare'],
+    ['Blightbane Cudgel', 'tank', 'weapon', 'rare'],
+    ['Warden\'s Groundbreaker', 'tank', 'weapon', 'epic'],
+    ['Emberforged Bulwark-Maul', 'tank', 'weapon', 'epic'],
+    ['Hoarfrost Judgement', 'tank', 'weapon', 'epic'],
+    ['Anvil of the First Frost', 'tank', 'weapon', 'legendary'],
+    // tank · armor
+    ['Mud-Crusted Plate', 'tank', 'armor', 'common'],
+    ['Patched Burlap Coat', 'tank', 'armor', 'common'],
+    ['Splintbark Vest', 'tank', 'armor', 'common'],
+    ['Sackcloth Brigandine', 'tank', 'armor', 'common'],
+    ['Dented Washtub Cuirass', 'tank', 'armor', 'common'],
+    ['Frost-Stiffened Jerkin', 'tank', 'armor', 'common'],
+    ['Compost-Stained Hauberk', 'tank', 'armor', 'common'],
+    ['Nettle-Woven Guard', 'tank', 'armor', 'common'],
+    ['Rough Cordwood Shell', 'tank', 'armor', 'common'],
+    ['Ironbark Carapace', 'tank', 'armor', 'uncommon'],
+    ['Emberweave Coat', 'tank', 'armor', 'uncommon'],
+    ['Thistleplate Girdle', 'tank', 'armor', 'uncommon'],
+    ['Loamforged Cuirass', 'tank', 'armor', 'uncommon'],
+    ['Rimeguard Hauberk', 'tank', 'armor', 'uncommon'],
+    ['Huskshell Brigandine', 'tank', 'armor', 'uncommon'],
+    ['Grubhide Bulwark', 'tank', 'armor', 'uncommon'],
+    ['Cinderplate Aegis', 'tank', 'armor', 'rare'],
+    ['Thornsteel Carapace', 'tank', 'armor', 'rare'],
+    ['Mirewrought Bulwark', 'tank', 'armor', 'rare'],
+    ['Rimeshell Hauberk', 'tank', 'armor', 'rare'],
+    ['Warden\'s Ironroot Plate', 'tank', 'armor', 'epic'],
+    ['Scarecrow\'s Tattered Aegis', 'tank', 'armor', 'epic'],
+    ['Bastion of the Proving Bed', 'tank', 'armor', 'legendary'],
+    // tank · trinket
+    ['Chipped Grindstone', 'tank', 'trinket', 'common'],
+    ['Knotted Twine Charm', 'tank', 'trinket', 'common'],
+    ['River-Smoothed Ballast', 'tank', 'trinket', 'common'],
+    ['Cracked Clay Seal', 'tank', 'trinket', 'common'],
+    ['Rusted Gate Weight', 'tank', 'trinket', 'common'],
+    ['Frostbitten Acorn', 'tank', 'trinket', 'common'],
+    ['Split Geode Token', 'tank', 'trinket', 'common'],
+    ['Old Fencepost Nail', 'tank', 'trinket', 'common'],
+    ['Dry Gourd Rattle', 'tank', 'trinket', 'common'],
+    ['Ironbark Knot', 'tank', 'trinket', 'uncommon'],
+    ['Emberstone Seal', 'tank', 'trinket', 'uncommon'],
+    ['Thistleroot Anchor', 'tank', 'trinket', 'uncommon'],
+    ['Loamheart Talisman', 'tank', 'trinket', 'uncommon'],
+    ['Rimebound Ballast', 'tank', 'trinket', 'uncommon'],
+    ['Huskiron Sigil', 'tank', 'trinket', 'uncommon'],
+    ['Cinderheart Stone', 'tank', 'trinket', 'rare'],
+    ['Thornsteel Sigil', 'tank', 'trinket', 'rare'],
+    ['Mireroot Anchor', 'tank', 'trinket', 'rare'],
+    ['Rimeforged Seal', 'tank', 'trinket', 'rare'],
+    ['Blightward Totem', 'tank', 'trinket', 'rare'],
+    ['Warden\'s Unmoving Stone', 'tank', 'trinket', 'epic'],
+    ['Ironroot Heartseal', 'tank', 'trinket', 'epic'],
+    ['Hoarfrost Keystone', 'tank', 'trinket', 'epic'],
+    ['Keystone of the Unbroken Row', 'tank', 'trinket', 'legendary'],
+    // healer · weapon
+    ['Chipped Clay Ladle', 'healer', 'weapon', 'common'],
+    ['Split Willow Wand', 'healer', 'weapon', 'common'],
+    ['Tarnished Dew Bell', 'healer', 'weapon', 'common'],
+    ['Frayed Reed Crook', 'healer', 'weapon', 'common'],
+    ['Cracked Pollen Censer', 'healer', 'weapon', 'common'],
+    ['Bent Copper Sprinkler', 'healer', 'weapon', 'common'],
+    ['Knotted Sprig Rod', 'healer', 'weapon', 'common'],
+    ['Frost-Dulled Chime', 'healer', 'weapon', 'common'],
+    ['Hollow Stem Pipette', 'healer', 'weapon', 'common'],
+    ['Ironbark Crook', 'healer', 'weapon', 'uncommon'],
+    ['Emberlight Censer', 'healer', 'weapon', 'uncommon'],
+    ['Thistledown Wand', 'healer', 'weapon', 'uncommon'],
+    ['Loambloom Scepter', 'healer', 'weapon', 'uncommon'],
+    ['Rimewater Aspergillum', 'healer', 'weapon', 'uncommon'],
+    ['Huskbloom Rod', 'healer', 'weapon', 'uncommon'],
+    ['Grubwax Taper', 'healer', 'weapon', 'uncommon'],
+    ['Cinderbloom Scepter', 'healer', 'weapon', 'rare'],
+    ['Thornmend Crook', 'healer', 'weapon', 'rare'],
+    ['Mireblossom Wand', 'healer', 'weapon', 'rare'],
+    ['Rimewater Censer', 'healer', 'weapon', 'rare'],
+    ['Warden\'s Mending Bough', 'healer', 'weapon', 'epic'],
+    ['Hoarfrost Benediction', 'healer', 'weapon', 'epic'],
+    ['Bell of the Quiet Bloom', 'healer', 'weapon', 'legendary'],
+    // healer · armor
+    ['Threadbare Herb Wrap', 'healer', 'armor', 'common'],
+    ['Pollen-Dusted Smock', 'healer', 'armor', 'common'],
+    ['Frayed Muslin Veil', 'healer', 'armor', 'common'],
+    ['Patched Seedcloth Robes', 'healer', 'armor', 'common'],
+    ['Damp Moss Mantle', 'healer', 'armor', 'common'],
+    ['Frost-Touched Shawl', 'healer', 'armor', 'common'],
+    ['Rough Linen Vestment', 'healer', 'armor', 'common'],
+    ['Faded Chamomile Wrap', 'healer', 'armor', 'common'],
+    ['Stained Apiary Veil', 'healer', 'armor', 'common'],
+    ['Ironbark Raiment', 'healer', 'armor', 'uncommon'],
+    ['Emberweave Shawl', 'healer', 'armor', 'uncommon'],
+    ['Thistledown Mantle', 'healer', 'armor', 'uncommon'],
+    ['Loambloom Vestment', 'healer', 'armor', 'uncommon'],
+    ['Rimesilk Veil', 'healer', 'armor', 'uncommon'],
+    ['Huskweave Robes', 'healer', 'armor', 'uncommon'],
+    ['Cinderbloom Raiment', 'healer', 'armor', 'rare'],
+    ['Thornmend Vestment', 'healer', 'armor', 'rare'],
+    ['Mirebloom Shawl', 'healer', 'armor', 'rare'],
+    ['Rimesilk Mantle', 'healer', 'armor', 'rare'],
+    ['Blightward Robes', 'healer', 'armor', 'rare'],
+    ['Warden\'s Verdant Raiment', 'healer', 'armor', 'epic'],
+    ['Hoarfrost Shroud', 'healer', 'armor', 'epic'],
+    ['Scarecrow\'s Kindly Wrap', 'healer', 'armor', 'epic'],
+    ['Mantle of the First Green', 'healer', 'armor', 'legendary'],
+    // healer · trinket
+    ['Cracked Dew Phial', 'healer', 'trinket', 'common'],
+    ['Wilted Sprig Locket', 'healer', 'trinket', 'common'],
+    ['Dry Seed Pouch', 'healer', 'trinket', 'common'],
+    ['Chipped Honey Jar', 'healer', 'trinket', 'common'],
+    ['Frostbitten Bloom', 'healer', 'trinket', 'common'],
+    ['Tarnished Chime', 'healer', 'trinket', 'common'],
+    ['Knotted Herb Bundle', 'healer', 'trinket', 'common'],
+    ['Hollow Reed Whistle', 'healer', 'trinket', 'common'],
+    ['Ironbark Phial', 'healer', 'trinket', 'uncommon'],
+    ['Emberdew Locket', 'healer', 'trinket', 'uncommon'],
+    ['Thistlebloom Sachet', 'healer', 'trinket', 'uncommon'],
+    ['Loamheart Seed', 'healer', 'trinket', 'uncommon'],
+    ['Rimedew Vial', 'healer', 'trinket', 'uncommon'],
+    ['Huskbloom Charm', 'healer', 'trinket', 'uncommon'],
+    ['Grubwax Salve', 'healer', 'trinket', 'uncommon'],
+    ['Cinderdew Phial', 'healer', 'trinket', 'rare'],
+    ['Thornmend Locket', 'healer', 'trinket', 'rare'],
+    ['Mirebloom Sachet', 'healer', 'trinket', 'rare'],
+    ['Rimedew Reliquary', 'healer', 'trinket', 'rare'],
+    ['Blightward Poultice', 'healer', 'trinket', 'rare'],
+    ['Warden\'s Everdew Phial', 'healer', 'trinket', 'epic'],
+    ['Hoarfrost Reliquary', 'healer', 'trinket', 'epic'],
+    ['Scarecrow\'s Last Kindness', 'healer', 'trinket', 'epic'],
+    // dps · weapon
+    ['Notched Pruning Shears', 'dps', 'weapon', 'common'],
+    ['Rusted Scythe-Blade', 'dps', 'weapon', 'common'],
+    ['Chipped Flint Kris', 'dps', 'weapon', 'common'],
+    ['Splintered Cane Spear', 'dps', 'weapon', 'common'],
+    ['Bent Harvest Sickle', 'dps', 'weapon', 'common'],
+    ['Frost-Cracked Dirk', 'dps', 'weapon', 'common'],
+    ['Crude Bramble Glaive', 'dps', 'weapon', 'common'],
+    ['Warped Yew Bow', 'dps', 'weapon', 'common'],
+    ['Ironbark Sickle', 'dps', 'weapon', 'uncommon'],
+    ['Emberbrand Dirk', 'dps', 'weapon', 'uncommon'],
+    ['Thistlebarb Kris', 'dps', 'weapon', 'uncommon'],
+    ['Loamsteel Edge', 'dps', 'weapon', 'uncommon'],
+    ['Rimeglass Shiv', 'dps', 'weapon', 'uncommon'],
+    ['Huskthorn Glaive', 'dps', 'weapon', 'uncommon'],
+    ['Grubfang Bow', 'dps', 'weapon', 'uncommon'],
+    ['Cinderfang Sickle', 'dps', 'weapon', 'rare'],
+    ['Thornsteel Glaive', 'dps', 'weapon', 'rare'],
+    ['Mirestalker Kris', 'dps', 'weapon', 'rare'],
+    ['Rimeglass Edge', 'dps', 'weapon', 'rare'],
+    ['Warden\'s Culling Edge', 'dps', 'weapon', 'epic'],
+    ['Hoarfrost Executioner', 'dps', 'weapon', 'epic'],
+    // dps · armor
+    ['Scuffed Bramble Hide', 'dps', 'armor', 'common'],
+    ['Patched Poacher\'s Leathers', 'dps', 'armor', 'common'],
+    ['Frayed Nightshade Garb', 'dps', 'armor', 'common'],
+    ['Torn Burlap Shroud', 'dps', 'armor', 'common'],
+    ['Dust-Caked Jerkin', 'dps', 'armor', 'common'],
+    ['Frost-Rimed Cloak', 'dps', 'armor', 'common'],
+    ['Crude Grubskin Wrap', 'dps', 'armor', 'common'],
+    ['Stiffened Husk Mail', 'dps', 'armor', 'common'],
+    ['Nettle-Scratched Vest', 'dps', 'armor', 'common'],
+    ['Ironbark Leathers', 'dps', 'armor', 'uncommon'],
+    ['Emberweave Shroud', 'dps', 'armor', 'uncommon'],
+    ['Thistlehide Garb', 'dps', 'armor', 'uncommon'],
+    ['Loamstalker Jerkin', 'dps', 'armor', 'uncommon'],
+    ['Rimeshadow Cloak', 'dps', 'armor', 'uncommon'],
+    ['Huskmail Wrap', 'dps', 'armor', 'uncommon'],
+    ['Grubskin Leathers', 'dps', 'armor', 'uncommon'],
+    ['Cinderstalker Hide', 'dps', 'armor', 'rare'],
+    ['Thornshade Leathers', 'dps', 'armor', 'rare'],
+    ['Mirecreeper Garb', 'dps', 'armor', 'rare'],
+    ['Rimeshadow Shroud', 'dps', 'armor', 'rare'],
+    ['Warden\'s Silent Garb', 'dps', 'armor', 'epic'],
+    ['Hoarfrost Predator\'s Hide', 'dps', 'armor', 'epic'],
+    ['Scarecrow\'s Ragged Shroud', 'dps', 'armor', 'epic'],
+    ['Shroud of the Rotten Row', 'dps', 'armor', 'legendary'],
+    // dps · trinket
+    ['Dull Beetle Carapace', 'dps', 'trinket', 'common'],
+    ['Cracked Thorn Talon', 'dps', 'trinket', 'common'],
+    ['Dry Husk Seed', 'dps', 'trinket', 'common'],
+    ['Chipped Flint Spark', 'dps', 'trinket', 'common'],
+    ['Frostbitten Fang', 'dps', 'trinket', 'common'],
+    ['Knotted Snare Cord', 'dps', 'trinket', 'common'],
+    ['Rusted Trap Spring', 'dps', 'trinket', 'common'],
+    ['Hollow Wasp Gall', 'dps', 'trinket', 'common'],
+    ['Splintered Quill', 'dps', 'trinket', 'common'],
+    ['Ironbark Talon', 'dps', 'trinket', 'uncommon'],
+    ['Thistlebarb Fang', 'dps', 'trinket', 'uncommon'],
+    ['Loamspark Idol', 'dps', 'trinket', 'uncommon'],
+    ['Rimeglass Shard', 'dps', 'trinket', 'uncommon'],
+    ['Huskthorn Seed', 'dps', 'trinket', 'uncommon'],
+    ['Grubfang Charm', 'dps', 'trinket', 'uncommon'],
+    ['Cinderspark Idol', 'dps', 'trinket', 'rare'],
+    ['Thornfang Talisman', 'dps', 'trinket', 'rare'],
+    ['Mirestalker Fang', 'dps', 'trinket', 'rare'],
+    ['Rimeglass Focus', 'dps', 'trinket', 'rare'],
+    ['Blightseed Token', 'dps', 'trinket', 'rare'],
+    ['Warden\'s Hunting Fang', 'dps', 'trinket', 'epic'],
+    ['Hoarfrost Killing Seed', 'dps', 'trinket', 'epic'],
+    ['Ember of the Foul Bloom', 'dps', 'trinket', 'legendary'],
+  ],
+  // ══ SEASON 2 — The Sweltering Patch (high summer blight) ══
+  [
+    // tank · weapon
+    ['Sun-Warped Mattock', 'tank', 'weapon', 'common'],
+    ['Dust-Choked Maul', 'tank', 'weapon', 'common'],
+    ['Cracked Kiln Hammer', 'tank', 'weapon', 'common'],
+    ['Blistered Fencepost', 'tank', 'weapon', 'common'],
+    ['Parched Cordwood Cudgel', 'tank', 'weapon', 'common'],
+    ['Chaff-Clogged Flail', 'tank', 'weapon', 'common'],
+    ['Heat-Bent Turf Spade', 'tank', 'weapon', 'common'],
+    ['Split Tasselwood Beam', 'tank', 'weapon', 'common'],
+    ['Kilnforged Mattock', 'tank', 'weapon', 'uncommon'],
+    ['Bramblebound Cudgel', 'tank', 'weapon', 'uncommon'],
+    ['Sunbaked Sledge', 'tank', 'weapon', 'uncommon'],
+    ['Cornsilk-Wound Maul', 'tank', 'weapon', 'uncommon'],
+    ['Resin-Sealed Bludgeon', 'tank', 'weapon', 'uncommon'],
+    ['Beetleplate Hammer', 'tank', 'weapon', 'uncommon'],
+    ['Droughtiron Spade', 'tank', 'weapon', 'uncommon'],
+    ['Scorchsteel Sledge', 'tank', 'weapon', 'rare'],
+    ['Thornwretch Mattock', 'tank', 'weapon', 'rare'],
+    ['Cicadabrand Warhammer', 'tank', 'weapon', 'rare'],
+    ['Sapforged Maul', 'tank', 'weapon', 'rare'],
+    ['Hornworm Crusher', 'tank', 'weapon', 'rare'],
+    ['Sunscorch\'s Anvil-Hand', 'tank', 'weapon', 'epic'],
+    ['Tassel-Tyrant Groundbreaker', 'tank', 'weapon', 'epic'],
+    ['Solstice Judgement', 'tank', 'weapon', 'epic'],
+    ['Hammer of the Standing Noon', 'tank', 'weapon', 'legendary'],
+    // tank · armor
+    ['Dust-Caked Plate', 'tank', 'armor', 'common'],
+    ['Sun-Bleached Brigandine', 'tank', 'armor', 'common'],
+    ['Cracked Husk Cuirass', 'tank', 'armor', 'common'],
+    ['Parched Leather Coat', 'tank', 'armor', 'common'],
+    ['Chaff-Stuffed Gambeson', 'tank', 'armor', 'common'],
+    ['Blistered Tin Hauberk', 'tank', 'armor', 'common'],
+    ['Sweat-Stained Guard', 'tank', 'armor', 'common'],
+    ['Kiln-Fired Clay Vest', 'tank', 'armor', 'common'],
+    ['Frayed Tarpaulin Shell', 'tank', 'armor', 'common'],
+    ['Kilnplate Carapace', 'tank', 'armor', 'uncommon'],
+    ['Bramblebound Girdle', 'tank', 'armor', 'uncommon'],
+    ['Sunbaked Cuirass', 'tank', 'armor', 'uncommon'],
+    ['Cornhusk Brigandine', 'tank', 'armor', 'uncommon'],
+    ['Resin-Sealed Hauberk', 'tank', 'armor', 'uncommon'],
+    ['Beetleback Carapace', 'tank', 'armor', 'uncommon'],
+    ['Droughtiron Coat', 'tank', 'armor', 'uncommon'],
+    ['Scorchplate Aegis', 'tank', 'armor', 'rare'],
+    ['Thornwretch Carapace', 'tank', 'armor', 'rare'],
+    ['Sapwrought Bulwark', 'tank', 'armor', 'rare'],
+    ['Ten-Lined Shellguard', 'tank', 'armor', 'rare'],
+    ['Sunscorch\'s Blistered Plate', 'tank', 'armor', 'epic'],
+    ['Colossus Huskmail', 'tank', 'armor', 'epic'],
+    // tank · trinket
+    ['Sun-Cracked Grindstone', 'tank', 'trinket', 'common'],
+    ['Dry Cistern Weight', 'tank', 'trinket', 'common'],
+    ['Chipped Kiln Brick', 'tank', 'trinket', 'common'],
+    ['Dusty Ballast Stone', 'tank', 'trinket', 'common'],
+    ['Blistered Iron Ring', 'tank', 'trinket', 'common'],
+    ['Parched Clay Seal', 'tank', 'trinket', 'common'],
+    ['Hollow Cicada Shell', 'tank', 'trinket', 'common'],
+    ['Split Sunstone Shard', 'tank', 'trinket', 'common'],
+    ['Knotted Cornsilk Cord', 'tank', 'trinket', 'common'],
+    ['Kilnstone Seal', 'tank', 'trinket', 'uncommon'],
+    ['Bramble-Knot Anchor', 'tank', 'trinket', 'uncommon'],
+    ['Sunbaked Sigil', 'tank', 'trinket', 'uncommon'],
+    ['Cornheart Talisman', 'tank', 'trinket', 'uncommon'],
+    ['Resin-Locked Ballast', 'tank', 'trinket', 'uncommon'],
+    ['Beetleshell Totem', 'tank', 'trinket', 'uncommon'],
+    ['Scorchheart Stone', 'tank', 'trinket', 'rare'],
+    ['Thornwretch Sigil', 'tank', 'trinket', 'rare'],
+    ['Saproot Anchor', 'tank', 'trinket', 'rare'],
+    ['Cicadastone Seal', 'tank', 'trinket', 'rare'],
+    ['Droughtward Totem', 'tank', 'trinket', 'rare'],
+    ['Sunscorch\'s Unmoving Ember', 'tank', 'trinket', 'epic'],
+    ['Tassel-Tyrant Keystone', 'tank', 'trinket', 'epic'],
+    ['Solstice Heartseal', 'tank', 'trinket', 'epic'],
+    ['Keystone of the Endless Dry', 'tank', 'trinket', 'legendary'],
+    // healer · weapon
+    ['Sun-Split Ladle', 'healer', 'weapon', 'common'],
+    ['Dry Gourd Dipper', 'healer', 'weapon', 'common'],
+    ['Cracked Nectar Censer', 'healer', 'weapon', 'common'],
+    ['Warped Cane Crook', 'healer', 'weapon', 'common'],
+    ['Dusty Pollen Bell', 'healer', 'weapon', 'common'],
+    ['Blistered Copper Sprinkler', 'healer', 'weapon', 'common'],
+    ['Parched Reed Rod', 'healer', 'weapon', 'common'],
+    ['Hollow Cornstalk Pipe', 'healer', 'weapon', 'common'],
+    ['Tarnished Sun Chime', 'healer', 'weapon', 'common'],
+    ['Kilnlight Censer', 'healer', 'weapon', 'uncommon'],
+    ['Bramblebloom Crook', 'healer', 'weapon', 'uncommon'],
+    ['Sunbloom Scepter', 'healer', 'weapon', 'uncommon'],
+    ['Cornsilk Wand', 'healer', 'weapon', 'uncommon'],
+    ['Resin-Sealed Aspergillum', 'healer', 'weapon', 'uncommon'],
+    ['Nectarwarm Rod', 'healer', 'weapon', 'uncommon'],
+    ['Cicadasong Chime', 'healer', 'weapon', 'uncommon'],
+    ['Scorchbloom Scepter', 'healer', 'weapon', 'rare'],
+    ['Thornwretch Crook', 'healer', 'weapon', 'rare'],
+    ['Sapmender Wand', 'healer', 'weapon', 'rare'],
+    ['Solstice Censer', 'healer', 'weapon', 'rare'],
+    ['Sunscorch\'s Mercy', 'healer', 'weapon', 'epic'],
+    ['Broodmother Benediction', 'healer', 'weapon', 'epic'],
+    ['Chime of the Long Noon', 'healer', 'weapon', 'legendary'],
+    // healer · armor
+    ['Sun-Bleached Smock', 'healer', 'armor', 'common'],
+    ['Dust-Grimed Veil', 'healer', 'armor', 'common'],
+    ['Frayed Shade Wrap', 'healer', 'armor', 'common'],
+    ['Parched Muslin Robes', 'healer', 'armor', 'common'],
+    ['Sweat-Stained Vestment', 'healer', 'armor', 'common'],
+    ['Cracked Resin Mantle', 'healer', 'armor', 'common'],
+    ['Rough Cornsilk Shawl', 'healer', 'armor', 'common'],
+    ['Faded Nectar Wrap', 'healer', 'armor', 'common'],
+    ['Threadbare Awning Cloak', 'healer', 'armor', 'common'],
+    ['Kilnweave Raiment', 'healer', 'armor', 'uncommon'],
+    ['Bramblebloom Shawl', 'healer', 'armor', 'uncommon'],
+    ['Sunshade Mantle', 'healer', 'armor', 'uncommon'],
+    ['Cornsilk Vestment', 'healer', 'armor', 'uncommon'],
+    ['Resinweave Veil', 'healer', 'armor', 'uncommon'],
+    ['Nectarbloom Robes', 'healer', 'armor', 'uncommon'],
+    ['Scorchbloom Raiment', 'healer', 'armor', 'rare'],
+    ['Thornwretch Vestment', 'healer', 'armor', 'rare'],
+    ['Sapbloom Shawl', 'healer', 'armor', 'rare'],
+    ['Cicadasilk Mantle', 'healer', 'armor', 'rare'],
+    ['Droughtward Robes', 'healer', 'armor', 'rare'],
+    ['Sunscorch\'s Kindly Shade', 'healer', 'armor', 'epic'],
+    ['Broodmother Shroud', 'healer', 'armor', 'epic'],
+    ['Tassel-Tyrant Raiment', 'healer', 'armor', 'epic'],
+    ['Shade of the Sweltering Patch', 'healer', 'armor', 'legendary'],
+    // healer · trinket
+    ['Cracked Nectar Phial', 'healer', 'trinket', 'common'],
+    ['Dry Sunflower Locket', 'healer', 'trinket', 'common'],
+    ['Dusty Seed Pouch', 'healer', 'trinket', 'common'],
+    ['Chipped Resin Jar', 'healer', 'trinket', 'common'],
+    ['Sun-Wilted Bloom', 'healer', 'trinket', 'common'],
+    ['Hollow Cicada Whistle', 'healer', 'trinket', 'common'],
+    ['Knotted Cornsilk Bundle', 'healer', 'trinket', 'common'],
+    ['Tarnished Dew Vial', 'healer', 'trinket', 'common'],
+    ['Kilnfired Phial', 'healer', 'trinket', 'uncommon'],
+    ['Bramblebloom Sachet', 'healer', 'trinket', 'uncommon'],
+    ['Sundew Locket', 'healer', 'trinket', 'uncommon'],
+    ['Cornheart Seed', 'healer', 'trinket', 'uncommon'],
+    ['Resin-Sealed Vial', 'healer', 'trinket', 'uncommon'],
+    ['Nectarwarm Charm', 'healer', 'trinket', 'uncommon'],
+    ['Cicadashell Salve', 'healer', 'trinket', 'uncommon'],
+    ['Scorchdew Phial', 'healer', 'trinket', 'rare'],
+    ['Thornwretch Locket', 'healer', 'trinket', 'rare'],
+    ['Sapbloom Sachet', 'healer', 'trinket', 'rare'],
+    ['Solstice Reliquary', 'healer', 'trinket', 'rare'],
+    ['Droughtward Poultice', 'healer', 'trinket', 'rare'],
+    ['Sunscorch\'s Everdew', 'healer', 'trinket', 'epic'],
+    ['Broodmother Reliquary', 'healer', 'trinket', 'epic'],
+    ['Venus Nectar-Heart', 'healer', 'trinket', 'epic'],
+    ['Heart of the High Summer', 'healer', 'trinket', 'legendary'],
+    // dps · weapon
+    ['Sun-Notched Shears', 'dps', 'weapon', 'common'],
+    ['Dust-Dulled Sickle', 'dps', 'weapon', 'common'],
+    ['Cracked Flint Kris', 'dps', 'weapon', 'common'],
+    ['Warped Cane Spear', 'dps', 'weapon', 'common'],
+    ['Blistered Pruning Blade', 'dps', 'weapon', 'common'],
+    ['Parched Yew Bow', 'dps', 'weapon', 'common'],
+    ['Chaff-Clogged Glaive', 'dps', 'weapon', 'common'],
+    ['Heat-Bent Dirk', 'dps', 'weapon', 'common'],
+    ['Kilnbrand Sickle', 'dps', 'weapon', 'uncommon'],
+    ['Bramblebarb Kris', 'dps', 'weapon', 'uncommon'],
+    ['Sunfang Dirk', 'dps', 'weapon', 'uncommon'],
+    ['Cornsilk-Wound Edge', 'dps', 'weapon', 'uncommon'],
+    ['Resin-Slick Shiv', 'dps', 'weapon', 'uncommon'],
+    ['Beetlefang Glaive', 'dps', 'weapon', 'uncommon'],
+    ['Cicadawing Bow', 'dps', 'weapon', 'uncommon'],
+    ['Scorchfang Sickle', 'dps', 'weapon', 'rare'],
+    ['Thornwretch Glaive', 'dps', 'weapon', 'rare'],
+    ['Sapstalker Kris', 'dps', 'weapon', 'rare'],
+    ['Hornworm Ripper', 'dps', 'weapon', 'rare'],
+    ['Sunscorch\'s Culling Blaze', 'dps', 'weapon', 'epic'],
+    ['Snaptrap Executioner', 'dps', 'weapon', 'epic'],
+    // dps · armor
+    ['Sun-Faded Hide', 'dps', 'armor', 'common'],
+    ['Dust-Caked Leathers', 'dps', 'armor', 'common'],
+    ['Frayed Bramble Garb', 'dps', 'armor', 'common'],
+    ['Torn Awning Shroud', 'dps', 'armor', 'common'],
+    ['Blistered Poacher’s Jerkin', 'dps', 'armor', 'common'],
+    ['Parched Snakeskin Wrap', 'dps', 'armor', 'common'],
+    ['Crude Beetleshell Vest', 'dps', 'armor', 'common'],
+    ['Stiffened Cornhusk Mail', 'dps', 'armor', 'common'],
+    ['Chaff-Strewn Cloak', 'dps', 'armor', 'common'],
+    ['Kilnweave Leathers', 'dps', 'armor', 'uncommon'],
+    ['Bramblehide Garb', 'dps', 'armor', 'uncommon'],
+    ['Sunstalker Jerkin', 'dps', 'armor', 'uncommon'],
+    ['Cornhusk Shroud', 'dps', 'armor', 'uncommon'],
+    ['Resin-Slick Wrap', 'dps', 'armor', 'uncommon'],
+    ['Beetleshell Leathers', 'dps', 'armor', 'uncommon'],
+    ['Cicadawing Cloak', 'dps', 'armor', 'uncommon'],
+    ['Scorchstalker Hide', 'dps', 'armor', 'rare'],
+    ['Thornwretch Leathers', 'dps', 'armor', 'rare'],
+    ['Sapcreeper Garb', 'dps', 'armor', 'rare'],
+    ['Ten-Lined Carapace', 'dps', 'armor', 'rare'],
+    ['Sunscorch\'s Silent Ash', 'dps', 'armor', 'epic'],
+    ['Broodmother Chitin', 'dps', 'armor', 'epic'],
+    ['Snaptrap Shroud', 'dps', 'armor', 'epic'],
+    ['Hide of the Ten-Lined Horde', 'dps', 'armor', 'legendary'],
+    // dps · trinket
+    ['Dull Beetle Wing', 'dps', 'trinket', 'common'],
+    ['Cracked Bramble Talon', 'dps', 'trinket', 'common'],
+    ['Dry Cornsilk Tuft', 'dps', 'trinket', 'common'],
+    ['Chipped Sunstone Spark', 'dps', 'trinket', 'common'],
+    ['Sun-Wilted Fang', 'dps', 'trinket', 'common'],
+    ['Knotted Snare Wire', 'dps', 'trinket', 'common'],
+    ['Sun-Seized Trap Spring', 'dps', 'trinket', 'common'],
+    ['Hollow Hornworm Casing', 'dps', 'trinket', 'common'],
+    ['Splintered Cicada Quill', 'dps', 'trinket', 'common'],
+    ['Kilnspark Idol', 'dps', 'trinket', 'uncommon'],
+    ['Bramblebarb Fang', 'dps', 'trinket', 'uncommon'],
+    ['Sunspark Token', 'dps', 'trinket', 'uncommon'],
+    ['Cornheart Charm', 'dps', 'trinket', 'uncommon'],
+    ['Resin-Locked Shard', 'dps', 'trinket', 'uncommon'],
+    ['Beetlefang Talisman', 'dps', 'trinket', 'uncommon'],
+    ['Scorchspark Idol', 'dps', 'trinket', 'rare'],
+    ['Thornwretch Talisman', 'dps', 'trinket', 'rare'],
+    ['Sapstalker Fang', 'dps', 'trinket', 'rare'],
+    ['Cicadaglass Focus', 'dps', 'trinket', 'rare'],
+    ['Droughtseed Token', 'dps', 'trinket', 'rare'],
+    ['Sunscorch\'s Killing Ember', 'dps', 'trinket', 'epic'],
+    ['Broodmother Eggseed', 'dps', 'trinket', 'epic'],
+    ['Ember of the Tassel Crown', 'dps', 'trinket', 'legendary'],
+  ],
+  // ══ SEASON 3 — The Last Harvest (rot & untimely frost) ══
+  [
+    // tank · weapon
+    ['Rot-Pitted Mattock', 'tank', 'weapon', 'common'],
+    ['Hollow Gourd Maul', 'tank', 'weapon', 'common'],
+    ['Cracked Grave-Marker', 'tank', 'weapon', 'common'],
+    ['Tattered Flail', 'tank', 'weapon', 'common'],
+    ['Mulch-Clogged Sledge', 'tank', 'weapon', 'common'],
+    ['Frost-Split Threshing Bar', 'tank', 'weapon', 'common'],
+    ['Worm-Bored Cudgel', 'tank', 'weapon', 'common'],
+    ['Dulled Sheaf Hammer', 'tank', 'weapon', 'common'],
+    ['Mulchforged Mattock', 'tank', 'weapon', 'uncommon'],
+    ['Gourdplate Cudgel', 'tank', 'weapon', 'uncommon'],
+    ['Wormwood Sledge', 'tank', 'weapon', 'uncommon'],
+    ['Tatterbound Maul', 'tank', 'weapon', 'uncommon'],
+    ['Sheafiron Spade', 'tank', 'weapon', 'uncommon'],
+    ['Duskforged Bludgeon', 'tank', 'weapon', 'uncommon'],
+    ['Lanternlight Hammer', 'tank', 'weapon', 'uncommon'],
+    ['Graveweight Sledge', 'tank', 'weapon', 'rare'],
+    ['Hollowbone Mattock', 'tank', 'weapon', 'rare'],
+    ['Wormwood Warhammer', 'tank', 'weapon', 'rare'],
+    ['Reaper’s Groundbreaker', 'tank', 'weapon', 'rare'],
+    ['Hoarfrost Threshing Maul', 'tank', 'weapon', 'rare'],
+    ['Gourdfather\'s Hollow Fist', 'tank', 'weapon', 'epic'],
+    ['Tatterking\'s Rusted Sceptre', 'tank', 'weapon', 'epic'],
+    ['Requiem Judgement', 'tank', 'weapon', 'epic'],
+    ['Anvil of the Last Furrow', 'tank', 'weapon', 'legendary'],
+    // tank · armor
+    ['Rot-Streaked Plate', 'tank', 'armor', 'common'],
+    ['Hollow Gourd Cuirass', 'tank', 'armor', 'common'],
+    ['Tattered Scarecrow Coat', 'tank', 'armor', 'common'],
+    ['Mulch-Caked Brigandine', 'tank', 'armor', 'common'],
+    ['Chaff-Stuffed Hauberk', 'tank', 'armor', 'common'],
+    ['Frost-Rimed Guard', 'tank', 'armor', 'common'],
+    ['Worm-Bored Shell', 'tank', 'armor', 'common'],
+    ['Grave-Soil Gambeson', 'tank', 'armor', 'common'],
+    ['Split Sheafwood Vest', 'tank', 'armor', 'common'],
+    ['Mulchplate Carapace', 'tank', 'armor', 'uncommon'],
+    ['Gourdshell Girdle', 'tank', 'armor', 'uncommon'],
+    ['Wormwood Cuirass', 'tank', 'armor', 'uncommon'],
+    ['Tatterweave Brigandine', 'tank', 'armor', 'uncommon'],
+    ['Sheafiron Hauberk', 'tank', 'armor', 'uncommon'],
+    ['Duskplate Coat', 'tank', 'armor', 'uncommon'],
+    ['Lanternward Carapace', 'tank', 'armor', 'uncommon'],
+    ['Gravewrought Aegis', 'tank', 'armor', 'rare'],
+    ['Hollowbone Carapace', 'tank', 'armor', 'rare'],
+    ['Wormwood Bulwark', 'tank', 'armor', 'rare'],
+    ['Hoarfrost Shellguard', 'tank', 'armor', 'rare'],
+    ['Gourdfather\'s Hollow Aegis', 'tank', 'armor', 'epic'],
+    ['Tatterking\'s Ragged Plate', 'tank', 'armor', 'epic'],
+    ['Bastion of the Verdant Majesty', 'tank', 'armor', 'legendary'],
+    // tank · trinket
+    ['Cracked Grave Weight', 'tank', 'trinket', 'common'],
+    ['Hollow Gourd Rattle', 'tank', 'trinket', 'common'],
+    ['Rot-Blackened Seal', 'tank', 'trinket', 'common'],
+    ['Tattered Binding Cord', 'tank', 'trinket', 'common'],
+    ['Mulch-Packed Ballast', 'tank', 'trinket', 'common'],
+    ['Frostbitten Root-Knot', 'tank', 'trinket', 'common'],
+    ['Worm-Bored Stone', 'tank', 'trinket', 'common'],
+    ['Dry Sheaf Token', 'tank', 'trinket', 'common'],
+    ['Chipped Lantern Glass', 'tank', 'trinket', 'common'],
+    ['Mulchstone Seal', 'tank', 'trinket', 'uncommon'],
+    ['Gourdheart Anchor', 'tank', 'trinket', 'uncommon'],
+    ['Wormwood Sigil', 'tank', 'trinket', 'uncommon'],
+    ['Tatterknot Talisman', 'tank', 'trinket', 'uncommon'],
+    ['Sheafbound Ballast', 'tank', 'trinket', 'uncommon'],
+    ['Duskstone Totem', 'tank', 'trinket', 'uncommon'],
+    ['Graveroot Anchor', 'tank', 'trinket', 'rare'],
+    ['Hollowheart Stone', 'tank', 'trinket', 'rare'],
+    ['Wormwood Keystone', 'tank', 'trinket', 'rare'],
+    ['Reaper’s Seal', 'tank', 'trinket', 'rare'],
+    ['Hoarfrost Ballast', 'tank', 'trinket', 'rare'],
+    ['Gourdfather\'s Hollow Heart', 'tank', 'trinket', 'epic'],
+    ['Tatterking\'s Crown-Nail', 'tank', 'trinket', 'epic'],
+    ['Requiem Heartseal', 'tank', 'trinket', 'epic'],
+    // healer · weapon
+    ['Cracked Grave Censer', 'healer', 'weapon', 'common'],
+    ['Hollow Gourd Dipper', 'healer', 'weapon', 'common'],
+    ['Tattered Prayer Bell', 'healer', 'weapon', 'common'],
+    ['Rot-Dulled Ladle', 'healer', 'weapon', 'common'],
+    ['Mulch-Stained Crook', 'healer', 'weapon', 'common'],
+    ['Frost-Cracked Chime', 'healer', 'weapon', 'common'],
+    ['Worm-Bored Reed Rod', 'healer', 'weapon', 'common'],
+    ['Dry Sheaf Aspergillum', 'healer', 'weapon', 'common'],
+    ['Guttered Lantern Wand', 'healer', 'weapon', 'common'],
+    ['Mulchbloom Crook', 'healer', 'weapon', 'uncommon'],
+    ['Gourdlight Censer', 'healer', 'weapon', 'uncommon'],
+    ['Wormwood Wand', 'healer', 'weapon', 'uncommon'],
+    ['Tatterweave Scepter', 'healer', 'weapon', 'uncommon'],
+    ['Sheafbloom Rod', 'healer', 'weapon', 'uncommon'],
+    ['Dusklight Chime', 'healer', 'weapon', 'uncommon'],
+    ['Lanternbearer’s Crook', 'healer', 'weapon', 'uncommon'],
+    ['Gravebloom Scepter', 'healer', 'weapon', 'rare'],
+    ['Hollowlight Crook', 'healer', 'weapon', 'rare'],
+    ['Wormwood Censer', 'healer', 'weapon', 'rare'],
+    ['Hoarfrost Aspergillum', 'healer', 'weapon', 'rare'],
+    ['Gourdfather\'s Quiet Lantern', 'healer', 'weapon', 'epic'],
+    ['Wormwood Choir-Bell', 'healer', 'weapon', 'epic'],
+    // healer · armor
+    ['Rot-Stained Smock', 'healer', 'armor', 'common'],
+    ['Hollow Gourd Veil', 'healer', 'armor', 'common'],
+    ['Tattered Shroud-Wrap', 'healer', 'armor', 'common'],
+    ['Mulch-Grimed Robes', 'healer', 'armor', 'common'],
+    ['Chaff-Dusted Vestment', 'healer', 'armor', 'common'],
+    ['Frostbitten Shawl', 'healer', 'armor', 'common'],
+    ['Worm-Bored Mantle', 'healer', 'armor', 'common'],
+    ['Dry Sheaf Cloak', 'healer', 'armor', 'common'],
+    ['Guttered Lantern Wrap', 'healer', 'armor', 'common'],
+    ['Mulchweave Raiment', 'healer', 'armor', 'uncommon'],
+    ['Gourdsilk Shawl', 'healer', 'armor', 'uncommon'],
+    ['Wormwood Vestment', 'healer', 'armor', 'uncommon'],
+    ['Tatterweave Veil', 'healer', 'armor', 'uncommon'],
+    ['Sheafbloom Mantle', 'healer', 'armor', 'uncommon'],
+    ['Duskweave Robes', 'healer', 'armor', 'uncommon'],
+    ['Gravebloom Raiment', 'healer', 'armor', 'rare'],
+    ['Hollowsilk Vestment', 'healer', 'armor', 'rare'],
+    ['Wormwood Shawl', 'healer', 'armor', 'rare'],
+    ['Reaper’s Mantle', 'healer', 'armor', 'rare'],
+    ['Hoarfrost Veil', 'healer', 'armor', 'rare'],
+    ['Gourdfather\'s Kindly Hollow', 'healer', 'armor', 'epic'],
+    ['Wormwood Choir-Robes', 'healer', 'armor', 'epic'],
+    ['Tatterking\'s Mercy', 'healer', 'armor', 'epic'],
+    ['Raiment of the Okra Eternal', 'healer', 'armor', 'legendary'],
+    // healer · trinket
+    ['Cracked Grave Phial', 'healer', 'trinket', 'common'],
+    ['Hollow Gourd Seed', 'healer', 'trinket', 'common'],
+    ['Tattered Herb Bundle', 'healer', 'trinket', 'common'],
+    ['Rot-Blackened Locket', 'healer', 'trinket', 'common'],
+    ['Mulch-Packed Pouch', 'healer', 'trinket', 'common'],
+    ['Frostbitten Blossom', 'healer', 'trinket', 'common'],
+    ['Worm-Bored Vial', 'healer', 'trinket', 'common'],
+    ['Guttered Lantern Ember', 'healer', 'trinket', 'common'],
+    ['Mulchheart Phial', 'healer', 'trinket', 'uncommon'],
+    ['Gourdbloom Sachet', 'healer', 'trinket', 'uncommon'],
+    ['Wormwood Vial', 'healer', 'trinket', 'uncommon'],
+    ['Tatterknot Charm', 'healer', 'trinket', 'uncommon'],
+    ['Sheafbloom Seed', 'healer', 'trinket', 'uncommon'],
+    ['Dusklight Locket', 'healer', 'trinket', 'uncommon'],
+    ['Lanternwarm Salve', 'healer', 'trinket', 'uncommon'],
+    ['Gravebloom Phial', 'healer', 'trinket', 'rare'],
+    ['Hollowheart Locket', 'healer', 'trinket', 'rare'],
+    ['Wormwood Reliquary', 'healer', 'trinket', 'rare'],
+    ['Reaper’s Poultice', 'healer', 'trinket', 'rare'],
+    ['Hoarfrost Sachet', 'healer', 'trinket', 'rare'],
+    ['Gourdfather\'s Everdew', 'healer', 'trinket', 'epic'],
+    ['Wormwood Choir-Reliquary', 'healer', 'trinket', 'epic'],
+    ['Requiem Blossom', 'healer', 'trinket', 'epic'],
+    ['Seed of the Verdant Majesty', 'healer', 'trinket', 'legendary'],
+    // dps · weapon
+    ['Rust-Eaten Scythe', 'dps', 'weapon', 'common'],
+    ['Hollow Gourd Shears', 'dps', 'weapon', 'common'],
+    ['Tattered Reaping Hook', 'dps', 'weapon', 'common'],
+    ['Chipped Grave Kris', 'dps', 'weapon', 'common'],
+    ['Mulch-Dulled Sickle', 'dps', 'weapon', 'common'],
+    ['Frost-Cracked Glaive', 'dps', 'weapon', 'common'],
+    ['Worm-Bored Yew Bow', 'dps', 'weapon', 'common'],
+    ['Splintered Sheaf Spear', 'dps', 'weapon', 'common'],
+    ['Mulchbrand Sickle', 'dps', 'weapon', 'uncommon'],
+    ['Gourdfang Kris', 'dps', 'weapon', 'uncommon'],
+    ['Wormwood Glaive', 'dps', 'weapon', 'uncommon'],
+    ['Tatterbarb Edge', 'dps', 'weapon', 'uncommon'],
+    ['Sheafsteel Scythe', 'dps', 'weapon', 'uncommon'],
+    ['Duskfang Shiv', 'dps', 'weapon', 'uncommon'],
+    ['Lanternglass Bow', 'dps', 'weapon', 'uncommon'],
+    ['Gravefang Scythe', 'dps', 'weapon', 'rare'],
+    ['Hollowbone Glaive', 'dps', 'weapon', 'rare'],
+    ['Wormwood Kris', 'dps', 'weapon', 'rare'],
+    ['Hoarfrost Ripper', 'dps', 'weapon', 'rare'],
+    ['Gourdfather\'s Hollow Edge', 'dps', 'weapon', 'epic'],
+    ['Tatterking\'s Culling Hook', 'dps', 'weapon', 'epic'],
+    ['Scythe of the Final Sheaf', 'dps', 'weapon', 'legendary'],
+    // dps · armor
+    ['Rot-Streaked Hide', 'dps', 'armor', 'common'],
+    ['Hollow Gourd Vest', 'dps', 'armor', 'common'],
+    ['Tattered Poacher’s Garb', 'dps', 'armor', 'common'],
+    ['Mulch-Caked Leathers', 'dps', 'armor', 'common'],
+    ['Chaff-Strewn Shroud', 'dps', 'armor', 'common'],
+    ['Frost-Gnawed Cloak', 'dps', 'armor', 'common'],
+    ['Worm-Bored Jerkin', 'dps', 'armor', 'common'],
+    ['Dry Sheaf Wrap', 'dps', 'armor', 'common'],
+    ['Guttered Lantern Mail', 'dps', 'armor', 'common'],
+    ['Mulchweave Leathers', 'dps', 'armor', 'uncommon'],
+    ['Gourdshell Garb', 'dps', 'armor', 'uncommon'],
+    ['Wormwood Jerkin', 'dps', 'armor', 'uncommon'],
+    ['Tatterweave Shroud', 'dps', 'armor', 'uncommon'],
+    ['Sheafhide Wrap', 'dps', 'armor', 'uncommon'],
+    ['Duskstalker Cloak', 'dps', 'armor', 'uncommon'],
+    ['Lanternshade Leathers', 'dps', 'armor', 'uncommon'],
+    ['Gravestalker Hide', 'dps', 'armor', 'rare'],
+    ['Hollowbone Leathers', 'dps', 'armor', 'rare'],
+    ['Wormwood Garb', 'dps', 'armor', 'rare'],
+    ['Hoarfrost Cerement', 'dps', 'armor', 'rare'],
+    ['Gourdfather\'s Silent Hollow', 'dps', 'armor', 'epic'],
+    ['Tatterking\'s Ragged Shade', 'dps', 'armor', 'epic'],
+    ['Requiem Chitin', 'dps', 'armor', 'epic'],
+    ['Shroud of the Wormwood Choir', 'dps', 'armor', 'legendary'],
+    // dps · trinket
+    ['Dull Grave Talon', 'dps', 'trinket', 'common'],
+    ['Hollow Gourd Seed-Rattle', 'dps', 'trinket', 'common'],
+    ['Tattered Snare Cord', 'dps', 'trinket', 'common'],
+    ['Cracked Reaping Fang', 'dps', 'trinket', 'common'],
+    ['Mulch-Packed Spark', 'dps', 'trinket', 'common'],
+    ['Frostbitten Thorn', 'dps', 'trinket', 'common'],
+    ['Worm-Bored Quill', 'dps', 'trinket', 'common'],
+    ['Chaff-Bound Token', 'dps', 'trinket', 'common'],
+    ['Guttered Lantern Shard', 'dps', 'trinket', 'common'],
+    ['Mulchspark Idol', 'dps', 'trinket', 'uncommon'],
+    ['Gourdfang Charm', 'dps', 'trinket', 'uncommon'],
+    ['Wormwood Talon', 'dps', 'trinket', 'uncommon'],
+    ['Tatterbarb Fang', 'dps', 'trinket', 'uncommon'],
+    ['Sheafseed Rattle', 'dps', 'trinket', 'uncommon'],
+    ['Duskglass Shard', 'dps', 'trinket', 'uncommon'],
+    ['Gravespark Idol', 'dps', 'trinket', 'rare'],
+    ['Hollowheart Fang', 'dps', 'trinket', 'rare'],
+    ['Wormwood Focus', 'dps', 'trinket', 'rare'],
+    ['Reaper’s Talisman', 'dps', 'trinket', 'rare'],
+    ['Hoarfrost Reaping Seed', 'dps', 'trinket', 'rare'],
+    ['Gourdfather\'s Hollow Ember', 'dps', 'trinket', 'epic'],
+    ['Tatterking\'s Last Nail', 'dps', 'trinket', 'epic'],
+    ['Knell of the Untimely Frost', 'dps', 'trinket', 'legendary'],
+  ],
+];
+
+/** `"Warden's Groundbreaker"` → `wardens_groundbreaker` (id-safe, ASCII). */
+function slugify(name) {
+  return String(name)
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/['‘’]/g, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Expand the name table into full item records. Bonus = the rarity's base for
+ * that season, fanned across its tier by TIER_SPREAD, floored at 1.
+ * @returns {{ items: Record<string, object>, bySeason: string[][] }}
+ */
+function buildSeasonGear() {
+  const items = {};
+  const bySeason = SEASON_GEAR.map(() => []);
+
+  SEASON_GEAR.forEach((rows, seasonIdx) => {
+    const power = SEASON_POWER[seasonIdx] ?? 1;
+    // Group by role+slot+rarity so a tier's spread is computed over its own members.
+    const tiers = new Map();
+    for (const row of rows) {
+      const key = `${row[1]}/${row[2]}/${row[3]}`;
+      if (!tiers.has(key)) tiers.set(key, []);
+      tiers.get(key).push(row);
+    }
+    for (const tier of tiers.values()) {
+      const n = tier.length;
+      tier.forEach(([name, role, slot, rarity], i) => {
+        const step = n > 1 ? (i - (n - 1) / 2) * TIER_SPREAD : 0;
+        const bonus = Math.max(1, Math.round((RARITY_BASE[rarity] ?? 1) * power * (1 + step)));
+        const id = `itm_s${seasonIdx + 1}_${slugify(name)}`;
+        items[id] = { name, slot, rarity, role, bonuses: { [role]: bonus } };
+        bySeason[seasonIdx].push(id);
+      });
+    }
+  });
+
+  return { items, bySeason };
+}
+
+const SEASON_GEAR_BUILT = buildSeasonGear();
+
+/**
+ * The full gear catalog: hand-authored entries (starter gear + the original 48
+ * season items, whose ids are already in players' bags) plus the generated
+ * pyramid. Hand-authored entries WIN on an id clash, so a generated item can
+ * never quietly redefine one people already own.
+ */
+export const ITEMS = { ...SEASON_GEAR_BUILT.items, ...HAND_ITEMS };
+
+/**
+ * Per-season drop pools: the original hand-tuned ids first (stable, already
+ * owned), then that season's pyramid.
+ * @type {string[][]}
+ */
+export const SEASON_LOOT = HAND_SEASON_LOOT.map((ids, i) => [...ids, ...SEASON_GEAR_BUILT.bySeason[i]]);
 
 /**
  * Default drop pool when a season has no explicit lootTable configured. Mirrors

--- a/test/rules/items-catalog.test.js
+++ b/test/rules/items-catalog.test.js
@@ -1,0 +1,180 @@
+// The season gear catalog. Two things matter here and they pull in opposite
+// directions: the pyramid must stay COMPLETE (that is the whole point of the
+// expansion), and the ids must stay STABLE (players' bags and equipped slots
+// are keyed by them, and ids are derived from names — so a rename silently
+// orphans whatever is holding the item).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ITEMS, SEASON_LOOT, PYRAMID, SLOTS, STARTER_WEAPONS, STARTER_ARMOR } from '../../src/content/items.js';
+import { config } from '../../src/config.js';
+
+const ROLES = ['tank', 'healer', 'dps'];
+const RARITIES = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
+
+/** Count a season's items by role → slot → rarity. */
+function cells(seasonIdx) {
+  const g = new Map();
+  for (const id of SEASON_LOOT[seasonIdx]) {
+    const it = ITEMS[id];
+    for (const role of Object.keys(it.bonuses || {})) {
+      const key = `${role}/${it.slot}/${it.rarity}`;
+      g.set(key, (g.get(key) || 0) + 1);
+    }
+  }
+  return g;
+}
+
+test('every season fills the full pyramid — every role, every slot, every rarity', () => {
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    const g = cells(s);
+    for (const role of ROLES) {
+      for (const slot of SLOTS) {
+        for (const rarity of RARITIES) {
+          assert.equal(
+            g.get(`${role}/${slot}/${rarity}`) || 0,
+            PYRAMID[rarity],
+            `season ${s + 1} ${role}/${slot} ${rarity}: expected ${PYRAMID[rarity]}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('every role has a legendary in every slot — the gap that started this', () => {
+  // Before the expansion each season had exactly ONE tank weapon and ONE dps
+  // armor, and most role×slot pairs had no legendary at all.
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    for (const role of ROLES) {
+      for (const slot of SLOTS) {
+        const top = SEASON_LOOT[s]
+          .map((id) => ITEMS[id])
+          .filter((it) => it.rarity === 'legendary' && it.slot === slot && it.bonuses?.[role]);
+        assert.equal(top.length, 1, `season ${s + 1} ${role}/${slot} needs exactly one legendary`);
+      }
+    }
+  }
+});
+
+test('a season offers a full 25-item ladder to each role in each slot', () => {
+  const perCell = Object.values(PYRAMID).reduce((a, b) => a + b, 0);
+  assert.equal(perCell, 25);
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    assert.equal(SEASON_LOOT[s].length, perCell * ROLES.length * SLOTS.length);
+  }
+});
+
+test('ids are unique, and every loot-table id resolves', () => {
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    const ids = SEASON_LOOT[s];
+    assert.equal(new Set(ids).size, ids.length, `season ${s + 1} has a duplicate id`);
+    for (const id of ids) assert.ok(ITEMS[id], `${id} is in a loot table but not the catalog`);
+  }
+  const all = SEASON_LOOT.flat();
+  assert.equal(new Set(all).size, all.length, 'an id is shared across seasons');
+});
+
+test('ids follow itm_s<season>_<slug> and match their season', () => {
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    for (const id of SEASON_LOOT[s]) {
+      assert.match(id, /^itm_s[123]_[a-z0-9_]+$/, `${id} is not a well-formed id`);
+      assert.equal(id.startsWith(`itm_s${s + 1}_`), true, `${id} is in season ${s + 1}'s table`);
+    }
+  }
+});
+
+test('the original hand-authored ids all survive — bags are keyed by them', () => {
+  // These are in prod players' inventories and equipped slots RIGHT NOW. The
+  // expansion must never renumber or drop one.
+  const ORIGINALS = [
+    'itm_s1_cinder_spade', 'itm_s1_mire_poultice', 'itm_s1_thornnettle_dirk',
+    'itm_s1_stoneheart_charm', 'itm_s1_pollenward_mantle', 'itm_s1_ember_token',
+    'itm_s1_ashbark_aegis', 'itm_s1_dewmender_scepter', 'itm_s1_stormcaller_edge',
+    'itm_s1_blightstalker_hide', 'itm_s1_wardens_bastion', 'itm_s1_choirs_lament',
+    'itm_s1_emberforged_blade', 'itm_s1_tyrants_emberseed', 'itm_s1_final_knell_reaper',
+    'itm_s1_heart_of_the_grove',
+  ];
+  for (const id of ORIGINALS) {
+    assert.ok(ITEMS[id], `${id} vanished from the catalog — prod bags reference it`);
+    assert.ok(SEASON_LOOT[0].includes(id), `${id} fell out of season 1's table`);
+  }
+  // And their hand-tuned values are untouched by the generator.
+  assert.equal(ITEMS.itm_s1_final_knell_reaper.bonuses.dps, 104);
+  assert.equal(ITEMS.itm_s1_cinder_spade.bonuses.tank, 10);
+});
+
+test('starter gear is untouched and stays out of the season tables', () => {
+  const starters = [...Object.values(STARTER_WEAPONS), ...Object.values(STARTER_ARMOR)].flat();
+  assert.equal(starters.length, 24);
+  for (const id of starters) {
+    assert.ok(ITEMS[id], `${id} missing`);
+    assert.equal(SEASON_LOOT.flat().includes(id), false, `${id} must not be a season drop`);
+  }
+});
+
+test('every item is well-formed and pays out to exactly its own role', () => {
+  for (const [id, it] of Object.entries(ITEMS)) {
+    assert.ok(it.name, `${id} has no name`);
+    assert.ok(SLOTS.includes(it.slot), `${id} has slot "${it.slot}"`);
+    assert.ok(RARITIES.includes(it.rarity), `${id} has rarity "${it.rarity}"`);
+    assert.ok(ROLES.includes(it.role), `${id} has role "${it.role}"`);
+    const paid = Object.keys(it.bonuses || {});
+    assert.deepEqual(paid, [it.role], `${id} pays out to ${paid} but is a ${it.role} item`);
+    assert.ok(it.bonuses[it.role] > 0, `${id} grants no rating`);
+  }
+});
+
+test('rarity is worth more than the tier below it, in every season and slot', () => {
+  for (let s = 0; s < SEASON_LOOT.length; s++) {
+    for (const role of ROLES) {
+      for (const slot of SLOTS) {
+        const byRarity = RARITIES.map((rarity) => {
+          const vals = SEASON_LOOT[s]
+            .map((id) => ITEMS[id])
+            .filter((it) => it.slot === slot && it.bonuses?.[role] && it.rarity === rarity)
+            .map((it) => it.bonuses[role]);
+          return { rarity, min: Math.min(...vals), max: Math.max(...vals) };
+        });
+        for (let i = 1; i < byRarity.length; i++) {
+          assert.ok(
+            byRarity[i].min > byRarity[i - 1].max,
+            `season ${s + 1} ${role}/${slot}: ${byRarity[i].rarity} (min ${byRarity[i].min}) does not beat every ${byRarity[i - 1].rarity} (max ${byRarity[i - 1].max})`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('a tier is a spread, not nine identical items', () => {
+  // Nine commons that all grant the same number is nine cosmetic reskins.
+  const vals = SEASON_LOOT[0]
+    .map((id) => ITEMS[id])
+    .filter((it) => it.role === 'tank' && it.slot === 'weapon' && it.rarity === 'common')
+    .map((it) => it.bonuses.tank);
+  assert.ok(new Set(vals).size > 1, 'commons in a tier should differ');
+  assert.ok(Math.max(...vals) - Math.min(...vals) <= 6, 'but only slightly — not a second rarity ladder');
+});
+
+test('later seasons out-scale earlier ones at the same rarity', () => {
+  for (const rarity of RARITIES) {
+    const peak = SEASON_LOOT.map((ids) =>
+      Math.max(...ids.map((id) => ITEMS[id]).filter((it) => it.rarity === rarity).map((it) => Object.values(it.bonuses)[0])),
+    );
+    assert.ok(peak[1] > peak[0], `season 2 ${rarity} must beat season 1`);
+    assert.ok(peak[2] > peak[1], `season 3 ${rarity} must beat season 2`);
+  }
+});
+
+test('a full legendary loadout stays in the band the hand-tuned gear set', () => {
+  // Gear should dominate a season's power budget without making level/renown
+  // irrelevant — the original S1 legendaries were ~100 a slot, so ~300 a set.
+  for (const role of ROLES) {
+    const best = SLOTS.map((slot) =>
+      Math.max(...SEASON_LOOT[0].map((id) => ITEMS[id]).filter((it) => it.slot === slot && it.bonuses?.[role]).map((it) => it.bonuses[role])),
+    ).reduce((a, b) => a + b, 0);
+    assert.ok(best >= 280 && best <= 320, `${role}'s best S1 set is +${best}, outside the established band`);
+    // Renown stays a perk next to gear, never a replacement for it.
+    assert.ok(best > config.rating.renownCap * config.rating.renownPerPoint);
+  }
+});


### PR DESCRIPTION
Independent of #74 — this touches only `src/content/items.js`, a new test file, and `docs/design/items.md`, none of which #74 goes near. Either can merge first.

## The gap

Each season shipped **16 items total**, spread so thin that most role×slot pairs had nothing:

| S1 | weapon | armor | trinket |
|---|---|---|---|
| tank | **1** | 2 | 1 |
| healer | 2 | **1** | 2 |
| dps | 4 | **1** | 2 |

Every season had exactly one tank weapon and one dps armor, and most role×slot pairs had **no legendary at all**. A tank's entire six-week weapon progression was "starter gear, then the one drop".

## The pyramid

Every season now fills, per role × slot:

| common | uncommon | rare | epic | legendary |
|---|---|---|---|---|
| 9 | 7 | 5 | 3 | **1** |

= 25 per cell × 3 roles × 3 slots = **225 a season**, 699 items total. All 27 cells in all 3 seasons hit the target exactly (test-enforced). Every role now has a legendary in every slot.

The shape mirrors the drop weights — variety in the tiers you roll often, a single trophy at the top. A hero sees many different commons across a season and at most one legendary.

## How it's authored

A **name table** (`SEASON_GEAR`), not 600+ object literals. Names are the content; ids and bonuses follow by rule, so the balance ladder lives in one place instead of being restated 600 times. Within a tier values fan out ~4% per step, so nine commons are nine slightly different items rather than nine reskins.

Generated bands land on the hand-tuned ladder exactly — S1 common 8–12 (originals were 9–12), legendary 96–104 (originals 96–104), with S2 ×1.25 and S3 ×1.5. Nothing is inflated: a best-in-slot S1 legendary set is +300 rating, the same as before.

## Prod safety

Ids are derived from names (`itm_s<season>_<slug>`) and are the stable contract — bags, equipped slots and the site's Compendium key off them. The original 48 season ids are hand-authored, untouched, and **win on any id clash**, because prod players are holding them right now. A test pins each one by id and value.

Verified: `node scripts/export-catalog.mjs` emits 699 well-formed rows (157KB) bucketed Starter/Season 1–3.

## Pre-existing drift this surfaced

Names follow each season's **bosses**. S2's bosses are high summer — Sunscorch, the Ten-Lined Horde, the Snaptrap Coven, the Hornworm Broodmother, the Cornstalk Colossus — but its 16 legacy items are **aquatic** (brine, tide, glacial, coral, riptide, leviathan, "the Drowned Court"), authored against a *Drowned Bloom* season plan that exists nowhere else in the codebase. `SEASON_THEMES` agrees with the bosses, so the loot table is the odd one out.

New S2 content follows the bosses. That leaves 16 aquatic items visible in a summer season. Fixing it means renaming those 16 while keeping their ids (safe, but leaves `itm_s2_brineforged_maul` pointing at a summer name) — flagged in `docs/design/items.md` as an owner decision rather than done silently.

## Verification

`npm test` 186 · `npm run test:emulator` 76 · `npm run test:e2e` 31 — all green.

New tests cover pyramid completeness, a legendary per role per slot, id uniqueness and well-formedness, the original ids surviving with their hand-tuned values, starter gear staying out of season tables, every item paying out to exactly its own role, rarity strictly beating the tier below in every season and slot, seasons out-scaling each other, and the legendary set staying in its established band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)